### PR TITLE
web: check for react prop changes in ReactiveComponent

### DIFF
--- a/packages/web/src/components/basic/ReactiveComponent.js
+++ b/packages/web/src/components/basic/ReactiveComponent.js
@@ -12,6 +12,7 @@ import {
 	pushToAndClause,
 	parseHits,
 	isEqual,
+	checkPropChange,
 } from '@appbaseio/reactivecore/lib/utils/helper';
 import types from '@appbaseio/reactivecore/lib/utils/types';
 
@@ -93,6 +94,10 @@ class ReactiveComponent extends Component {
 				query: query || null,
 			});
 		}
+
+		checkPropChange(this.props.react, nextProps.react, () => {
+			this.setReact(nextProps);
+		});
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
This checks for changes to `ReactiveComponent`'s `react` prop after the component has mounted in order to update the state accordingly - similar to several of the other web UI components.