### PR TITLE
Get initial search state from query params to make SSR pagination work.

### DIFF
--- a/packages/web/examples/ssr/pages/index.js
+++ b/packages/web/examples/ssr/pages/index.js
@@ -78,6 +78,7 @@ const components = {
 			url: data.listing_url,
 		}),
 		pagination: true,
+		URLParams: true,
 		react: {
 			and: ['SearchSensor', 'GuestSensor'],
 		},
@@ -91,7 +92,7 @@ const components = {
 };
 
 export default class Main extends Component {
-	static async getInitialProps() {
+	static async getInitialProps({ pathname, query }) {
 		return {
 			store: await initReactivesearch(
 				[
@@ -116,7 +117,7 @@ export default class Main extends Component {
 						source: ResultCard,
 					},
 				],
-				null,
+				query,
 				components.settings,
 			),
 		};


### PR DESCRIPTION
a followup for discussion in #441 

pagination in this example now works even with js disabled, but for now you'll need to modify url manually (i.e. `?SearchResult=1` or `?SearchResult=2`) because pagination component needs some changes to be clickable while js is disabled.