### PR TITLE
Support setting current page of result components from outside the component.

### DIFF
--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -471,7 +471,7 @@ const mapStateToProps = (state, props) => ({
 	currentPage: (
 		state.selectedValues[`${props.componentId}-page`]
 		&& state.selectedValues[`${props.componentId}-page`].value - 1
-	) || 0,
+	) || props.currentPage || 0,
 	hits: state.hits[props.componentId] && state.hits[props.componentId].hits,
 	isLoading: state.isLoading[props.componentId] || false,
 	streamHits: state.streamHits[props.componentId] || [],

--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -43,6 +43,13 @@ class ReactiveList extends Component {
 		this.props.addComponent(this.internalComponent);
 		this.props.addComponent(this.props.componentId);
 
+		if (this.props.providerRef) {
+			this.props.providerRef({
+				setPage: (page) => { this.setPage(page); },
+				getResultStats: () => this.getResultStats(),
+			});
+		}
+
 		if (this.props.stream) {
 			this.props.setStreaming(this.props.componentId, true);
 		}
@@ -213,6 +220,9 @@ class ReactiveList extends Component {
 	componentWillUnmount() {
 		this.props.removeComponent(this.props.componentId);
 		this.props.removeComponent(this.internalComponent);
+		if (this.props.providerRef) {
+			this.props.providerRef(null);
+		}
 	}
 
 	setReact = (props) => {
@@ -282,6 +292,15 @@ class ReactiveList extends Component {
 			);
 		}
 	};
+
+	getResultStats = () => ({
+		currentPage: this.state.currentPage,
+		totalPages: this.state.totalPages,
+		total: this.props.total,
+		totalHits: (this.props.hits || {}).length || 0,
+		pageSize: this.props.size,
+	});
+
 
 	renderResultStats = () => {
 		if (this.props.onResultStats && this.props.total) {
@@ -454,6 +473,7 @@ ReactiveList.propTypes = {
 	style: types.style,
 	URLParams: types.bool,
 	onPageChange: types.func,
+	providerRef: types.func,
 };
 
 ReactiveList.defaultProps = {

--- a/packages/web/src/components/result/ResultCard.js
+++ b/packages/web/src/components/result/ResultCard.js
@@ -503,7 +503,7 @@ const mapStateToProps = (state, props) => ({
 	currentPage: (
 		state.selectedValues[`${props.componentId}-page`]
 		&& state.selectedValues[`${props.componentId}-page`].value - 1
-	) || 0,
+	) || props.currentPage || 0,
 	hits: state.hits[props.componentId] && state.hits[props.componentId].hits,
 	isLoading: state.isLoading[props.componentId] || false,
 	streamHits: state.streamHits[props.componentId] || [],

--- a/packages/web/src/components/result/ResultCard.js
+++ b/packages/web/src/components/result/ResultCard.js
@@ -45,6 +45,13 @@ class ResultCard extends Component {
 		this.props.addComponent(this.internalComponent);
 		this.props.addComponent(this.props.componentId);
 
+		if (this.props.providerRef) {
+			this.props.providerRef({
+				setPage: (page) => { this.setPage(page); },
+				getResultStats: () => this.getResultStats(),
+			});
+		}
+
 		if (this.props.stream) {
 			this.props.setStreaming(this.props.componentId, true);
 		}
@@ -213,6 +220,9 @@ class ResultCard extends Component {
 	componentWillUnmount() {
 		this.props.removeComponent(this.props.componentId);
 		this.props.removeComponent(this.internalComponent);
+		if (this.props.providerRef) {
+			this.props.providerRef(null);
+		}
 	}
 
 	setReact = (props) => {
@@ -322,6 +332,14 @@ class ResultCard extends Component {
 
 		return null;
 	};
+
+	getResultStats = () => ({
+		currentPage: this.state.currentPage,
+		totalPages: this.state.totalPages,
+		total: this.props.total,
+		totalHits: (this.props.hits || {}).length || 0,
+		pageSize: this.props.size,
+	});
 
 	renderResultStats = () => {
 		if (this.props.onResultStats && this.props.total) {
@@ -485,6 +503,7 @@ ResultCard.propTypes = {
 	target: types.stringRequired,
 	URLParams: types.bool,
 	onPageChange: types.func,
+	providerRef: types.func,
 };
 
 ResultCard.defaultProps = {

--- a/packages/web/src/components/result/ResultList.js
+++ b/packages/web/src/components/result/ResultList.js
@@ -45,6 +45,13 @@ class ResultList extends Component {
 		this.props.addComponent(this.internalComponent);
 		this.props.addComponent(this.props.componentId);
 
+		if (this.props.providerRef) {
+			this.props.providerRef({
+				setPage: (page) => { this.setPage(page); },
+				getResultStats: () => this.getResultStats(),
+			});
+		}
+
 		if (this.props.stream) {
 			this.props.setStreaming(this.props.componentId, true);
 		}
@@ -213,6 +220,9 @@ class ResultList extends Component {
 	componentWillUnmount() {
 		this.props.removeComponent(this.props.componentId);
 		this.props.removeComponent(this.internalComponent);
+		if (this.props.providerRef) {
+			this.props.providerRef(null);
+		}
 	}
 
 	setReact = (props) => {
@@ -331,6 +341,14 @@ class ResultList extends Component {
 
 		return null;
 	};
+
+	getResultStats = () => ({
+		currentPage: this.state.currentPage,
+		totalPages: this.state.totalPages,
+		total: this.props.total,
+		totalHits: (this.props.hits || {}).length || 0,
+		pageSize: this.props.size,
+	});
 
 	renderResultStats = () => {
 		if (this.props.onResultStats && this.props.total) {
@@ -494,6 +512,7 @@ ResultList.propTypes = {
 	target: types.stringRequired,
 	URLParams: types.bool,
 	onPageChange: types.func,
+	providerRef: types.func,
 };
 
 ResultList.defaultProps = {

--- a/packages/web/src/components/result/ResultList.js
+++ b/packages/web/src/components/result/ResultList.js
@@ -512,7 +512,7 @@ const mapStateToProps = (state, props) => ({
 	currentPage: (
 		state.selectedValues[`${props.componentId}-page`]
 		&& state.selectedValues[`${props.componentId}-page`].value - 1
-	) || 0,
+	) || props.currentPage || 0,
 	hits: state.hits[props.componentId] && state.hits[props.componentId].hits,
 	isLoading: state.isLoading[props.componentId] || false,
 	streamHits: state.streamHits[props.componentId] || [],


### PR DESCRIPTION
This PR is for feature enhancement #287.

There are two main changes with this pull request. The first change allows the currentPage prop to define which page the result components will initially show. 

```
render() {
	<ReactiveList
		dataField="original_title.raw"
		size={2}
                 currentPage={5}
		pagination
		onData={this.booksReactiveList}
		react={{
			and: ['BookSensor'],
		}}
	/>
}
```
The second change provides a way to set the current page from outside of the result components after the result component has already been rendered. This second change will provide developers an avenue to implement custom pagination. 
Here is how it can be used.
```
onNextPage() => {
	const stats = this.reactiveList.getResultStats();
	this.reactiveList.setPage(stats.currentPage + 1};
}


render() {
	<ReactiveList
		componentId="SearchResult"
		dataField="original_title.raw"
		className="result-list-container"
		from={10}
		size={2}
		providerRef={(provider) => { this.reactiveList = provider; }}
		stream={false}
		pagination
		pages={5}
		paginationAt="bottom"
		onData={this.booksReactiveList}
		react={{
			and: ['BookSensor'],
		}}
	/>
}
```