### PR TITLE
listClass prop defaulted to an empty string value

### DIFF
--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -548,6 +548,7 @@ ReactiveList.propTypes = {
 ReactiveList.defaultProps = {
 	className: null,
 	currentPage: 0,
+	listClass: '',
 	pages: 5,
 	pagination: false,
 	paginationAt: 'bottom',


### PR DESCRIPTION
When we render a ReactiveList without a parent ResultCard, in those scenarios listClass prop is not passed which lead to this issue
https://github.com/appbaseio/reactivesearch/issues/416

Setting it's default value to empty string fixes that.