### PR TITLE
Fix ToggleList issue to correctly match defaultSelected

### DIFF
--- a/app/sensors/ToggleList.js
+++ b/app/sensors/ToggleList.js
@@ -55,7 +55,7 @@ export default class ToggleList extends Component {
 		if (!_.isEqual(this.defaultSelected, defaultValue)) {
 			this.defaultSelected = defaultValue;
 			if (!this.props.multiSelect) {
-				const records = this.defaultSelected === null ? null : this.props.data.filter(record => this.defaultSelected && this.defaultSelected.indexOf(record.label) > -1);
+				const records = this.defaultSelected === null ? null : this.props.data.filter(record => this.defaultSelected && this.defaultSelected === record.label);
 				this.setState({
 					selected: records
 				});
@@ -87,7 +87,7 @@ export default class ToggleList extends Component {
 				let records = [];
 				if(this.defaultSelected) {
 					this.defaultSelected.forEach((item) => {
-						records = records.concat(this.props.data.filter(record => item.indexOf(record.label) > -1));
+						records = records.concat(this.props.data.filter(record => item === record.label));
 					});
 				} else if(this.defaultSelected === null) {
 					records = null;

--- a/app/stories/index.js
+++ b/app/stories/index.js
@@ -62,9 +62,15 @@ storiesOf("ToggleList", module)
 	.add("Basic", withReadme(removeFirstLine(ToggleButtonReadme), () => (
 		<ToggleListDefault />
 	)))
-	.add("With Default Selected", withReadme(removeFirstLine(ToggleButtonReadme), () => (
+	.add("With Default Selected and multiSelect on", withReadme(removeFirstLine(ToggleButtonReadme), () => (
 		<ToggleListDefault
 			defaultSelected={array("defaultSelected", ["Social"])}
+		/>
+	)))
+	.add("With Default Selected and multiSelect off", withReadme(removeFirstLine(ToggleButtonReadme), () => (
+		<ToggleListDefault
+			defaultSelected={text("defaultSelected", "Social")}
+			multiSelect={false}
 		/>
 	)))
 	.add("Playground", withReadme(removeFirstLine(ToggleButtonReadme), () => (


### PR DESCRIPTION
Earlier we were using `indexOf` which was causing incorrect and weird behavior.
Say a ToggleList has `Social`, `Travel`, `Music`

Then even for `defaultSelected=['Socialsome', 'goTravelgo']` it would select `Social` and `Travel`

Also fixes similar behavior with `multiSelect={false}`