### PR TITLE
web: add analytics support

### DIFF
--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Dynamically change include/exclude Fields [#417](https://github.com/appbaseio/reactivesearch/issues/417)
 - Fix empty categories in suggestions for `CategorySearch` [#502](https://github.com/appbaseio/reactivesearch/issues/502)
 - Fix `defaultSuggestions` not appearing in `CategorySearch` [commit](https://github.com/appbaseio/reactivesearch/commit/776074f766d5e4c14759ed36e1531d234df35e91)
+- Add analytics support [#484](https://github.com/appbaseio/reactivesearch/issues/484)
 
 </details>
 

--- a/packages/web/src/components/basic/NumberBox.js
+++ b/packages/web/src/components/basic/NumberBox.js
@@ -146,6 +146,7 @@ class NumberBox extends Component {
 			value,
 			showFilter: false, // we don't need filters for NumberBox
 			URLParams: props.URLParams,
+			componentType: 'NUMBERBOX',
 		});
 	};
 

--- a/packages/web/src/components/basic/TagCloud.js
+++ b/packages/web/src/components/basic/TagCloud.js
@@ -214,6 +214,7 @@ class TagCloud extends Component {
 			label: props.filterLabel,
 			showFilter: props.showFilter,
 			URLParams: props.URLParams,
+			componentType: 'TAGCLOUD',
 		});
 	};
 

--- a/packages/web/src/components/basic/ToggleButton.js
+++ b/packages/web/src/components/basic/ToggleButton.js
@@ -162,6 +162,7 @@ class ToggleButton extends Component {
 			label: props.filterLabel,
 			showFilter: props.showFilter,
 			URLParams: props.URLParams,
+			componentType: 'TOGGLEBUTTON',
 		});
 	};
 

--- a/packages/web/src/components/date/DatePicker.js
+++ b/packages/web/src/components/date/DatePicker.js
@@ -169,6 +169,7 @@ class DatePicker extends Component {
 			showFilter: props.showFilter,
 			label: props.filterLabel,
 			URLParams: props.URLParams,
+			componentType: 'DATEPICKER',
 		});
 	};
 

--- a/packages/web/src/components/date/DateRange.js
+++ b/packages/web/src/components/date/DateRange.js
@@ -268,6 +268,7 @@ class DateRange extends Component {
 				showFilter: props.showFilter,
 				label: props.filterLabel,
 				URLParams: props.URLParams,
+				componentType: 'DATERANGE',
 			});
 		}
 	};

--- a/packages/web/src/components/list/MultiDataList.js
+++ b/packages/web/src/components/list/MultiDataList.js
@@ -218,6 +218,7 @@ class MultiDataList extends Component {
 			label: props.filterLabel,
 			showFilter: props.showFilter,
 			URLParams: props.URLParams,
+			componentType: 'MULTIDATALIST',
 		});
 	};
 

--- a/packages/web/src/components/list/MultiDropdownList.js
+++ b/packages/web/src/components/list/MultiDropdownList.js
@@ -268,6 +268,7 @@ class MultiDropdownList extends Component {
 			label: props.filterLabel,
 			showFilter: props.showFilter,
 			URLParams: props.URLParams,
+			componentType: 'MULTIDROPDOWNLIST',
 		});
 	};
 

--- a/packages/web/src/components/list/MultiList.js
+++ b/packages/web/src/components/list/MultiList.js
@@ -273,6 +273,7 @@ class MultiList extends Component {
 			label: props.filterLabel,
 			showFilter: props.showFilter,
 			URLParams: props.URLParams,
+			componentType: 'MULTILIST',
 		});
 	};
 

--- a/packages/web/src/components/list/SingleDataList.js
+++ b/packages/web/src/components/list/SingleDataList.js
@@ -140,6 +140,7 @@ class SingleDataList extends Component {
 			label: props.filterLabel,
 			showFilter: props.showFilter,
 			URLParams: props.URLParams,
+			componentType: 'SINGLEDATALIST',
 		});
 	};
 

--- a/packages/web/src/components/list/SingleDropdownList.js
+++ b/packages/web/src/components/list/SingleDropdownList.js
@@ -171,6 +171,7 @@ class SingleDropdownList extends Component {
 			label: props.filterLabel,
 			showFilter: props.showFilter,
 			URLParams: props.URLParams,
+			componentType: 'SINGLEDROPDOWNLIST',
 		});
 	};
 

--- a/packages/web/src/components/list/SingleList.js
+++ b/packages/web/src/components/list/SingleList.js
@@ -180,6 +180,7 @@ class SingleList extends Component {
 			label: props.filterLabel,
 			showFilter: props.showFilter,
 			URLParams: props.URLParams,
+			componentType: 'SINGLELIST',
 		});
 	};
 

--- a/packages/web/src/components/range/DynamicRangeSlider.js
+++ b/packages/web/src/components/range/DynamicRangeSlider.js
@@ -278,6 +278,7 @@ class DynamicRangeSlider extends Component {
 			label: props.filterLabel,
 			showFilter: showFilter && !isInitialValue,
 			URLParams: props.URLParams,
+			componentType: 'DYNAMICRANGESLIDER',
 		});
 	};
 

--- a/packages/web/src/components/range/MultiDropdownRange.js
+++ b/packages/web/src/components/range/MultiDropdownRange.js
@@ -164,6 +164,7 @@ class MultiDropdownRange extends Component {
 			label: props.filterLabel,
 			showFilter: props.showFilter,
 			URLParams: props.URLParams,
+			componentType: 'MULTIDROPDOWNRANGE',
 		});
 	};
 

--- a/packages/web/src/components/range/MultiRange.js
+++ b/packages/web/src/components/range/MultiRange.js
@@ -173,6 +173,7 @@ class MultiRange extends Component {
 			label: props.filterLabel,
 			showFilter: props.showFilter,
 			URLParams: props.URLParams,
+			componentType: 'MULTIRANGE',
 		});
 	};
 

--- a/packages/web/src/components/range/RangeSlider.js
+++ b/packages/web/src/components/range/RangeSlider.js
@@ -236,6 +236,7 @@ class RangeSlider extends Component {
 			label: props.filterLabel,
 			showFilter: showFilter && !isInitialValue,
 			URLParams: props.URLParams,
+			componentType: 'RANGESLIDER',
 		});
 	};
 

--- a/packages/web/src/components/range/RatingsFilter.js
+++ b/packages/web/src/components/range/RatingsFilter.js
@@ -140,6 +140,7 @@ class RatingsFilter extends Component {
 			label: props.filterLabel,
 			showFilter: false,
 			URLParams: props.URLParams,
+			componentType: 'RATINGSFILTER',
 		});
 	};
 

--- a/packages/web/src/components/range/SingleDropdownRange.js
+++ b/packages/web/src/components/range/SingleDropdownRange.js
@@ -131,6 +131,7 @@ class SingleDropdownRange extends Component {
 			label: props.filterLabel,
 			showFilter: props.showFilter,
 			URLParams: props.URLParams,
+			componentType: 'SINGLEDROPDOWNRANGE',
 		});
 	};
 

--- a/packages/web/src/components/range/SingleRange.js
+++ b/packages/web/src/components/range/SingleRange.js
@@ -127,6 +127,7 @@ class SingleRange extends Component {
 			label: props.filterLabel,
 			showFilter: props.showFilter,
 			URLParams: props.URLParams,
+			componentType: 'SINGLERANGE',
 		});
 	};
 

--- a/packages/web/src/components/result/ResultCard.js
+++ b/packages/web/src/components/result/ResultCard.js
@@ -9,7 +9,7 @@ import Card, { container, Image } from '../../styles/Card';
 class ResultCard extends Component {
 	static generateQueryOptions = props => ReactiveList.generateQueryOptions(props);
 
-	renderAsCard = (item) => {
+	renderAsCard = (item, triggerClickAnalytics) => {
 		const result = this.props.onData(item);
 
 		if (result) {
@@ -20,6 +20,7 @@ class ResultCard extends Component {
 					className={getClassName(this.props.innerClass, 'listItem')}
 					target={this.props.target}
 					rel={this.props.target === '_blank' ? 'noopener noreferrer' : null}
+					onClick={triggerClickAnalytics}
 					{...result.containerProps}
 				>
 					<Image

--- a/packages/web/src/components/result/ResultList.js
+++ b/packages/web/src/components/result/ResultList.js
@@ -9,7 +9,7 @@ import ReactiveList from './ReactiveList';
 class ResultList extends Component {
 	static generateQueryOptions = props => ReactiveList.generateQueryOptions(props);
 
-	renderAsListItem = (item) => {
+	renderAsListItem = (item, triggerClickAnalytics) => {
 		const result = this.props.onData(item);
 
 		if (result) {
@@ -22,6 +22,7 @@ class ResultList extends Component {
 					className={getClassName(this.props.innerClass, 'listItem')}
 					target={this.props.target}
 					rel={this.props.target === '_blank' ? 'noopener noreferrer' : null}
+					onClick={triggerClickAnalytics}
 					{...result.containerProps}
 				>
 					{

--- a/packages/web/src/components/search/CategorySearch.js
+++ b/packages/web/src/components/search/CategorySearch.js
@@ -375,6 +375,7 @@ class CategorySearch extends Component {
 			label: filterLabel,
 			showFilter,
 			URLParams,
+			componentType: 'CATEGORYSEARCH',
 		});
 	};
 

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -335,6 +335,7 @@ class DataSearch extends Component {
 			label: filterLabel,
 			showFilter,
 			URLParams,
+			componentType: 'DATASEARCH',
 		});
 	};
 


### PR DESCRIPTION
- ReactiveCore would use these to set the analytics related values

Resolves #484. This PR is necessary for the analytics logic in reactivecore to work. In the next PR I'll include support for filters and click analytics.

[Docs](https://opensource.appbase.io/reactive-manual/advanced/analytics.html)