### PR TITLE
Add on demand loading for list components

### DIFF
--- a/packages/web/src/components/list/MultiDropdownList.d.ts
+++ b/packages/web/src/components/list/MultiDropdownList.d.ts
@@ -24,6 +24,7 @@ export interface MultiDropdownList extends CommonProps {
 	title?: types.title;
 	showMissing?: boolean;
 	missingLabel?: string;
+	showLoadMore?: boolean;
 }
 
 declare const MultiDropdownList: React.ComponentType<MultiDropdownList>;

--- a/packages/web/src/components/list/MultiDropdownList.js
+++ b/packages/web/src/components/list/MultiDropdownList.js
@@ -13,7 +13,6 @@ import {
 	getQueryOptions,
 	pushToAndClause,
 	checkValueChange,
-	getAggsOrder,
 	checkPropChange,
 	checkSomePropChange,
 	getClassName,
@@ -21,6 +20,7 @@ import {
 
 import types from '@appbaseio/reactivecore/lib/utils/types';
 
+import { getAggsQuery } from './utils';
 import Title from '../../styles/Title';
 import Container from '../../styles/Container';
 import Dropdown from '../shared/Dropdown';
@@ -274,19 +274,7 @@ class MultiDropdownList extends Component {
 
 	static generateQueryOptions(props) {
 		const queryOptions = getQueryOptions(props);
-		queryOptions.size = 0;
-		queryOptions.aggs = {
-			[props.dataField]: {
-				terms: {
-					field: props.dataField,
-					size: props.size,
-					order: getAggsOrder(props.sortBy || 'count'),
-					...(props.showMissing ? { missing: props.missingLabel } : {}),
-				},
-			},
-		};
-
-		return queryOptions;
+		return getAggsQuery(queryOptions, props);
 	}
 
 	updateQueryOptions = (props) => {

--- a/packages/web/src/components/list/MultiDropdownList.js
+++ b/packages/web/src/components/list/MultiDropdownList.js
@@ -20,9 +20,10 @@ import {
 
 import types from '@appbaseio/reactivecore/lib/utils/types';
 
-import { getAggsQuery } from './utils';
+import { getAggsQuery, getCompositeAggsQuery } from './utils';
 import Title from '../../styles/Title';
 import Container from '../../styles/Container';
+import Button, { loadMoreContainer } from '../../styles/Button';
 import Dropdown from '../shared/Dropdown';
 import { connect } from '../../utils';
 
@@ -33,6 +34,8 @@ class MultiDropdownList extends Component {
 		this.state = {
 			currentValue: {},
 			options: [],
+			after: {},	// for composite aggs
+			isLastBucket: false,
 		};
 		this.locked = false;
 		this.internalComponent = `${props.componentId}__internal`;
@@ -63,11 +66,35 @@ class MultiDropdownList extends Component {
 			this.props.options,
 			nextProps.options,
 			() => {
-				this.setState({
-					options: nextProps.options[nextProps.dataField]
-						? nextProps.options[nextProps.dataField].buckets
-						: [],
-				});
+				const { showLoadMore, dataField } = nextProps;
+				const { options } = this.state;
+				if (showLoadMore) {
+					// append options with showLoadMore
+					const { buckets } = nextProps.options[dataField];
+					const nextOptions = [
+						...options,
+						...buckets.map(bucket => ({
+							key: bucket.key[dataField],
+							doc_count: bucket.doc_count,
+						})),
+					];
+					const after = nextProps.options[dataField].after_key;
+					// detect the last bucket by checking if the next set of buckets were empty
+					const isLastBucket = !buckets.length;
+					this.setState({
+						after: {
+							after,
+						},
+						isLastBucket,
+						options: nextOptions,
+					});
+				} else {
+					this.setState({
+						options: nextProps.options[nextProps.dataField]
+							? nextProps.options[nextProps.dataField].buckets
+							: [],
+					});
+				}
 			},
 		);
 		checkSomePropChange(
@@ -272,17 +299,33 @@ class MultiDropdownList extends Component {
 		});
 	};
 
-	static generateQueryOptions(props) {
+	static generateQueryOptions(props, after) {
 		const queryOptions = getQueryOptions(props);
-		return getAggsQuery(queryOptions, props);
+		return props.showLoadMore
+			? getCompositeAggsQuery(queryOptions, props, after)
+			: getAggsQuery(queryOptions, props);
 	}
 
-	updateQueryOptions = (props) => {
-		const queryOptions = MultiDropdownList.generateQueryOptions(props);
+	updateQueryOptions = (props, addAfterKey = false) => {
+		// when using composite aggs flush the current options for a fresh query
+		if (props.showLoadMore && !addAfterKey) {
+			this.setState({
+				options: [],
+			});
+		}
+		// for a new query due to other changes don't append after to get fresh results
+		const queryOptions = MultiDropdownList
+			.generateQueryOptions(props, addAfterKey ? this.state.after : {});
 		props.setQueryOptions(this.internalComponent, queryOptions);
 	};
 
+	handleLoadMore = () => {
+		this.updateQueryOptions(this.props, true);
+	}
+
 	render() {
+		const { showLoadMore } = this.props;
+		const { isLastBucket } = this.state;
 		let selectAll = [];
 
 		if (this.state.options.length === 0) {
@@ -318,6 +361,13 @@ class MultiDropdownList extends Component {
 					renderListItem={this.props.renderListItem}
 					showSearch={this.props.showSearch}
 					transformData={this.props.transformData}
+					footer={
+						showLoadMore && !isLastBucket && (
+							<div css={loadMoreContainer}>
+								<Button onClick={this.handleLoadMore}>Load More</Button>
+							</div>
+						)
+					}
 				/>
 			</Container>
 		);
@@ -361,6 +411,7 @@ MultiDropdownList.propTypes = {
 	showMissing: types.bool,
 	missingLabel: types.string,
 	showSearch: types.bool,
+	showLoadMore: types.bool,
 };
 
 MultiDropdownList.defaultProps = {
@@ -376,6 +427,7 @@ MultiDropdownList.defaultProps = {
 	showMissing: false,
 	missingLabel: 'N/A',
 	showSearch: false,
+	showLoadMore: false,
 };
 
 const mapStateToProps = (state, props) => ({

--- a/packages/web/src/components/list/MultiList.d.ts
+++ b/packages/web/src/components/list/MultiList.d.ts
@@ -26,6 +26,7 @@ export interface MultiList extends CommonProps {
 	title?: types.title;
 	showMissing?: boolean;
 	missingLabel?: string;
+	showLoadMore?: boolean;
 }
 
 declare const MultiList: React.ComponentType<MultiList>;

--- a/packages/web/src/components/list/MultiList.js
+++ b/packages/web/src/components/list/MultiList.js
@@ -13,7 +13,6 @@ import {
 	getQueryOptions,
 	pushToAndClause,
 	checkValueChange,
-	getAggsOrder,
 	checkPropChange,
 	checkSomePropChange,
 	getClassName,
@@ -21,6 +20,7 @@ import {
 
 import types from '@appbaseio/reactivecore/lib/utils/types';
 
+import { getAggsQuery } from './utils';
 import Title from '../../styles/Title';
 import Input from '../../styles/Input';
 import Container from '../../styles/Container';
@@ -279,19 +279,7 @@ class MultiList extends Component {
 
 	static generateQueryOptions(props) {
 		const queryOptions = getQueryOptions(props);
-		queryOptions.size = 0;
-		queryOptions.aggs = {
-			[props.dataField]: {
-				terms: {
-					field: props.dataField,
-					size: props.size,
-					order: getAggsOrder(props.sortBy || 'count'),
-					...(props.showMissing ? { missing: props.missingLabel } : {}),
-				},
-			},
-		};
-
-		return queryOptions;
+		return getAggsQuery(queryOptions, props);
 	}
 
 	updateQueryOptions = (props) => {

--- a/packages/web/src/components/list/MultiList.js
+++ b/packages/web/src/components/list/MultiList.js
@@ -20,9 +20,10 @@ import {
 
 import types from '@appbaseio/reactivecore/lib/utils/types';
 
-import { getAggsQuery } from './utils';
+import { getAggsQuery, getCompositeAggsQuery } from './utils';
 import Title from '../../styles/Title';
 import Input from '../../styles/Input';
+import Button, { loadMoreContainer } from '../../styles/Button';
 import Container from '../../styles/Container';
 import { UL, Checkbox } from '../../styles/FormControlList';
 import { connect } from '../../utils';
@@ -37,6 +38,8 @@ class MultiList extends Component {
 				? props.options[props.dataField].buckets
 				: [],
 			searchTerm: '',
+			after: {},	// for composite aggs
+			isLastBucket: false,
 		};
 		this.locked = false;
 		this.internalComponent = `${props.componentId}__internal`;
@@ -67,11 +70,35 @@ class MultiList extends Component {
 			this.props.options,
 			nextProps.options,
 			() => {
-				this.setState({
-					options: nextProps.options[nextProps.dataField]
-						? nextProps.options[nextProps.dataField].buckets
-						: [],
-				});
+				const { showLoadMore, dataField } = nextProps;
+				const { options } = this.state;
+				if (showLoadMore) {
+					// append options with showLoadMore
+					const { buckets } = nextProps.options[dataField];
+					const nextOptions = [
+						...options,
+						...buckets.map(bucket => ({
+							key: bucket.key[dataField],
+							doc_count: bucket.doc_count,
+						})),
+					];
+					const after = nextProps.options[dataField].after_key;
+					// detect the last bucket by checking if the next set of buckets were empty
+					const isLastBucket = !buckets.length;
+					this.setState({
+						after: {
+							after,
+						},
+						isLastBucket,
+						options: nextOptions,
+					});
+				} else {
+					this.setState({
+						options: nextProps.options[nextProps.dataField]
+							? nextProps.options[nextProps.dataField].buckets
+							: [],
+					});
+				}
 			},
 		);
 		checkSomePropChange(
@@ -277,13 +304,23 @@ class MultiList extends Component {
 		});
 	};
 
-	static generateQueryOptions(props) {
+	static generateQueryOptions(props, after) {
 		const queryOptions = getQueryOptions(props);
-		return getAggsQuery(queryOptions, props);
+		return props.showLoadMore
+			? getCompositeAggsQuery(queryOptions, props, after)
+			: getAggsQuery(queryOptions, props);
 	}
 
-	updateQueryOptions = (props) => {
-		const queryOptions = MultiList.generateQueryOptions(props);
+	updateQueryOptions = (props, addAfterKey = false) => {
+		// when using composite aggs flush the current options for a fresh query
+		if (props.showLoadMore && !addAfterKey) {
+			this.setState({
+				options: [],
+			});
+		}
+		// for a new query due to other changes don't append after to get fresh results
+		const queryOptions = MultiList
+			.generateQueryOptions(props, addAfterKey ? this.state.after : {});
 		props.setQueryOptions(this.internalComponent, queryOptions);
 	};
 
@@ -293,6 +330,10 @@ class MultiList extends Component {
 			searchTerm: value,
 		});
 	};
+
+	handleLoadMore = () => {
+		this.updateQueryOptions(this.props, true);
+	}
 
 	renderSearch = () => {
 		if (this.props.showSearch) {
@@ -315,7 +356,8 @@ class MultiList extends Component {
 	};
 
 	render() {
-		const { selectAllLabel, renderListItem } = this.props;
+		const { selectAllLabel, renderListItem, showLoadMore } = this.props;
+		const { isLastBucket } = this.state;
 
 		if (this.state.options.length === 0) {
 			return null;
@@ -408,6 +450,13 @@ class MultiList extends Component {
 								</li>
 							))
 					}
+					{
+						showLoadMore && !isLastBucket && (
+							<div css={loadMoreContainer}>
+								<Button onClick={this.handleLoadMore}>Load More</Button>
+							</div>
+						)
+					}
 				</UL>
 			</Container>
 		);
@@ -451,6 +500,7 @@ MultiList.propTypes = {
 	URLParams: types.bool,
 	showMissing: types.bool,
 	missingLabel: types.string,
+	showLoadMore: types.bool,
 };
 
 MultiList.defaultProps = {
@@ -466,6 +516,7 @@ MultiList.defaultProps = {
 	URLParams: false,
 	showMissing: false,
 	missingLabel: 'N/A',
+	showLoadMore: false,
 };
 
 const mapStateToProps = (state, props) => ({

--- a/packages/web/src/components/list/SingleDropdownList.d.ts
+++ b/packages/web/src/components/list/SingleDropdownList.d.ts
@@ -23,6 +23,7 @@ export interface SingleDropdownList extends CommonProps {
 	themePreset?: types.themePreset;
 	showMissing?: boolean;
 	missingLabel?: string;
+	showLoadMore?: boolean;
 }
 
 declare const SingleDropdownList: React.ComponentType<SingleDropdownList>;

--- a/packages/web/src/components/list/SingleDropdownList.js
+++ b/packages/web/src/components/list/SingleDropdownList.js
@@ -19,9 +19,10 @@ import {
 
 import types from '@appbaseio/reactivecore/lib/utils/types';
 
-import { getAggsQuery } from './utils';
+import { getAggsQuery, getCompositeAggsQuery } from './utils';
 import Title from '../../styles/Title';
 import Container from '../../styles/Container';
+import Button, { loadMoreContainer } from '../../styles/Button';
 import Dropdown from '../shared/Dropdown';
 import { connect } from '../../utils';
 
@@ -32,6 +33,8 @@ class SingleDropdownList extends Component {
 		this.state = {
 			currentValue: '',
 			options: [],
+			after: {},	// for composite aggs
+			isLastBucket: false,
 		};
 		this.locked = false;
 		this.internalComponent = `${props.componentId}__internal`;
@@ -62,11 +65,35 @@ class SingleDropdownList extends Component {
 			this.props.options,
 			nextProps.options,
 			() => {
-				this.setState({
-					options: nextProps.options[nextProps.dataField]
-						? nextProps.options[nextProps.dataField].buckets
-						: [],
-				});
+				const { showLoadMore, dataField } = nextProps;
+				const { options } = this.state;
+				if (showLoadMore) {
+					// append options with showLoadMore
+					const { buckets } = nextProps.options[dataField];
+					const nextOptions = [
+						...options,
+						...buckets.map(bucket => ({
+							key: bucket.key[dataField],
+							doc_count: bucket.doc_count,
+						})),
+					];
+					const after = nextProps.options[dataField].after_key;
+					// detect the last bucket by checking if the next set of buckets were empty
+					const isLastBucket = !buckets.length;
+					this.setState({
+						after: {
+							after,
+						},
+						isLastBucket,
+						options: nextOptions,
+					});
+				} else {
+					this.setState({
+						options: nextProps.options[nextProps.dataField]
+							? nextProps.options[nextProps.dataField].buckets
+							: [],
+					});
+				}
 			},
 		);
 		checkSomePropChange(
@@ -175,17 +202,33 @@ class SingleDropdownList extends Component {
 		});
 	};
 
-	static generateQueryOptions(props) {
+	static generateQueryOptions(props, after) {
 		const queryOptions = getQueryOptions(props);
-		return getAggsQuery(queryOptions, props);
+		return props.showLoadMore
+			? getCompositeAggsQuery(queryOptions, props, after)
+			: getAggsQuery(queryOptions, props);
 	}
 
-	updateQueryOptions = (props) => {
-		const queryOptions = SingleDropdownList.generateQueryOptions(props);
+	updateQueryOptions = (props, addAfterKey = false) => {
+		// when using composite aggs flush the current options for a fresh query
+		if (props.showLoadMore && !addAfterKey) {
+			this.setState({
+				options: [],
+			});
+		}
+		// for a new query due to other changes don't append after to get fresh results
+		const queryOptions = SingleDropdownList
+			.generateQueryOptions(props, addAfterKey ? this.state.after : {});
 		props.setQueryOptions(this.internalComponent, queryOptions);
 	};
 
+	handleLoadMore = () => {
+		this.updateQueryOptions(this.props, true);
+	}
+
 	render() {
+		const { showLoadMore } = this.props;
+		const { isLastBucket } = this.state;
 		let selectAll = [];
 
 		if (this.state.options.length === 0) {
@@ -220,6 +263,13 @@ class SingleDropdownList extends Component {
 					renderListItem={this.props.renderListItem}
 					showSearch={this.props.showSearch}
 					transformData={this.props.transformData}
+					footer={
+						showLoadMore && !isLastBucket && (
+							<div css={loadMoreContainer}>
+								<Button onClick={this.handleLoadMore}>Load More</Button>
+							</div>
+						)
+					}
 				/>
 			</Container>
 		);
@@ -262,6 +312,7 @@ SingleDropdownList.propTypes = {
 	showMissing: types.bool,
 	missingLabel: types.string,
 	showSearch: types.bool,
+	showLoadMore: types.bool,
 };
 
 SingleDropdownList.defaultProps = {
@@ -276,6 +327,7 @@ SingleDropdownList.defaultProps = {
 	showMissing: false,
 	missingLabel: 'N/A',
 	showSearch: false,
+	showLoadMore: false,
 };
 
 const mapStateToProps = (state, props) => ({

--- a/packages/web/src/components/list/SingleDropdownList.js
+++ b/packages/web/src/components/list/SingleDropdownList.js
@@ -12,7 +12,6 @@ import {
 	getQueryOptions,
 	pushToAndClause,
 	checkValueChange,
-	getAggsOrder,
 	checkPropChange,
 	checkSomePropChange,
 	getClassName,
@@ -20,6 +19,7 @@ import {
 
 import types from '@appbaseio/reactivecore/lib/utils/types';
 
+import { getAggsQuery } from './utils';
 import Title from '../../styles/Title';
 import Container from '../../styles/Container';
 import Dropdown from '../shared/Dropdown';
@@ -177,18 +177,7 @@ class SingleDropdownList extends Component {
 
 	static generateQueryOptions(props) {
 		const queryOptions = getQueryOptions(props);
-		queryOptions.size = 0;
-		queryOptions.aggs = {
-			[props.dataField]: {
-				terms: {
-					field: props.dataField,
-					size: props.size,
-					order: getAggsOrder(props.sortBy || 'count'),
-					...(props.showMissing ? { missing: props.missingLabel } : {}),
-				},
-			},
-		};
-		return queryOptions;
+		return getAggsQuery(queryOptions, props);
 	}
 
 	updateQueryOptions = (props) => {

--- a/packages/web/src/components/list/SingleList.d.ts
+++ b/packages/web/src/components/list/SingleList.d.ts
@@ -25,6 +25,7 @@ export interface SingleList extends CommonProps {
 	title?: types.title;
 	showMissing?: boolean;
 	missingLabel?: string;
+	showLoadMore?: boolean;
 }
 
 declare const SingleList: React.ComponentType<SingleList>;

--- a/packages/web/src/components/list/SingleList.js
+++ b/packages/web/src/components/list/SingleList.js
@@ -12,7 +12,6 @@ import {
 	getQueryOptions,
 	pushToAndClause,
 	checkValueChange,
-	getAggsOrder,
 	checkPropChange,
 	checkSomePropChange,
 	getClassName,
@@ -20,6 +19,7 @@ import {
 
 import types from '@appbaseio/reactivecore/lib/utils/types';
 
+import { getAggsQuery } from './utils';
 import Title from '../../styles/Title';
 import Input from '../../styles/Input';
 import Container from '../../styles/Container';
@@ -186,18 +186,7 @@ class SingleList extends Component {
 
 	static generateQueryOptions(props) {
 		const queryOptions = getQueryOptions(props);
-		queryOptions.size = 0;
-		queryOptions.aggs = {
-			[props.dataField]: {
-				terms: {
-					field: props.dataField,
-					size: props.size,
-					order: getAggsOrder(props.sortBy || 'count'),
-					...(props.showMissing ? { missing: props.missingLabel } : {}),
-				},
-			},
-		};
-		return queryOptions;
+		return getAggsQuery(queryOptions, props);
 	}
 
 	updateQueryOptions = (props) => {

--- a/packages/web/src/components/list/SingleList.js
+++ b/packages/web/src/components/list/SingleList.js
@@ -19,13 +19,15 @@ import {
 
 import types from '@appbaseio/reactivecore/lib/utils/types';
 
-import { getAggsQuery } from './utils';
+import { getAggsQuery, getCompositeAggsQuery } from './utils';
 import Title from '../../styles/Title';
 import Input from '../../styles/Input';
+import Button, { loadMoreContainer } from '../../styles/Button';
 import Container from '../../styles/Container';
 import { UL, Radio } from '../../styles/FormControlList';
 import { connect } from '../../utils';
 
+// showLoadMore is experimental API and works only with ES6
 class SingleList extends Component {
 	constructor(props) {
 		super(props);
@@ -36,6 +38,8 @@ class SingleList extends Component {
 				? props.options[props.dataField].buckets
 				: [],
 			searchTerm: '',
+			after: {},	// for composite aggs
+			isLastBucket: false,
 		};
 		this.locked = false;
 		this.internalComponent = `${props.componentId}__internal`;
@@ -66,11 +70,35 @@ class SingleList extends Component {
 			this.props.options,
 			nextProps.options,
 			() => {
-				this.setState({
-					options: nextProps.options[nextProps.dataField]
-						? nextProps.options[nextProps.dataField].buckets
-						: [],
-				});
+				const { showLoadMore, dataField } = nextProps;
+				const { options } = this.state;
+				if (showLoadMore) {
+					// append options with showLoadMore
+					const { buckets } = nextProps.options[dataField];
+					const nextOptions = [
+						...options,
+						...buckets.map(bucket => ({
+							key: bucket.key[dataField],
+							doc_count: bucket.doc_count,
+						})),
+					];
+					const after = nextProps.options[dataField].after_key;
+					// detect the last bucket by checking if the next set of buckets were empty
+					const isLastBucket = !buckets.length;
+					this.setState({
+						after: {
+							after,
+						},
+						isLastBucket,
+						options: nextOptions,
+					});
+				} else {
+					this.setState({
+						options: nextProps.options[nextProps.dataField]
+							? nextProps.options[nextProps.dataField].buckets
+							: [],
+					});
+				}
 			},
 		);
 		checkSomePropChange(
@@ -184,13 +212,23 @@ class SingleList extends Component {
 		});
 	};
 
-	static generateQueryOptions(props) {
+	static generateQueryOptions(props, after) {
 		const queryOptions = getQueryOptions(props);
-		return getAggsQuery(queryOptions, props);
+		return props.showLoadMore
+			? getCompositeAggsQuery(queryOptions, props, after)
+			: getAggsQuery(queryOptions, props);
 	}
 
-	updateQueryOptions = (props) => {
-		const queryOptions = SingleList.generateQueryOptions(props);
+	updateQueryOptions = (props, addAfterKey = false) => {
+		// when using composite aggs flush the current options for a fresh query
+		if (props.showLoadMore && !addAfterKey) {
+			this.setState({
+				options: [],
+			});
+		}
+		// for a new query due to other changes don't append after to get fresh results
+		const queryOptions = SingleList
+			.generateQueryOptions(props, addAfterKey ? this.state.after : {});
 		props.setQueryOptions(this.internalComponent, queryOptions);
 	};
 
@@ -200,6 +238,10 @@ class SingleList extends Component {
 			searchTerm: value,
 		});
 	};
+
+	handleLoadMore = () => {
+		this.updateQueryOptions(this.props, true);
+	}
 
 	renderSearch = () => {
 		if (this.props.showSearch) {
@@ -222,7 +264,8 @@ class SingleList extends Component {
 	};
 
 	render() {
-		const { selectAllLabel, renderListItem } = this.props;
+		const { selectAllLabel, renderListItem, showLoadMore } = this.props;
+		const { isLastBucket } = this.state;
 
 		if (this.state.options.length === 0) {
 			return null;
@@ -317,6 +360,13 @@ class SingleList extends Component {
 								</li>
 							))
 					}
+					{
+						showLoadMore && !isLastBucket && (
+							<div css={loadMoreContainer}>
+								<Button onClick={this.handleLoadMore}>Load More</Button>
+							</div>
+						)
+					}
 				</UL>
 			</Container>
 		);
@@ -360,6 +410,7 @@ SingleList.propTypes = {
 	URLParams: types.bool,
 	showMissing: types.bool,
 	missingLabel: types.string,
+	showLoadMore: types.bool,
 };
 
 SingleList.defaultProps = {
@@ -375,6 +426,7 @@ SingleList.defaultProps = {
 	URLParams: false,
 	showMissing: false,
 	missingLabel: 'N/A',
+	showLoadMore: false,
 };
 
 const mapStateToProps = (state, props) => ({

--- a/packages/web/src/components/list/utils.js
+++ b/packages/web/src/components/list/utils.js
@@ -1,0 +1,24 @@
+import { getAggsOrder } from '@appbaseio/reactivecore/lib/utils/helper';
+
+const getAggsQuery = (query, props) => {
+	const clonedQuery = { ...query };
+	clonedQuery.size = 0;
+	clonedQuery.aggs = {
+		[props.dataField]: {
+			terms: {
+				field: props.dataField,
+				size: props.size,
+				order: getAggsOrder(props.sortBy || 'count'),
+				...(props.showMissing ? { missing: props.missingLabel } : {}),
+			},
+		},
+	};
+
+	return clonedQuery;
+};
+
+const getCompositeAggsQuery = () => ({
+
+});
+
+export { getAggsQuery, getCompositeAggsQuery };

--- a/packages/web/src/components/list/utils.js
+++ b/packages/web/src/components/list/utils.js
@@ -2,14 +2,17 @@ import { getAggsOrder } from '@appbaseio/reactivecore/lib/utils/helper';
 
 const getAggsQuery = (query, props) => {
 	const clonedQuery = { ...query };
+	const {
+		dataField, size, sortBy, showMissing, missingLabel,
+	} = props;
 	clonedQuery.size = 0;
 	clonedQuery.aggs = {
-		[props.dataField]: {
+		[dataField]: {
 			terms: {
-				field: props.dataField,
-				size: props.size,
-				order: getAggsOrder(props.sortBy || 'count'),
-				...(props.showMissing ? { missing: props.missingLabel } : {}),
+				field: dataField,
+				size,
+				order: getAggsOrder(sortBy || 'count'),
+				...(showMissing ? { missing: missingLabel } : {}),
 			},
 		},
 	};
@@ -17,8 +20,32 @@ const getAggsQuery = (query, props) => {
 	return clonedQuery;
 };
 
-const getCompositeAggsQuery = () => ({
+const getCompositeAggsQuery = (query, props, after) => {
+	const clonedQuery = { ...query };
+	// missing label not available in composite aggs
+	const {
+		dataField, size, sortBy, showMissing,
+	} = props;
+	const order = sortBy === 'count' ? {} : { order: sortBy };	// composite aggs only allows asc and desc
+	clonedQuery.aggs = {
+		[dataField]: {
+			composite: {
+				sources: [{
+					[dataField]: {
+						terms: {
+							field: dataField,
+							...order,
+							...(showMissing ? { missing_bucket: true } : {}),
+						},
+					},
+				}],
+				size,
+				...after,
+			},
+		},
+	};
 
-});
+	return clonedQuery;
+};
 
 export { getAggsQuery, getCompositeAggsQuery };

--- a/packages/web/src/components/shared/Dropdown.js
+++ b/packages/web/src/components/shared/Dropdown.js
@@ -97,6 +97,7 @@ class Dropdown extends Component {
 			theme,
 			renderListItem,
 			transformData,
+			footer,
 		} = this.props;
 
 		let itemsToRender = items;
@@ -233,6 +234,7 @@ class Dropdown extends Component {
 												);
 											})
 									}
+									{footer}
 								</ul>
 							)
 							: null

--- a/packages/web/src/styles/Button.js
+++ b/packages/web/src/styles/Button.js
@@ -69,6 +69,12 @@ const numberBoxContainer = css`
 	}
 `;
 
+const loadMoreContainer = css({
+	margin: '5px 0',
+	display: 'flex',
+	justifyContent: 'center',
+});
+
 const primary = ({ theme }) => css`
 	background-color: ${theme.colors.primaryColor};
 	color: ${theme.colors.primaryTextColor};
@@ -132,5 +138,5 @@ const Button = styled('a')`
 	${props => props.large && large};
 `;
 
-export { pagination, filters, toggleButtons, numberBoxContainer };
+export { pagination, filters, toggleButtons, numberBoxContainer, loadMoreContainer };
 export default Button;


### PR DESCRIPTION
Adds on demand loading in list components for https://github.com/appbaseio/reactivesearch/issues/515

- Refactor query options for list components
- Add `showLoadMore` and composite aggs in list components (ES >= 6 required)

I spent a lot of time understanding composite aggs (limited resources on internet) and this PR includes the best way I found for supporting it in list components. My implementation is quite good IMO but there might be a bit better way to do things with composite aggs.

[Docs](https://opensource.appbase.io/reactive-manual/list-components/singledropdownlist.html#props)

**NOTE**: Composite aggs are fairly new and in beta. This API is experimental and might need changes if composite aggs changes in the future.

![composite](https://user-images.githubusercontent.com/6682655/46104316-b8b54780-c1f0-11e8-9dd1-b68cba695903.gif)
