### PR TITLE
onClear Prop added to SelectedFilters component and dataField prop should accept both string and array

### DIFF
--- a/packages/web/src/components/basic/SelectedFilters.js
+++ b/packages/web/src/components/basic/SelectedFilters.js
@@ -49,7 +49,7 @@ class SelectedFilters extends Component {
 
 							if (label && ((isArray && value.length) || (!isArray && value))) {
 								hasValues = true;
-								let valueToRender = this.renderValue(value, isArray);
+								const valueToRender = this.renderValue(value, isArray);
 								return (
 									<Button
 										className={getClassName(this.props.innerClass, 'button') || null}

--- a/packages/web/src/components/basic/SelectedFilters.js
+++ b/packages/web/src/components/basic/SelectedFilters.js
@@ -9,9 +9,15 @@ import Container from '../../styles/Container';
 import { connect } from '../../utils';
 
 class SelectedFilters extends Component {
-	remove = (component) => {
+	remove = (component, value = null) => {
 		this.props.setValue(component, null);
+		this.props.onClear && this.props.onClear(component, value);
 	};
+
+	clearValues = () => {
+		this.props.clearValues();
+		this.props.onClear && this.props.onClear(null);
+	}
 
 	renderValue = (value, isArray) => {
 		if (isArray && value.length) {
@@ -43,14 +49,15 @@ class SelectedFilters extends Component {
 
 							if (label && ((isArray && value.length) || (!isArray && value))) {
 								hasValues = true;
+								let valueToRender = this.renderValue(value, isArray);
 								return (
 									<Button
 										className={getClassName(this.props.innerClass, 'button') || null}
 										key={`${component}-${index}`} // eslint-disable-line
-										onClick={() => this.remove(component)}
+										onClick={() => this.remove(component, value)}
 									>
 										<span>
-											{selectedValues[component].label}: {this.renderValue(value, isArray)}
+											{selectedValues[component].label}: {valueToRender}
 										</span>
 										<span>&#x2715;</span>
 									</Button>
@@ -64,7 +71,7 @@ class SelectedFilters extends Component {
 						? (
 							<Button
 								className={getClassName(this.props.innerClass, 'button') || null}
-								onClick={this.props.clearValues}
+								onClick={this.clearValues}
 							>
 								{this.props.clearAllLabel}
 							</Button>
@@ -87,6 +94,7 @@ SelectedFilters.propTypes = {
 	showClearAll: types.bool,
 	style: types.style,
 	theme: types.style,
+	onClear: types.func
 };
 
 SelectedFilters.defaultProps = {

--- a/packages/web/src/components/date/DateRange.js
+++ b/packages/web/src/components/date/DateRange.js
@@ -398,7 +398,7 @@ DateRange.propTypes = {
 	autoFocusEnd: types.bool,
 	className: types.string,
 	componentId: types.stringRequired,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldArray,
 	dayPickerInputProps: types.props,
 	defaultSelected: types.dateObject,
 	filterLabel: types.string,

--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -548,6 +548,7 @@ ReactiveList.propTypes = {
 ReactiveList.defaultProps = {
 	className: null,
 	currentPage: 0,
+	listClass: '',
 	pages: 5,
 	pagination: false,
 	paginationAt: 'bottom',


### PR DESCRIPTION
- Added a new prop onClear to SelectedFilters that will be invoked with the component name and the value of the selected filter being cleared.

- When clearAll is clicked this function will be called with just param and that would be null to indicate that the clearAll has been called.

- DateRange dataField prop should accept both string and array 

This is fix for https://github.com/appbaseio/reactivesearch/issues/401
and
https://github.com/appbaseio/reactivesearch/issues/421
