### PR TITLE
move-expo to dependency

### DIFF
--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -39,7 +39,6 @@
 		"eslint-plugin-prettier": "^2.6.0",
 		"eslint-plugin-react": "^7.7.0",
 		"eslint-plugin-react-native": "^3.2.1",
-		"expo": "^27.0.2",
 		"husky": "^0.14.3",
 		"prettier": "^1.12.1",
 		"react": "^16.3.2",
@@ -54,6 +53,7 @@
 		"prop-types": "^15.6.1",
 		"react-native-calendars": "^1.18.2",
 		"react-redux": "^5.0.7",
-		"xdate": "^0.8.2"
+		"xdate": "^0.8.2",
+		"expo": "^27.0.2"
 	}
 }


### PR DESCRIPTION
This break 0.8.0 build since expo is required in ReactiveMap