### PR TITLE
web: Improve suggestion rendering in search components

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -39,6 +39,7 @@
     "prop-types": "^15.6.0",
     "react-day-picker": "^7.0.5",
     "react-emotion": "^9.0.0",
+    "react-highlight-words": "^0.14.0",
     "react-redux": "^5.0.7",
     "rheostat": "^2.1.1",
     "url-search-params": "^0.10.0",

--- a/packages/web/src/components/search/CategorySearch.js
+++ b/packages/web/src/components/search/CategorySearch.js
@@ -29,6 +29,7 @@ import SearchSvg from '../shared/SearchSvg';
 import InputIcon from '../../styles/InputIcon';
 import Container from '../../styles/Container';
 import { connect } from '../../utils';
+import SuggestionItem from './addons/SuggestionItem';
 
 const Text = withTheme(props => (
 	<span
@@ -278,19 +279,29 @@ class CategorySearch extends Component {
 	};
 
 	onSuggestions = (searchSuggestions) => {
-		if (this.props.onSuggestion) {
-			return searchSuggestions.map(suggestion => this.props.onSuggestion(suggestion));
+		const { onSuggestion, renderSuggestion } = this.props;
+		if (onSuggestion) {
+			if (process.env.NODE_ENV !== 'production') {
+				console.warn('onSuggestion prop is deprecated please use renderSuggestion');
+			}
+			return searchSuggestions.map(suggestion => onSuggestion(suggestion));
 		}
 
 		const fields = Array.isArray(this.props.dataField)
 			? this.props.dataField
 			: [this.props.dataField];
 
-		return getSuggestions(
+		const parsedSuggestions = getSuggestions(
 			fields,
 			searchSuggestions,
 			this.state.currentValue.toLowerCase(),
 		);
+
+		if (renderSuggestion) {
+			return parsedSuggestions.map(suggestion => renderSuggestion(suggestion));
+		}
+
+		return parsedSuggestions;
 	};
 
 	setValue = (value, isDefaultValue = false, props = this.props, category, cause) => {
@@ -491,6 +502,7 @@ class CategorySearch extends Component {
 	render() {
 		let suggestionsList = [];
 		let finalSuggestionsList = [];
+		const { currentValue } = this.state;
 		const {
 			theme,
 			themePreset,
@@ -620,7 +632,9 @@ class CategorySearch extends Component {
 													),
 												}}
 											>
-												<Text primary={!!item.category}>{item.label}</Text>
+												<Text primary={!!item.category}>
+													<SuggestionItem currentValue={currentValue} suggestion={item} />
+												</Text>
 											</li>
 										))}
 									</ul>

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -29,7 +29,7 @@ import CancelSvg from '../shared/CancelSvg';
 import InputIcon from '../../styles/InputIcon';
 import Container from '../../styles/Container';
 import { connect } from '../../utils';
-
+import SuggestionItem from './addons/SuggestionItem';
 
 class DataSearch extends Component {
 	constructor(props) {
@@ -238,18 +238,28 @@ class DataSearch extends Component {
 	};
 
 	onSuggestions = (results) => {
-		if (this.props.onSuggestion) {
-			return results.map(suggestion => this.props.onSuggestion(suggestion));
+		const { onSuggestion, renderSuggestion } = this.props;
+		if (onSuggestion) {
+			if (process.env.NODE_ENV !== 'production') {
+				console.warn('onSuggestion prop is deprecated please use renderSuggestion');
+			}
+			return results.map(suggestion => onSuggestion(suggestion));
 		}
 
 		const fields = Array.isArray(this.props.dataField)
 			? this.props.dataField : [this.props.dataField];
 
-		return getSuggestions(
+		const parsedSuggestions = getSuggestions(
 			fields,
 			results,
 			this.state.currentValue.toLowerCase(),
 		);
+
+		if (renderSuggestion) {
+			return parsedSuggestions.map(suggestion => renderSuggestion(suggestion));
+		}
+
+		return parsedSuggestions;
 	};
 
 	setValue = (value, isDefaultValue = false, props = this.props, cause) => {
@@ -438,6 +448,7 @@ class DataSearch extends Component {
 	);
 
 	render() {
+		const { currentValue } = this.state;
 		let suggestionsList = [];
 
 		if (
@@ -451,7 +462,6 @@ class DataSearch extends Component {
 		}
 
 		const { theme, themePreset, renderSuggestions } = this.props;
-
 		return (
 			<Container style={this.props.style} className={this.props.className}>
 				{this.props.title && <Title className={getClassName(this.props.innerClass, 'title') || null}>{this.props.title}</Title>}
@@ -518,16 +528,7 @@ class DataSearch extends Component {
 																		),
 																	}}
 																>
-																	{
-																		typeof item.label === 'string'
-																			? <div
-																				className="trim"
-																				dangerouslySetInnerHTML={{
-																					__html: item.label,
-																				}}
-																			/>
-																			: item.label
-																	}
+																	<SuggestionItem currentValue={currentValue} suggestion={item} />
 																</li>
 															))
 													}

--- a/packages/web/src/components/search/addons/SuggestionItem.js
+++ b/packages/web/src/components/search/addons/SuggestionItem.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import Highlight from 'react-highlight-words';
+import { css, cx } from 'react-emotion';
+
+import Flex from '../../../styles/Flex';
+
+const highlightStyle = {
+	fontWeight: 600,
+	padding: 0,
+	backgroundColor: 'transparent',
+	color: 'inherit',
+};
+
+const SuggestionItem = ({ currentValue, suggestion }) => {
+	const {
+		label,
+		value,
+		title,
+		description,
+		image,
+	} = suggestion;
+	if (label) {
+		// label has highest precedence
+		return typeof label === 'string'
+			? (
+				<div
+					className="trim"
+				>
+					<Highlight
+						searchWords={currentValue.split(' ')}
+						textToHighlight={label}
+						highlightStyle={highlightStyle}
+					/>
+				</div>
+			)
+			: label;
+	} else if (title || image || description) {
+		return (
+			<Flex alignItems="center" css={{ width: '100%' }}>
+				{
+					image
+					&& (
+						<div css={{ margin: 'auto', marginRight: 10 }}>
+							<img src={image} alt=" " height="50px" width="50px" css={{ objectFit: 'contain' }} />
+						</div>
+					)
+				}
+				<Flex direction="column" css={{ width: image ? 'calc(100% - 60px)' : '100%' }}>
+					{title && (
+						<div className="trim">
+							<Highlight
+								searchWords={currentValue.split(' ')}
+								textToHighlight={title}
+								highlightStyle={highlightStyle}
+								className={css({ fontSize: '1rem' })}
+							/>
+						</div>
+					)}
+					{description && (
+						<div
+							className={cx('trim', css({ marginTop: 3 }))}
+						>
+							<Highlight
+								searchWords={currentValue.split(' ')}
+								textToHighlight={description}
+								highlightStyle={highlightStyle}
+							/>
+						</div>
+					)}
+				</Flex>
+			</Flex>
+		);
+	}
+	return value;
+};
+
+export default SuggestionItem;

--- a/packages/web/src/styles/Input.js
+++ b/packages/web/src/styles/Input.js
@@ -96,16 +96,10 @@ const suggestions = (themePreset, theme) => css`
 		padding: 10px;
 		user-select: none;
 
-		& > .trim {
-			display: block;
-			display: -webkit-box;
-			width: 100%;
-			max-height: 2.3rem;
-			line-height: 1.2rem;
-			-webkit-line-clamp: 2;
-			-webkit-box-orient: vertical;
+		.trim {
 			overflow: hidden;
 			text-overflow: ellipsis;
+			white-space: nowrap;
 		}
 
 		&:hover,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1187,12 +1187,6 @@
   version "10.9.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
 
-"@types/prop-types@*":
-  version "15.5.5"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.5.tgz#17038dd322c2325f5da650a94d5f9974943625e3"
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-dom@^16.0.5":
   version "16.0.7"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.7.tgz#54d0f867a76b90597e8432030d297982f25c20ba"
@@ -1200,18 +1194,11 @@
     "@types/node" "*"
     "@types/react" "*"
 
-"@types/react@*":
+"@types/react@*", "@types/react@16.3.7", "@types/react@^16.3.10", "@types/react@^16.3.8":
   version "16.3.7"
   resolved "http://registry.npmjs.org/@types/react/-/react-16.3.7.tgz#3b90fc4c8382fc55f4d18a8d487dbd314eb6ec4c"
   dependencies:
     csstype "^2.0.0"
-
-"@types/react@^16.3.10", "@types/react@^16.3.8":
-  version "16.4.14"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.14.tgz#47c604c8e46ed674bbdf4aabf82b34b9041c6a04"
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
 
 "@webassemblyjs/ast@1.7.6":
   version "1.7.6"
@@ -2062,6 +2049,17 @@ babel-eslint@^8.2.2, babel-eslint@^8.2.3:
     "@babel/traverse" "7.0.0-beta.44"
     "@babel/types" "7.0.0-beta.44"
     babylon "7.0.0-beta.44"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
+
+babel-eslint@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-9.0.0.tgz#7d9445f81ed9f60aff38115f838970df9f2b6220"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
     eslint-scope "3.7.1"
     eslint-visitor-keys "^1.0.0"
 
@@ -5634,7 +5632,7 @@ eslint-plugin-babel@^5.1.0:
   dependencies:
     eslint-rule-composer "^0.3.0"
 
-eslint-plugin-import@^2.11.0, eslint-plugin-import@^2.8.0:
+eslint-plugin-import@^2.11.0, eslint-plugin-import@^2.14.0, eslint-plugin-import@^2.8.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz#6b17626d2e3e6ad52cfce8807a845d15e22111a8"
   dependencies:
@@ -5649,7 +5647,7 @@ eslint-plugin-import@^2.11.0, eslint-plugin-import@^2.8.0:
     read-pkg-up "^2.0.0"
     resolve "^1.6.0"
 
-eslint-plugin-jest@^21.12.2:
+eslint-plugin-jest@^21.12.2, eslint-plugin-jest@^21.22.0:
   version "21.22.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.22.0.tgz#1b9e49b3e5ce9a3d0a51af4579991d517f33726e"
 
@@ -7124,6 +7122,10 @@ hawk@1.1.1:
 he@1.1.1, he@1.1.x, he@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+
+highlight-words-core@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/highlight-words-core/-/highlight-words-core-1.2.0.tgz#232bec301cbf2a4943d335dc748ce70e9024f3b1"
 
 history@^4.7.2:
   version "4.7.2"
@@ -9083,6 +9085,10 @@ mem@^4.0.0:
     map-age-cleaner "^0.1.1"
     mimic-fn "^1.0.0"
     p-is-promise "^1.1.0"
+
+memoize-one@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.2.tgz#3fb8db695aa14ab9c0f1644e1585a8806adc1aee"
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
@@ -11682,6 +11688,14 @@ react-google-maps@^9.4.5:
     recompose "^0.26.0"
     scriptjs "^2.5.8"
     warning "^3.0.0"
+
+react-highlight-words@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/react-highlight-words/-/react-highlight-words-0.14.0.tgz#a1a40ff0a49ce78e7feb375a4e0a5fd1ca9c9609"
+  dependencies:
+    highlight-words-core "^1.2.0"
+    memoize-one "^4.0.0"
+    prop-types "^15.5.8"
 
 react-hot-loader@4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Resolves #507 and fixes #524 with `renderSuggestion` prop

- Adds highlighting
- Adds `renderSuggestion` prop
- Deprecates `onSuggestion` prop

### `renderSuggestion` usage

Similar to the existing `onSuggestion` prop usage but supports extra keys for `title`, `image` and `description`. Both title and description support highlighting. In order to take control of rendering specify a `label` key just like `onSuggestion` supports (this has the highest precedence while rendering).

```js
<DataSearch
  ...
  renderSuggestion={(suggestion) => ({
    title: suggestion.source.original_title,
    description: suggestion.source.authors,
    image: suggestion.source.image,
    value: suggestion.source.original_title,  // required
    // optionally render the entire JSX using label
    label: <JSX>,  // has higher precedence over title, description, image
    source: suggestion.source  // for onValueSelected to work with onSuggestion
  })}
/>
```

Also with `renderSuggestion` we don't/shouldn't implement the `url` part as specified in #507 since it introduces more complexity taking into consideration clicks or enter key presses. A better way to handle this is after a suggestion is selected using `onValueSelected`.

However if someone wishes to open links on clicking suggestions that should also work when using the `label` key in `renderSuggestion` and adding an `onClick` handler at the root.

It's also possible to select another value other than the rendered suggestion by specifying it in the `value` key. For example if someone wishes to only set a truncated value of max 20 characters they could do something like:

```js
{
  ...
  value: suggestion.source.original_title.slice(0, 20)
}
```

Docs can be updated later with the above usage when merged.