### PR TITLE
feat: onData prop className support

### DIFF
--- a/app/actuators/ResultCard.js
+++ b/app/actuators/ResultCard.js
@@ -336,7 +336,7 @@ export default class ResultCard extends Component {
 		markup = data.map((item) => {
 			const result = this.props.onData(item._source);
 			let cx = result.image ? "rbc-image-active" : "rbc-image-inactive";
-			cx = result.className ? cx + " " + result.className : cx;
+			cx = `${cx} ${result.className ? result.className : ""}`;
 			const details = (
 				<div>
 					{

--- a/app/actuators/ResultCard.js
+++ b/app/actuators/ResultCard.js
@@ -335,7 +335,8 @@ export default class ResultCard extends Component {
 
 		markup = data.map((item) => {
 			const result = this.props.onData(item._source);
-			const cx = result.image ? "rbc-image-active" : "rbc-image-inactive";
+			let cx = result.image ? "rbc-image-active" : "rbc-image-inactive";
+			cx = result.className ? cx + " " + result.className : cx;
 			const details = (
 				<div>
 					{

--- a/app/actuators/ResultList.js
+++ b/app/actuators/ResultList.js
@@ -335,7 +335,8 @@ export default class ResultList extends Component {
 
 		markup = data.map((item) => {
 			const result = this.props.onData(item._source);
-			const cx = result.image ? result.image_size === "small" ? "rbc-image-active rbc-image-small" : "rbc-image-active" : "rbc-image-inactive";
+			let cx = result.image ? result.image_size === "small" ? "rbc-image-active rbc-image-small" : "rbc-image-active" : "rbc-image-inactive";
+			cx = result.className ? cx + " " + result.className : cx;
 			const details = (
 				<div style={{display: "flex", flexDirection: "row"}}>
 					{

--- a/app/actuators/ResultList.js
+++ b/app/actuators/ResultList.js
@@ -336,7 +336,7 @@ export default class ResultList extends Component {
 		markup = data.map((item) => {
 			const result = this.props.onData(item._source);
 			let cx = result.image ? result.image_size === "small" ? "rbc-image-active rbc-image-small" : "rbc-image-active" : "rbc-image-inactive";
-			cx = result.className ? cx + " " + result.className : cx;
+			cx = `${cx} ${result.className ? result.className : ""}`;
 			const details = (
 				<div style={{display: "flex", flexDirection: "row"}}>
 					{


### PR DESCRIPTION
Support for `onData` prop object - custom `className` property that gets injected with: 
- ResultList: `class="rbc-resultcard-item custom-class"`
- ResultCard: `class="rbc-resultlist-item custom-class"`

Example usage:
```jsx
  onData={
    function(res) {
      return {
        image: res.image,
        title: res.name,
        className: "custom-class",
        desc: (
            <div>
                <div className="price">${res.price}</div>
                <p>{res.room_type} · {res.accommodates} guests</p>
            </div>
        ),
        url: res.listing_url
      }
    }
  }
```