### PR TITLE
fix to mappings file for multilist

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,13 @@
 		]
 	},
 	"devDependencies": {
+		"babel-eslint": "^9.0.0",
 		"concurrently": "^3.5.1",
 		"eslint": "^4.10.0",
 		"eslint-config-airbnb": "^16.1.0",
 		"eslint-plugin-babel": "^4.1.2",
+		"eslint-plugin-import": "^2.14.0",
+		"eslint-plugin-jest": "^21.22.0",
 		"eslint-plugin-jsx-a11y": "^6.0.3",
 		"eslint-plugin-react": "^7.5.1",
 		"husky": "^0.14.3",

--- a/packages/web/src/components/list/MultiList.d.ts
+++ b/packages/web/src/components/list/MultiList.d.ts
@@ -18,6 +18,7 @@ export interface MultiList extends CommonProps {
 	selectAllLabel?: string;
 	showCheckbox: boolean;
 	showCount?: boolean;
+	showFilter?: boolean;
 	showSearch?: boolean;
 	size?: number;
 	sortBy?: types.sortByWithCount;


### PR DESCRIPTION
I made the fix as we discussed in https://github.com/appbaseio/reactivesearch/issues/523

I also had to add a few things to the package.json to get things to run. eslint also throws a lot of errors but that might be just CRLF/LF issues on my mac here.

Change is minimal.

