### PR TITLE
web: Add onValueSelected for search components #254

### DIFF
--- a/packages/web/src/components/search/CategorySearch.d.ts
+++ b/packages/web/src/components/search/CategorySearch.d.ts
@@ -29,6 +29,7 @@ export interface CategorySearchProps extends CommonProps {
 	onKeyUp?: (...args: any[]) => any;
 	onSuggestion?: (...args: any[]) => any;
 	onValueChange?: (...args: any[]) => any;
+	onValueSelected?: (...args: any[]) => any;
 	placeholder?: string;
 	queryFormat?: types.queryFormatSearch;
 	react?: types.react;

--- a/packages/web/src/components/search/CategorySearch.js
+++ b/packages/web/src/components/search/CategorySearch.js
@@ -359,7 +359,7 @@ class CategorySearch extends Component {
 
 	clearValue = () => {
 		this.setValue('', true);
-		this.onValueSelected('');
+		this.onValueSelected(null);
 	};
 
 	// only works if there's a change in downshift's value

--- a/packages/web/src/components/search/CategorySearch.js
+++ b/packages/web/src/components/search/CategorySearch.js
@@ -359,17 +359,20 @@ class CategorySearch extends Component {
 
 	clearValue = () => {
 		this.setValue('', true);
+		this.onValueSelected('');
 	};
 
 	// only works if there's a change in downshift's value
 	handleOuterClick = () => {
 		this.setValue(this.state.currentValue, true);
+		this.onValueSelected();
 	};
 
-	handleKeyDown = (event) => {
-		if (event.key === 'Enter') {
-			event.target.blur();
+	handleKeyDown = (event, highlightedIndex) => {
+		// if a suggestion was selected, delegate the handling to suggestion handler
+		if (event.key === 'Enter' && highlightedIndex === null) {
 			this.setValue(event.target.value, true);
+			this.onValueSelected(event.target.value);
 		}
 		if (this.props.onKeyDown) {
 			this.props.onKeyDown(event);
@@ -378,6 +381,11 @@ class CategorySearch extends Component {
 
 	onInputChange = (e) => {
 		const { value } = e.target;
+		if (!this.state.isOpen) {
+			this.setState({
+				isOpen: true,
+			});
+		}
 		if (value.trim() !== this.state.currentValue.trim()) {
 			this.setState({
 				suggestions: [],
@@ -391,10 +399,18 @@ class CategorySearch extends Component {
 
 	onSuggestionSelected = (suggestion, event) => {
 		this.setValue(suggestion.value, true, this.props, suggestion.category);
+		this.onValueSelected(suggestion.value, suggestion.category);
 		if (this.props.onBlur) {
 			this.props.onBlur(event);
 		}
 	};
+
+	onValueSelected = (currentValue = this.state.currentValue, category = null) => {
+		const { onValueSelected } = this.props;
+		if (onValueSelected) {
+			onValueSelected(currentValue, category);
+		}
+	}
 
 	handleStateChange = (changes) => {
 		const { isOpen, type } = changes;
@@ -538,7 +554,7 @@ class CategorySearch extends Component {
 										onBlur: this.props.onBlur,
 										onFocus: this.handleFocus,
 										onKeyPress: this.props.onKeyPress,
-										onKeyDown: this.handleKeyDown,
+										onKeyDown: e => this.handleKeyDown(e, highlightedIndex),
 										onKeyUp: this.props.onKeyUp,
 									})}
 									themePreset={themePreset}
@@ -636,6 +652,7 @@ CategorySearch.propTypes = {
 	onQueryChange: types.func,
 	onSuggestion: types.func,
 	onValueChange: types.func,
+	onValueSelected: types.func,
 	placeholder: types.string,
 	queryFormat: types.queryFormatSearch,
 	react: types.react,

--- a/packages/web/src/components/search/DataSearch.d.ts
+++ b/packages/web/src/components/search/DataSearch.d.ts
@@ -28,6 +28,7 @@ export interface DataSearchProps extends CommonProps {
 	onKeyUp?: (...args: any[]) => any;
 	onSuggestion?: (...args: any[]) => any;
 	onValueChange?: (...args: any[]) => any;
+	onValueSelected?: (...args: any[]) => any;
 	placeholder?: string;
 	queryFormat?: types.queryFormatSearch;
 	react?: types.react;

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -318,7 +318,7 @@ class DataSearch extends Component {
 
 	clearValue = () => {
 		this.setValue('', true);
-		this.onValueSelected('');
+		this.onValueSelected(null);
 	};
 
 	// only works if there's a change in downshift's value

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -318,21 +318,23 @@ class DataSearch extends Component {
 
 	clearValue = () => {
 		this.setValue('', true);
+		this.onValueSelected('');
 	};
 
 	// only works if there's a change in downshift's value
 	handleOuterClick = (event) => {
 		this.setValue(this.state.currentValue, true);
-
+		this.onValueSelected();
 		if (this.props.onBlur) {
 			this.props.onBlur(event);
 		}
 	};
 
-	handleKeyDown = (event) => {
-		if (event.key === 'Enter') {
-			event.target.blur();
+	handleKeyDown = (event, highlightedIndex) => {
+		// if a suggestion was selected, delegate the handling to suggestion handler
+		if (event.key === 'Enter' && highlightedIndex === null) {
 			this.setValue(event.target.value, true);
+			this.onValueSelected(event.target.value);
 		}
 		if (this.props.onKeyDown) {
 			this.props.onKeyDown(event);
@@ -341,6 +343,11 @@ class DataSearch extends Component {
 
 	onInputChange = (e) => {
 		const { value } = e.target;
+		if (!this.state.isOpen) {
+			this.setState({
+				isOpen: true,
+			});
+		}
 		if (value.trim() !== this.state.currentValue.trim()) {
 			this.setState({
 				suggestions: [],
@@ -352,12 +359,17 @@ class DataSearch extends Component {
 		}
 	};
 
-	onSuggestionSelected = (suggestion, event) => {
+	onSuggestionSelected = (suggestion) => {
 		this.setValue(suggestion.value, true);
-		if (this.props.onBlur) {
-			this.props.onBlur(event);
-		}
+		this.onValueSelected(suggestion.value);
 	};
+
+	onValueSelected = (currentValue = this.state.currentValue) => {
+		const { onValueSelected } = this.props;
+		if (onValueSelected) {
+			onValueSelected(currentValue);
+		}
+	}
 
 	handleStateChange = (changes) => {
 		const { isOpen, type } = changes;
@@ -433,7 +445,6 @@ class DataSearch extends Component {
 						? (<Downshift
 							id={`${this.props.componentId}-downshift`}
 							onChange={this.onSuggestionSelected}
-							onOuterClick={this.handleOuterClick}
 							onStateChange={this.handleStateChange}
 							isOpen={this.state.isOpen}
 							itemToString={i => i}
@@ -458,7 +469,7 @@ class DataSearch extends Component {
 											onBlur: this.handleOuterClick,
 											onFocus: this.handleFocus,
 											onKeyPress: this.props.onKeyPress,
-											onKeyDown: this.handleKeyDown,
+											onKeyDown: e => this.handleKeyDown(e, highlightedIndex),
 											onKeyUp: this.props.onKeyUp,
 										})}
 										themePreset={themePreset}
@@ -571,6 +582,7 @@ DataSearch.propTypes = {
 	onQueryChange: types.func,
 	onSuggestion: types.func,
 	onValueChange: types.func,
+	onValueSelected: types.func,
 	placeholder: types.string,
 	queryFormat: types.queryFormatSearch,
 	react: types.react,


### PR DESCRIPTION
Resolves #254 

- introduces a new prop onValueSelected for `DataSearch` and `CategorySearch`
- changes blur behavior, does not auto blur after a selection
  has been made
- fixes an issue with stale values in onValueChange when selecting
  a suggestion
- fixes an issue with suggestions not displaying sometimes when
  clearing characters with backspace

If the changes look good, I can update the docs