### PR TITLE
Sync CategorySearch with DataSearch for #57

### DIFF
--- a/app/assets/css/style.css
+++ b/app/assets/css/style.css
@@ -11,37 +11,43 @@
   font-weight: 900;
   font-style: normal; }
 
-.rbc-red .rbc.rbc-categorysearch .Select-control .Select-arrow-zone .Select-arrow {
+.rbc-red .rbc.rbc-categorysearch .rbc-search-container:before,
+.rbc-red .rbc.rbc-categorysearch .react-autosuggest__container:before {
   color: red; }
 
 .rbc-red .rbc.rbc-categorysearch .rbc-strong {
   color: red; }
 
-.rbc-orange .rbc.rbc-categorysearch .Select-control .Select-arrow-zone .Select-arrow {
+.rbc-orange .rbc.rbc-categorysearch .rbc-search-container:before,
+.rbc-orange .rbc.rbc-categorysearch .react-autosuggest__container:before {
   color: orange; }
 
 .rbc-orange .rbc.rbc-categorysearch .rbc-strong {
   color: orange; }
 
-.rbc-yellow .rbc.rbc-categorysearch .Select-control .Select-arrow-zone .Select-arrow {
+.rbc-yellow .rbc.rbc-categorysearch .rbc-search-container:before,
+.rbc-yellow .rbc.rbc-categorysearch .react-autosuggest__container:before {
   color: yellow; }
 
 .rbc-yellow .rbc.rbc-categorysearch .rbc-strong {
   color: yellow; }
 
-.rbc-green .rbc.rbc-categorysearch .Select-control .Select-arrow-zone .Select-arrow {
+.rbc-green .rbc.rbc-categorysearch .rbc-search-container:before,
+.rbc-green .rbc.rbc-categorysearch .react-autosuggest__container:before {
   color: green; }
 
 .rbc-green .rbc.rbc-categorysearch .rbc-strong {
   color: green; }
 
-.rbc-blue .rbc.rbc-categorysearch .Select-control .Select-arrow-zone .Select-arrow {
+.rbc-blue .rbc.rbc-categorysearch .rbc-search-container:before,
+.rbc-blue .rbc.rbc-categorysearch .react-autosuggest__container:before {
   color: #1893e7; }
 
 .rbc-blue .rbc.rbc-categorysearch .rbc-strong {
   color: #1893e7; }
 
-.rbc-dark .rbc.rbc-categorysearch .Select-control .Select-arrow-zone .Select-arrow {
+.rbc-dark .rbc.rbc-categorysearch .rbc-search-container:before,
+.rbc-dark .rbc.rbc-categorysearch .react-autosuggest__container:before {
   color: #ccc; }
 
 .rbc-dark .rbc.rbc-categorysearch .rbc-strong {
@@ -90,53 +96,75 @@
 
 .rbc.rbc-categorysearch {
   margin-top: 10px;
-  padding: 0; }
-  .rbc.rbc-categorysearch .is-focused:not(.is-open) > .Select-control {
-    box-shadow: none;
-    border: 0; }
-  .rbc.rbc-categorysearch .Select-control {
-    border: 0;
-    height: 48px;
-    border-radius: 0;
-    font-family: "Lato Regular";
-    background: whitesmoke;
-    outline: none; }
-    .rbc.rbc-categorysearch .Select-control:hover, .rbc.rbc-categorysearch .Select-control:focus {
-      outline: none; }
-    .rbc.rbc-categorysearch .Select-control .Select-arrow-zone {
+  padding: 0;
+  display: flex;
+  flex-direction: column; }
+  .rbc.rbc-categorysearch .rbc-search-container {
+    padding: 0; }
+    .rbc.rbc-categorysearch .rbc-search-container input {
+      border-bottom: 2px solid whitesmoke; }
+  .rbc.rbc-categorysearch input {
+    width: 100%;
+    margin: 0;
+    padding: 0 35px 0 10px;
+    background-color: whitesmoke;
+    box-sizing: border-box; }
+  .rbc.rbc-categorysearch .react-autosuggest__container,
+  .rbc.rbc-categorysearch .rbc-search-container {
+    position: relative; }
+    .rbc.rbc-categorysearch .react-autosuggest__container:before,
+    .rbc.rbc-categorysearch .rbc-search-container:before {
+      content: "\f002";
       position: absolute;
-      right: 6px;
-      top: 12px; }
-      .rbc.rbc-categorysearch .Select-control .Select-arrow-zone .Select-arrow {
-        border: 0;
-        width: 30px;
-        height: 30px;
-        display: inline-block;
-        font: normal normal normal 14px/1 FontAwesome;
-        font-size: inherit;
-        text-rendering: auto;
-        -webkit-font-smoothing: antialiased; }
-        .rbc.rbc-categorysearch .Select-control .Select-arrow-zone .Select-arrow:before {
-          content: "\f002"; }
-  .rbc.rbc-categorysearch .Select--single > .Select-control .Select-value, .rbc.rbc-categorysearch .Select-placeholder {
-    line-height: 50px; }
-  .rbc.rbc-categorysearch .Select-placeholder,
-  .rbc.rbc-categorysearch .Select-control,
-  .rbc.rbc-categorysearch .Select--single > .Select-control .Select-value {
-    padding-right: 30px; }
-  .rbc.rbc-categorysearch .Select-input {
-    height: 48px; }
-    .rbc.rbc-categorysearch .Select-input input {
-      height: 48px;
-      line-height: 36px;
-      padding: 0;
-      -webkit-transition: none;
-      -moz-transition: none;
-      -ms-transition: none;
-      -o-transition: none;
-      transition: none; }
-    .rbc.rbc-categorysearch .Select-input:hover, .rbc.rbc-categorysearch .Select-input:focus {
-      outline: none; }
+      top: 15px;
+      right: -6px;
+      border: 0;
+      width: 30px;
+      height: 30px;
+      display: inline-block;
+      font: normal normal normal 14px/1 FontAwesome;
+      font-size: inherit;
+      text-rendering: auto;
+      -webkit-font-smoothing: antialiased; }
+  .rbc.rbc-categorysearch .react-autosuggest__input--focused {
+    outline: none; }
+  .rbc.rbc-categorysearch .react-autosuggest__input--open {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0; }
+  .rbc.rbc-categorysearch .react-autosuggest__suggestions-container {
+    display: none; }
+  .rbc.rbc-categorysearch .react-autosuggest__suggestions-container--open {
+    display: block;
+    position: absolute;
+    top: calc(3em - 2px);
+    width: 100%;
+    border: 1px solid #ccc;
+    background-color: #fff;
+    font-size: 16px;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    z-index: 2; }
+  .rbc.rbc-categorysearch .react-autosuggest__suggestions-list {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+    max-height: 210px;
+    overflow-y: scroll; }
+  .rbc.rbc-categorysearch .react-autosuggest__suggestion {
+    cursor: pointer;
+    padding: 10px;
+    word-wrap: break-word; }
+    .rbc.rbc-categorysearch .react-autosuggest__suggestion span {
+      display: inline-flex;
+      height: auto;
+      max-height: 44px;
+      line-height: 1.375em;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      text-overflow: ellipsis; }
+  .rbc.rbc-categorysearch .react-autosuggest__suggestion--highlighted {
+    background-color: #ddd; }
   .rbc.rbc-categorysearch .rbc-strong {
     font-family: "Lato Bold"; }
 

--- a/app/assets/styles/partials/components/_categorysearch.scss
+++ b/app/assets/styles/partials/components/_categorysearch.scss
@@ -1,74 +1,100 @@
+$input-bg: darken($light-grey, 2%);
+
 .rbc.rbc-categorysearch {
 	margin-top: 10px;
 	padding: 0;
+	display: flex;
+	flex-direction: column;
 
-	.is-focused:not(.is-open)>.Select-control {
-		box-shadow: none;
-		border: 0;
-	}
-	
-	.Select-control {
-		border: 0;
-		height: 48px;
-		border-radius: 0;
-		font-family: $font-regular;
-		background: darken($light-grey, 2%);
-		outline: none;
-
-		&:hover, &:focus {
-			outline: none;
-		}
-
-		.Select-arrow-zone {
-			position: absolute;
-			right: 6px;
-			top: 12px;
-
-			.Select-arrow {
-				border: 0;
-				width: 30px;
-				height: 30px;
-				display: inline-block;
-				font: normal normal normal 14px/1 FontAwesome;
-				font-size: inherit;
-				text-rendering: auto;
-				-webkit-font-smoothing: antialiased;
-
-				&:before {
-				  content: "\f002";
-				}
-			}
-		}
-	}
-
-	.Select--single>.Select-control .Select-value, .Select-placeholder {
-		line-height: 50px;
-	}
-
-	.Select-placeholder, 
-	.Select-control,
-	.Select--single>.Select-control .Select-value {
-		padding-right: 30px;
-	}
-	
-	.Select-input {
-		height: 48px;
+	.rbc-search-container {
+		padding: 0;
 
 		input {
-			height: 48px;
-			line-height: 36px;
-			padding: 0;
-			-webkit-transition: none;
-			-moz-transition: none;
-			-ms-transition: none;
-			-o-transition: none;
-			transition: none;
-
+			border-bottom: 2px solid $input-bg;
 		}
+	}
 
-		&:hover, &:focus {
-			outline: none;
+	input {
+		width: 100%;
+		margin: 0;
+		padding: 0 35px 0 10px;
+		background-color: $input-bg;
+		box-sizing: border-box;
+	}
+
+	.react-autosuggest__container,
+	.rbc-search-container {
+		position: relative;
+
+		&:before {
+			content: "\f002";
+			position: absolute;
+			top: 15px;
+			right: -6px;
+			border: 0;
+			width: 30px;
+			height: 30px;
+			display: inline-block;
+			font: normal normal normal 14px/1 FontAwesome;
+			font-size: inherit;
+			text-rendering: auto;
+			-webkit-font-smoothing: antialiased;
 		}
+	}
+
+	.react-autosuggest__input--focused {
+		outline: none;
+	}
+
+	.react-autosuggest__input--open {
+		border-bottom-left-radius: 0;
+		border-bottom-right-radius: 0;
+	}
+
+	.react-autosuggest__suggestions-container {
+		display: none;
+	}
+
+	.react-autosuggest__suggestions-container--open {
+		display: block;
+		position: absolute;
+		top: calc(3em - 2px);
+		width: 100%;
+		border: 1px solid #ccc;
+		background-color: #fff;
+		font-size: 16px;
+		border-bottom-left-radius: 4px;
+		border-bottom-right-radius: 4px;
+		z-index: 2;
+	}
+
+	.react-autosuggest__suggestions-list {
+		margin: 0;
+		padding: 0;
+		list-style-type: none;
+		max-height: 210px;
+		overflow-y: scroll;
+	}
+
+	.react-autosuggest__suggestion {
+		cursor: pointer;
+		padding: 10px;
+		word-wrap: break-word;
+
+		span {
+			display: inline-flex;
+			height: auto;
+			max-height: 16px * 1.375 * 2;
+			line-height: 1.375em;
+			-webkit-line-clamp: 2;
+			-webkit-box-orient: vertical;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+	}
+
+	.react-autosuggest__suggestion--highlighted {
+		background-color: #ddd;
 	}
 
 	.rbc-strong {

--- a/app/assets/styles/partials/theme/_default.scss
+++ b/app/assets/styles/partials/theme/_default.scss
@@ -11,11 +11,10 @@ $themes: (
 $map in $themes {
 	.#{$theme} {
 		.rbc.rbc-categorysearch {
-			.Select-control {
-				.Select-arrow-zone {
-					.Select-arrow {
-						color: map-get($map, color);
-					}
+			.rbc-search-container,
+			.react-autosuggest__container {
+				&:before {
+					color: map-get($map, color);
 				}
 			}
 

--- a/examples/CategorySearch/app.js
+++ b/examples/CategorySearch/app.js
@@ -8,29 +8,11 @@ import {
 class Main extends Component {
 	constructor(props) {
 		super(props);
-		this.onData = this.onData.bind(this);
+		this.itemMarkup = this.itemMarkup.bind(this);
 	}
 
-	onData(res) {
-		let result = null;
-		if (res) {
-			let combineData = res.currentData;
-			if (res.mode === "historic") {
-				combineData = res.currentData.concat(res.newData);
-			} else if (res.mode === "streaming") {
-				combineData = helper.combineStreamData(res.currentData, res.newData);
-			}
-			if (combineData) {
-				result = combineData.map((markerData) => {
-					const marker = markerData._source;
-					return this.itemMarkup(marker, markerData);
-				});
-			}
-		}
-		return result;
-	}
-
-	itemMarkup(marker, markerData) {
+	itemMarkup(markerData) {
+		const marker = markerData._source;
 		return (
 			<a
 				className="full_row single-record single_record_for_clone"
@@ -67,7 +49,7 @@ class Main extends Component {
 							categoryField="brand.raw"
 							componentId="CarSensor"
 							title="CategorySearch"
-							weights={[1,5]}
+							weights={[1, 5]}
 							URLParams={true}
 						/>
 					</div>
@@ -77,10 +59,9 @@ class Main extends Component {
 							componentId="SearchResult"
 							appbaseField="name"
 							title="Results"
-							sortBy="asc"
 							from={0}
 							size={20}
-							onData={this.onData}
+							onData={this.itemMarkup}
 							react={{
 								and: "CarSensor"
 							}}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "node-sass": "^4.5.1",
     "rc-slider": "^5.4.0",
     "react": "15.4.2",
+    "react-autosuggest": "^9.3.0",
     "react-dom": "15.4.2",
     "react-select": "^1.0.0-rc.3",
     "react-stars": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5143,7 +5143,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.8:
+prop-types@^15.5.10, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -5291,9 +5291,25 @@ react-autosuggest@^9.0.1:
     react-autowhatever "^10.0.0"
     shallow-equal "^1.0.0"
 
+react-autosuggest@^9.3.0:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-9.3.0.tgz#151da4fb41a84b07ef1d3211b7d6a92d44f7cddb"
+  dependencies:
+    prop-types "^15.5.10"
+    react-autowhatever "^10.1.0"
+    shallow-equal "^1.0.0"
+
 react-autowhatever@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/react-autowhatever/-/react-autowhatever-10.0.0.tgz#2d7fd54f0a330e33c06c53a83ef789da0ebb65bf"
+  dependencies:
+    prop-types "^15.5.8"
+    react-themeable "^1.1.0"
+    section-iterator "^2.0.0"
+
+react-autowhatever@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/react-autowhatever/-/react-autowhatever-10.1.0.tgz#41f6d69382437d3447a0a3c8913bb8ca2feaabc1"
   dependencies:
     prop-types "^15.5.8"
     react-themeable "^1.1.0"


### PR DESCRIPTION
**CategorySearch** now uses `react-autosuggest` instead of `react-select` and supports an `autoSuggest` prop
