### PR TITLE
Support setting the current page of the result component after it has been initialized. 

### DIFF
--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -168,7 +168,8 @@ class ReactiveList extends Component {
 				this.setState({
 					isLoading: false,
 				});
-			} else if (this.props.currentPage !== nextProps.currentPage
+			}
+			if (this.props.currentPage !== nextProps.currentPage
 					&& nextProps.currentPage > 0
 					&& nextProps.currentPage <= this.state.totalPages) {
 				this.setPage(nextProps.currentPage - 1);

--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -176,7 +176,9 @@ class ReactiveList extends Component {
 				this.setState({
 					isLoading: false,
 				});
-			} else if (this.props.currentPage !== nextProps.currentPage) {
+			} else if (this.props.currentPage !== nextProps.currentPage
+					&& nextProps.currentPage > 0
+					&& nextProps.currentPage <= this.state.totalPages) {
 				this.setPage(nextProps.currentPage - 1);
 			}
 		}

--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -166,7 +166,10 @@ class ReactiveList extends Component {
 		if (this.props.pagination) {
 			if (this.state.isLoading) {
 				if (nextProps.onPageChange) {
-					nextProps.onPageChange();
+					nextProps.onPageChange({
+						currentPage: this.state.currentPage + 1,
+						totalPages: this.state.totalPages,
+					});
 				} else {
 					window.scrollTo(0, 0);
 				}
@@ -199,7 +202,10 @@ class ReactiveList extends Component {
 			&& nextProps.hits.length < this.props.hits.length
 		) {
 			if (nextProps.onPageChange) {
-				nextProps.onPageChange();
+				nextProps.onPageChange({
+					currentPage: this.state.currentPage + 1,
+					totalPages: this.state.totalPages,
+				});
 			} else {
 				window.scrollTo(0, 0);
 			}
@@ -480,6 +486,7 @@ ReactiveList.defaultProps = {
 	size: 10,
 	style: {},
 	URLParams: false,
+	currentPage: 0,
 };
 
 const mapStateToProps = (state, props) => ({

--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -30,24 +30,19 @@ class ReactiveList extends Component {
 	constructor(props) {
 		super(props);
 
+		let currentPage = 0;
+		if (this.props.defaultPage) {
+			currentPage = this.props.defaultPage - 1;
+		} else if (this.props.currentPage) {
+			currentPage = Math.max(this.props.currentPage - 1, 0);
+		}
+
 		this.state = {
 			from: props.currentPage * props.size,
 			isLoading: false,
-			currentPage: props.currentPage,
+			currentPage,
 		};
 		this.internalComponent = `${props.componentId}__internal`;
-	}
-
-	componentWillMount() {
-		if (this.props.defaultPage !== undefined) {
-			this.setState({
-				currentPage: this.props.defaultPage,
-			});
-		} else if (this.props.currentPage) {
-			this.setState({
-				currentPage: Math.max(this.props.currentPage - 1, 0),
-			});
-		}
 	}
 
 	componentDidMount() {
@@ -494,8 +489,8 @@ ReactiveList.defaultProps = {
 const mapStateToProps = (state, props) => ({
 	defaultPage: (
 		state.selectedValues[`${props.componentId}-page`]
-		&& state.selectedValues[`${props.componentId}-page`].value - 1
-	),
+		&& state.selectedValues[`${props.componentId}-page`].value
+	) || 0,
 	hits: state.hits[props.componentId] && state.hits[props.componentId].hits,
 	isLoading: state.isLoading[props.componentId] || false,
 	streamHits: state.streamHits[props.componentId] || [],

--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -38,6 +38,18 @@ class ReactiveList extends Component {
 		this.internalComponent = `${props.componentId}__internal`;
 	}
 
+	componentWillMount() {
+		if (this.props.defaultPage !== undefined) {
+			this.setState({
+				currentPage: this.props.defaultPage,
+			});
+		} else if (this.props.currentPage) {
+			this.setState({
+				currentPage: Math.max(this.props.currentPage - 1, 0),
+			});
+		}
+	}
+
 	componentDidMount() {
 		this.props.addComponent(this.internalComponent);
 		this.props.addComponent(this.props.componentId);
@@ -151,15 +163,19 @@ class ReactiveList extends Component {
 		}
 
 		// called when page is changed
-		if (this.props.pagination && this.state.isLoading) {
-			if (nextProps.onPageChange) {
-				nextProps.onPageChange();
-			} else {
-				window.scrollTo(0, 0);
+		if (this.props.pagination) {
+			if (this.state.isLoading) {
+				if (nextProps.onPageChange) {
+					nextProps.onPageChange();
+				} else {
+					window.scrollTo(0, 0);
+				}
+				this.setState({
+					isLoading: false,
+				});
+			} else if (this.props.currentPage !== nextProps.currentPage) {
+				this.setPage(nextProps.currentPage - 1);
 			}
-			this.setState({
-				isLoading: false,
-			});
 		}
 
 		if (
@@ -452,6 +468,7 @@ ReactiveList.propTypes = {
 	style: types.style,
 	URLParams: types.bool,
 	onPageChange: types.func,
+	defaultPage: types.number,
 };
 
 ReactiveList.defaultProps = {
@@ -466,10 +483,10 @@ ReactiveList.defaultProps = {
 };
 
 const mapStateToProps = (state, props) => ({
-	currentPage: (
+	defaultPage: (
 		state.selectedValues[`${props.componentId}-page`]
 		&& state.selectedValues[`${props.componentId}-page`].value - 1
-	) || 0,
+	),
 	hits: state.hits[props.componentId] && state.hits[props.componentId].hits,
 	isLoading: state.isLoading[props.componentId] || false,
 	streamHits: state.streamHits[props.componentId] || [],

--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -166,10 +166,7 @@ class ReactiveList extends Component {
 		if (this.props.pagination) {
 			if (this.state.isLoading) {
 				if (nextProps.onPageChange) {
-					nextProps.onPageChange({
-						currentPage: this.state.currentPage + 1,
-						totalPages: this.state.totalPages,
-					});
+					nextProps.onPageChange(this.state.currentPage + 1, this.state.totalPages);
 				} else {
 					window.scrollTo(0, 0);
 				}
@@ -204,10 +201,7 @@ class ReactiveList extends Component {
 			&& nextProps.hits.length < this.props.hits.length
 		) {
 			if (nextProps.onPageChange) {
-				nextProps.onPageChange({
-					currentPage: this.state.currentPage + 1,
-					totalPages: this.state.totalPages,
-				});
+				nextProps.onPageChange(this.state.currentPage + 1, this.state.totalPages);
 			} else {
 				window.scrollTo(0, 0);
 			}
@@ -224,11 +218,8 @@ class ReactiveList extends Component {
 				currentPage,
 			});
 
-			if (this.props.onPageChange) {
-				this.props.onPageChange({
-					currentPage: currentPage + 1,
-					totalPages,
-				});
+			if (nextProps.onPageChange) {
+				nextProps.onPageChange(currentPage + 1, totalPages);
 			}
 		}
 

--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -31,8 +31,8 @@ class ReactiveList extends Component {
 		super(props);
 
 		let currentPage = 0;
-		if (this.props.defaultPage) {
-			currentPage = this.props.defaultPage - 1;
+		if (this.props.defaultPage >= 0) {
+			currentPage = this.props.defaultPage;
 		} else if (this.props.currentPage) {
 			currentPage = Math.max(this.props.currentPage - 1, 0);
 		}
@@ -490,8 +490,8 @@ ReactiveList.defaultProps = {
 const mapStateToProps = (state, props) => ({
 	defaultPage: (
 		state.selectedValues[`${props.componentId}-page`]
-		&& state.selectedValues[`${props.componentId}-page`].value
-	) || 0,
+		&& state.selectedValues[`${props.componentId}-page`].value - 1
+	) || -1,
 	hits: state.hits[props.componentId] && state.hits[props.componentId].hits,
 	isLoading: state.isLoading[props.componentId] || false,
 	streamHits: state.streamHits[props.componentId] || [],

--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -218,9 +218,18 @@ class ReactiveList extends Component {
 		}
 
 		if (nextProps.pagination && nextProps.total !== this.props.total) {
+			const totalPages = Math.ceil(nextProps.total / nextProps.size);
+			const currentPage = this.props.total ? 0 : this.state.currentPage;
 			this.setState({
-				currentPage: this.props.total ? 0 : this.state.currentPage,
+				currentPage,
 			});
+
+			if (this.props.onPageChange) {
+				this.props.onPageChange({
+					currentPage: currentPage + 1,
+					totalPages,
+				});
+			}
 		}
 
 		if (nextProps.pagination !== this.props.pagination) {

--- a/packages/web/src/components/result/ResultCard.js
+++ b/packages/web/src/components/result/ResultCard.js
@@ -168,10 +168,7 @@ class ResultCard extends Component {
 		if (this.props.pagination) {
 			if (this.state.isLoading) {
 				if (nextProps.onPageChange) {
-					nextProps.onPageChange({
-						currentPage: this.state.currentPage + 1,
-						totalPages: this.state.totalPages,
-					});
+					nextProps.onPageChange(this.state.currentPage + 1, this.state.totalPages);
 				} else {
 					window.scrollTo(0, 0);
 				}
@@ -204,10 +201,7 @@ class ResultCard extends Component {
 			&& nextProps.hits.length < this.props.hits.length
 		) {
 			if (nextProps.onPageChange) {
-				nextProps.onPageChange({
-					currentPage: this.state.currentPage + 1,
-					totalPages: this.state.totalPages,
-				});
+				nextProps.onPageChange(this.state.currentPage + 1, this.state.totalPages);
 			} else {
 				window.scrollTo(0, 0);
 			}
@@ -225,10 +219,7 @@ class ResultCard extends Component {
 			});
 
 			if (this.props.onPageChange) {
-				this.props.onPageChange({
-					currentPage: currentPage + 1,
-					totalPages,
-				});
+				nextProps.onPageChange(currentPage + 1, this.state.totalPages);
 			}
 		}
 

--- a/packages/web/src/components/result/ResultCard.js
+++ b/packages/web/src/components/result/ResultCard.js
@@ -213,7 +213,7 @@ class ResultCard extends Component {
 				currentPage,
 			});
 
-			if (this.props.onPageChange) {
+			if (nextProps.onPageChange) {
 				nextProps.onPageChange(currentPage + 1, this.state.totalPages);
 			}
 		}

--- a/packages/web/src/components/result/ResultCard.js
+++ b/packages/web/src/components/result/ResultCard.js
@@ -178,7 +178,9 @@ class ResultCard extends Component {
 				this.setState({
 					isLoading: false,
 				});
-			} else if (this.props.currentPage !== nextProps.currentPage) {
+			} else if (this.props.currentPage !== nextProps.currentPage
+					&& nextProps.currentPage > 0
+					&& nextProps.currentPage <= this.state.totalPages) {
 				this.setPage(nextProps.currentPage - 1);
 			}
 		}

--- a/packages/web/src/components/result/ResultCard.js
+++ b/packages/web/src/components/result/ResultCard.js
@@ -32,24 +32,19 @@ class ResultCard extends Component {
 	constructor(props) {
 		super(props);
 
+		let currentPage = 0;
+		if (this.props.defaultPage) {
+			currentPage = this.props.defaultPage - 1;
+		} else if (this.props.currentPage) {
+			currentPage = Math.max(this.props.currentPage - 1, 0);
+		}
+
 		this.state = {
 			from: props.currentPage * props.size,
 			isLoading: false,
-			currentPage: props.currentPage,
+			currentPage,
 		};
 		this.internalComponent = `${props.componentId}__internal`;
-	}
-
-	componentWillMount() {
-		if (this.props.defaultPage !== undefined) {
-			this.setState({
-				currentPage: this.props.defaultPage,
-			});
-		} else if (this.props.currentPage) {
-			this.setState({
-				currentPage: Math.max(this.props.currentPage - 1, 0),
-			});
-		}
 	}
 
 	componentDidMount() {
@@ -526,8 +521,8 @@ ResultCard.defaultProps = {
 const mapStateToProps = (state, props) => ({
 	defaultPage: (
 		state.selectedValues[`${props.componentId}-page`]
-		&& state.selectedValues[`${props.componentId}-page`].value - 1
-	),
+		&& state.selectedValues[`${props.componentId}-page`].value
+	) || 0,
 	hits: state.hits[props.componentId] && state.hits[props.componentId].hits,
 	isLoading: state.isLoading[props.componentId] || false,
 	streamHits: state.streamHits[props.componentId] || [],

--- a/packages/web/src/components/result/ResultCard.js
+++ b/packages/web/src/components/result/ResultCard.js
@@ -170,7 +170,8 @@ class ResultCard extends Component {
 				this.setState({
 					isLoading: false,
 				});
-			} else if (this.props.currentPage !== nextProps.currentPage
+			}
+			if (this.props.currentPage !== nextProps.currentPage
 					&& nextProps.currentPage > 0
 					&& nextProps.currentPage <= this.state.totalPages) {
 				this.setPage(nextProps.currentPage - 1);

--- a/packages/web/src/components/result/ResultCard.js
+++ b/packages/web/src/components/result/ResultCard.js
@@ -40,6 +40,18 @@ class ResultCard extends Component {
 		this.internalComponent = `${props.componentId}__internal`;
 	}
 
+	componentWillMount() {
+		if (this.props.defaultPage !== undefined) {
+			this.setState({
+				currentPage: this.props.defaultPage,
+			});
+		} else if (this.props.currentPage) {
+			this.setState({
+				currentPage: Math.max(this.props.currentPage - 1, 0),
+			});
+		}
+	}
+
 	componentDidMount() {
 		this.props.addComponent(this.internalComponent);
 		this.props.addComponent(this.props.componentId);
@@ -153,15 +165,19 @@ class ResultCard extends Component {
 		}
 
 		// called when page is changed
-		if (this.props.pagination && this.state.isLoading) {
-			if (nextProps.onPageChange) {
-				nextProps.onPageChange();
-			} else {
-				window.scrollTo(0, 0);
+		if (this.props.pagination) {
+			if (this.state.isLoading) {
+				if (nextProps.onPageChange) {
+					nextProps.onPageChange();
+				} else {
+					window.scrollTo(0, 0);
+				}
+				this.setState({
+					isLoading: false,
+				});
+			} else if (this.props.currentPage !== nextProps.currentPage) {
+				this.setPage(nextProps.currentPage - 1);
 			}
-			this.setState({
-				isLoading: false,
-			});
 		}
 
 		if (
@@ -483,6 +499,7 @@ ResultCard.propTypes = {
 	target: types.stringRequired,
 	URLParams: types.bool,
 	onPageChange: types.func,
+	defaultPage: types.number,
 };
 
 ResultCard.defaultProps = {
@@ -495,13 +512,14 @@ ResultCard.defaultProps = {
 	style: {},
 	target: '_blank',
 	URLParams: false,
+	currentPage: 0,
 };
 
 const mapStateToProps = (state, props) => ({
-	currentPage: (
+	defaultPage: (
 		state.selectedValues[`${props.componentId}-page`]
 		&& state.selectedValues[`${props.componentId}-page`].value - 1
-	) || 0,
+	),
 	hits: state.hits[props.componentId] && state.hits[props.componentId].hits,
 	isLoading: state.isLoading[props.componentId] || false,
 	streamHits: state.streamHits[props.componentId] || [],

--- a/packages/web/src/components/result/ResultCard.js
+++ b/packages/web/src/components/result/ResultCard.js
@@ -33,8 +33,8 @@ class ResultCard extends Component {
 		super(props);
 
 		let currentPage = 0;
-		if (this.props.defaultPage) {
-			currentPage = this.props.defaultPage - 1;
+		if (this.props.defaultPage >= 0) {
+			currentPage = this.props.defaultPage;
 		} else if (this.props.currentPage) {
 			currentPage = Math.max(this.props.currentPage - 1, 0);
 		}
@@ -522,8 +522,8 @@ ResultCard.defaultProps = {
 const mapStateToProps = (state, props) => ({
 	defaultPage: (
 		state.selectedValues[`${props.componentId}-page`]
-		&& state.selectedValues[`${props.componentId}-page`].value
-	) || 0,
+		&& state.selectedValues[`${props.componentId}-page`].value - 1
+	) || -1,
 	hits: state.hits[props.componentId] && state.hits[props.componentId].hits,
 	isLoading: state.isLoading[props.componentId] || false,
 	streamHits: state.streamHits[props.componentId] || [],

--- a/packages/web/src/components/result/ResultCard.js
+++ b/packages/web/src/components/result/ResultCard.js
@@ -218,9 +218,18 @@ class ResultCard extends Component {
 		}
 
 		if (nextProps.pagination && nextProps.total !== this.props.total) {
+			const totalPages = Math.ceil(nextProps.total / nextProps.size);
+			const currentPage = this.props.total ? 0 : this.state.currentPage;
 			this.setState({
-				currentPage: this.props.total ? 0 : this.state.currentPage,
+				currentPage,
 			});
+
+			if (this.props.onPageChange) {
+				this.props.onPageChange({
+					currentPage: currentPage + 1,
+					totalPages,
+				});
+			}
 		}
 
 		if (nextProps.pagination !== this.props.pagination) {

--- a/packages/web/src/components/result/ResultCard.js
+++ b/packages/web/src/components/result/ResultCard.js
@@ -168,7 +168,10 @@ class ResultCard extends Component {
 		if (this.props.pagination) {
 			if (this.state.isLoading) {
 				if (nextProps.onPageChange) {
-					nextProps.onPageChange();
+					nextProps.onPageChange({
+						currentPage: this.state.currentPage + 1,
+						totalPages: this.state.totalPages,
+					});
 				} else {
 					window.scrollTo(0, 0);
 				}
@@ -199,7 +202,10 @@ class ResultCard extends Component {
 			&& nextProps.hits.length < this.props.hits.length
 		) {
 			if (nextProps.onPageChange) {
-				nextProps.onPageChange();
+				nextProps.onPageChange({
+					currentPage: this.state.currentPage + 1,
+					totalPages: this.state.totalPages,
+				});
 			} else {
 				window.scrollTo(0, 0);
 			}

--- a/packages/web/src/components/result/ResultList.js
+++ b/packages/web/src/components/result/ResultList.js
@@ -168,7 +168,10 @@ class ResultList extends Component {
 		if (this.props.pagination) {
 			if (this.state.isLoading) {
 				if (nextProps.onPageChange) {
-					nextProps.onPageChange();
+					nextProps.onPageChange({
+						currentPage: this.state.currentPage + 1,
+						totalPages: this.state.totalPages,
+					});
 				} else {
 					window.scrollTo(0, 0);
 				}
@@ -199,7 +202,10 @@ class ResultList extends Component {
 			&& nextProps.hits.length < this.props.hits.length
 		) {
 			if (nextProps.onPageChange) {
-				nextProps.onPageChange();
+				nextProps.onPageChange({
+					currentPage: this.state.currentPage + 1,
+					totalPages: this.state.totalPages,
+				});
 			} else {
 				window.scrollTo(0, 0);
 			}

--- a/packages/web/src/components/result/ResultList.js
+++ b/packages/web/src/components/result/ResultList.js
@@ -218,9 +218,18 @@ class ResultList extends Component {
 		}
 
 		if (nextProps.pagination && nextProps.total !== this.props.total) {
+			const totalPages = Math.ceil(nextProps.total / nextProps.size);
+			const currentPage = this.props.total ? 0 : this.state.currentPage;
 			this.setState({
-				currentPage: this.props.total ? 0 : this.state.currentPage,
+				currentPage,
 			});
+
+			if (this.props.onPageChange) {
+				this.props.onPageChange({
+					currentPage: currentPage + 1,
+					totalPages,
+				});
+			}
 		}
 
 		if (nextProps.pagination !== this.props.pagination) {

--- a/packages/web/src/components/result/ResultList.js
+++ b/packages/web/src/components/result/ResultList.js
@@ -33,8 +33,8 @@ class ResultList extends Component {
 		super(props);
 
 		let currentPage = 0;
-		if (this.props.defaultPage) {
-			currentPage = this.props.defaultPage - 1;
+		if (this.props.defaultPage >= 0) {
+			currentPage = this.props.defaultPage;
 		} else if (this.props.currentPage) {
 			currentPage = Math.max(this.props.currentPage - 1, 0);
 		}
@@ -531,8 +531,8 @@ ResultList.defaultProps = {
 const mapStateToProps = (state, props) => ({
 	defaultPage: (
 		state.selectedValues[`${props.componentId}-page`]
-		&& state.selectedValues[`${props.componentId}-page`].value
-	) || 0,
+		&& state.selectedValues[`${props.componentId}-page`].value - 1
+	) || -1,
 	hits: state.hits[props.componentId] && state.hits[props.componentId].hits,
 	isLoading: state.isLoading[props.componentId] || false,
 	streamHits: state.streamHits[props.componentId] || [],

--- a/packages/web/src/components/result/ResultList.js
+++ b/packages/web/src/components/result/ResultList.js
@@ -32,24 +32,19 @@ class ResultList extends Component {
 	constructor(props) {
 		super(props);
 
+		let currentPage = 0;
+		if (this.props.defaultPage) {
+			currentPage = this.props.defaultPage - 1;
+		} else if (this.props.currentPage) {
+			currentPage = Math.max(this.props.currentPage - 1, 0);
+		}
+
 		this.state = {
 			from: props.currentPage * props.size,
 			isLoading: false,
-			currentPage: props.currentPage,
+			currentPage,
 		};
 		this.internalComponent = `${props.componentId}__internal`;
-	}
-
-	componentWillMount() {
-		if (this.props.defaultPage !== undefined) {
-			this.setState({
-				currentPage: this.props.defaultPage,
-			});
-		} else if (this.props.currentPage) {
-			this.setState({
-				currentPage: Math.max(this.props.currentPage - 1, 0),
-			});
-		}
 	}
 
 	componentDidMount() {
@@ -535,8 +530,8 @@ ResultList.defaultProps = {
 const mapStateToProps = (state, props) => ({
 	defaultPage: (
 		state.selectedValues[`${props.componentId}-page`]
-		&& state.selectedValues[`${props.componentId}-page`].value - 1
-	),
+		&& state.selectedValues[`${props.componentId}-page`].value
+	) || 0,
 	hits: state.hits[props.componentId] && state.hits[props.componentId].hits,
 	isLoading: state.isLoading[props.componentId] || false,
 	streamHits: state.streamHits[props.componentId] || [],

--- a/packages/web/src/components/result/ResultList.js
+++ b/packages/web/src/components/result/ResultList.js
@@ -178,7 +178,9 @@ class ResultList extends Component {
 				this.setState({
 					isLoading: false,
 				});
-			} else if (this.props.currentPage !== nextProps.currentPage) {
+			} else if (this.props.currentPage !== nextProps.currentPage
+					&& nextProps.currentPage > 0
+					&& nextProps.currentPage <= this.state.totalPages) {
 				this.setPage(nextProps.currentPage - 1);
 			}
 		}

--- a/packages/web/src/components/result/ResultList.js
+++ b/packages/web/src/components/result/ResultList.js
@@ -168,10 +168,7 @@ class ResultList extends Component {
 		if (this.props.pagination) {
 			if (this.state.isLoading) {
 				if (nextProps.onPageChange) {
-					nextProps.onPageChange({
-						currentPage: this.state.currentPage + 1,
-						totalPages: this.state.totalPages,
-					});
+					nextProps.onPageChange(this.state.currentPage + 1, this.state.totalPages);
 				} else {
 					window.scrollTo(0, 0);
 				}
@@ -204,10 +201,7 @@ class ResultList extends Component {
 			&& nextProps.hits.length < this.props.hits.length
 		) {
 			if (nextProps.onPageChange) {
-				nextProps.onPageChange({
-					currentPage: this.state.currentPage + 1,
-					totalPages: this.state.totalPages,
-				});
+				nextProps.onPageChange(this.state.currentPage + 1, this.state.totalPages);
 			} else {
 				window.scrollTo(0, 0);
 			}
@@ -225,10 +219,7 @@ class ResultList extends Component {
 			});
 
 			if (this.props.onPageChange) {
-				this.props.onPageChange({
-					currentPage: currentPage + 1,
-					totalPages,
-				});
+				nextProps.onPageChange(currentPage + 1, this.state.totalPages);
 			}
 		}
 

--- a/packages/web/src/components/result/ResultList.js
+++ b/packages/web/src/components/result/ResultList.js
@@ -40,6 +40,18 @@ class ResultList extends Component {
 		this.internalComponent = `${props.componentId}__internal`;
 	}
 
+	componentWillMount() {
+		if (this.props.defaultPage !== undefined) {
+			this.setState({
+				currentPage: this.props.defaultPage,
+			});
+		} else if (this.props.currentPage) {
+			this.setState({
+				currentPage: Math.max(this.props.currentPage - 1, 0),
+			});
+		}
+	}
+
 	componentDidMount() {
 		this.props.addComponent(this.internalComponent);
 		this.props.addComponent(this.props.componentId);
@@ -153,15 +165,19 @@ class ResultList extends Component {
 		}
 
 		// called when page is changed
-		if (this.props.pagination && this.state.isLoading) {
-			if (nextProps.onPageChange) {
-				nextProps.onPageChange();
-			} else {
-				window.scrollTo(0, 0);
+		if (this.props.pagination) {
+			if (this.state.isLoading) {
+				if (nextProps.onPageChange) {
+					nextProps.onPageChange();
+				} else {
+					window.scrollTo(0, 0);
+				}
+				this.setState({
+					isLoading: false,
+				});
+			} else if (this.props.currentPage !== nextProps.currentPage) {
+				this.setPage(nextProps.currentPage - 1);
 			}
-			this.setState({
-				isLoading: false,
-			});
 		}
 
 		if (
@@ -492,6 +508,7 @@ ResultList.propTypes = {
 	target: types.stringRequired,
 	URLParams: types.bool,
 	onPageChange: types.func,
+	defaultPage: types.number,
 };
 
 ResultList.defaultProps = {
@@ -504,13 +521,14 @@ ResultList.defaultProps = {
 	style: {},
 	target: '_blank',
 	URLParams: false,
+	currentPage: 0,
 };
 
 const mapStateToProps = (state, props) => ({
-	currentPage: (
+	defaultPage: (
 		state.selectedValues[`${props.componentId}-page`]
 		&& state.selectedValues[`${props.componentId}-page`].value - 1
-	) || 0,
+	),
 	hits: state.hits[props.componentId] && state.hits[props.componentId].hits,
 	isLoading: state.isLoading[props.componentId] || false,
 	streamHits: state.streamHits[props.componentId] || [],

--- a/packages/web/src/components/result/ResultList.js
+++ b/packages/web/src/components/result/ResultList.js
@@ -170,7 +170,8 @@ class ResultList extends Component {
 				this.setState({
 					isLoading: false,
 				});
-			} else if (this.props.currentPage !== nextProps.currentPage
+			}
+			if (this.props.currentPage !== nextProps.currentPage
 					&& nextProps.currentPage > 0
 					&& nextProps.currentPage <= this.state.totalPages) {
 				this.setPage(nextProps.currentPage - 1);

--- a/packages/web/src/components/result/ResultList.js
+++ b/packages/web/src/components/result/ResultList.js
@@ -213,7 +213,7 @@ class ResultList extends Component {
 				currentPage,
 			});
 
-			if (this.props.onPageChange) {
+			if (nextProps.onPageChange) {
 				nextProps.onPageChange(currentPage + 1, this.state.totalPages);
 			}
 		}


### PR DESCRIPTION
Reference #287 

The following PR adds support to set the current page of the result component. Prior to the result component's initialization the current page can be set from the URLParam or the `currentPage` prop. The URLParam holds precedence over the currentPage prop. Once the initialization of the component is complete, the current page can be changed with the `currentPage` prop. 

In addition, this pull request modifies the `onPageChange` to export the `currentPage` and `totalPages` state variables.