### PR TITLE
loadMoreLabel

### DIFF
--- a/packages/web/src/components/list/MultiDropdownList.d.ts
+++ b/packages/web/src/components/list/MultiDropdownList.d.ts
@@ -25,6 +25,7 @@ export interface MultiDropdownList extends CommonProps {
 	showMissing?: boolean;
 	missingLabel?: string;
 	showLoadMore?: boolean;
+	loadMoreLabel?: types.title;
 }
 
 declare const MultiDropdownList: React.ComponentType<MultiDropdownList>;

--- a/packages/web/src/components/list/MultiDropdownList.js
+++ b/packages/web/src/components/list/MultiDropdownList.js
@@ -324,7 +324,7 @@ class MultiDropdownList extends Component {
 	}
 
 	render() {
-		const { showLoadMore } = this.props;
+		const { showLoadMore, loadMoreLabel } = this.props;
 		const { isLastBucket } = this.state;
 		let selectAll = [];
 
@@ -364,7 +364,7 @@ class MultiDropdownList extends Component {
 					footer={
 						showLoadMore && !isLastBucket && (
 							<div css={loadMoreContainer}>
-								<Button onClick={this.handleLoadMore}>Load More</Button>
+								<Button onClick={this.handleLoadMore}>{loadMoreLabel}</Button>
 							</div>
 						)
 					}
@@ -412,6 +412,7 @@ MultiDropdownList.propTypes = {
 	missingLabel: types.string,
 	showSearch: types.bool,
 	showLoadMore: types.bool,
+	loadMoreLabel: types.title,
 };
 
 MultiDropdownList.defaultProps = {
@@ -428,6 +429,7 @@ MultiDropdownList.defaultProps = {
 	missingLabel: 'N/A',
 	showSearch: false,
 	showLoadMore: false,
+	loadMoreLabel: 'Load More',
 };
 
 const mapStateToProps = (state, props) => ({

--- a/packages/web/src/components/list/MultiList.d.ts
+++ b/packages/web/src/components/list/MultiList.d.ts
@@ -27,6 +27,7 @@ export interface MultiList extends CommonProps {
 	showMissing?: boolean;
 	missingLabel?: string;
 	showLoadMore?: boolean;
+	loadMoreLabel?: types.title;
 }
 
 declare const MultiList: React.ComponentType<MultiList>;

--- a/packages/web/src/components/list/MultiList.js
+++ b/packages/web/src/components/list/MultiList.js
@@ -501,7 +501,7 @@ MultiList.propTypes = {
 	showMissing: types.bool,
 	missingLabel: types.string,
 	showLoadMore: types.bool,
-	loadMoreLabel: types.string,
+	loadMoreLabel: types.title,
 };
 
 MultiList.defaultProps = {

--- a/packages/web/src/components/list/MultiList.js
+++ b/packages/web/src/components/list/MultiList.js
@@ -356,7 +356,7 @@ class MultiList extends Component {
 	};
 
 	render() {
-		const { selectAllLabel, renderListItem, showLoadMore } = this.props;
+		const { selectAllLabel, renderListItem, showLoadMore, loadMoreLabel } = this.props;
 		const { isLastBucket } = this.state;
 
 		if (this.state.options.length === 0) {
@@ -453,7 +453,7 @@ class MultiList extends Component {
 					{
 						showLoadMore && !isLastBucket && (
 							<div css={loadMoreContainer}>
-								<Button onClick={this.handleLoadMore}>{this.loadMoreLabel}</Button>
+								<Button onClick={this.handleLoadMore}>{loadMoreLabel}</Button>
 							</div>
 						)
 					}

--- a/packages/web/src/components/list/MultiList.js
+++ b/packages/web/src/components/list/MultiList.js
@@ -453,7 +453,7 @@ class MultiList extends Component {
 					{
 						showLoadMore && !isLastBucket && (
 							<div css={loadMoreContainer}>
-								<Button onClick={this.handleLoadMore}>Load More</Button>
+								<Button onClick={this.handleLoadMore}>{this.loadMoreLabel}</Button>
 							</div>
 						)
 					}
@@ -501,6 +501,7 @@ MultiList.propTypes = {
 	showMissing: types.bool,
 	missingLabel: types.string,
 	showLoadMore: types.bool,
+	loadMoreLabel: types.string,
 };
 
 MultiList.defaultProps = {
@@ -517,6 +518,7 @@ MultiList.defaultProps = {
 	showMissing: false,
 	missingLabel: 'N/A',
 	showLoadMore: false,
+	loadMoreLabel: 'Load More',
 };
 
 const mapStateToProps = (state, props) => ({

--- a/packages/web/src/components/list/SingleDropdownList.d.ts
+++ b/packages/web/src/components/list/SingleDropdownList.d.ts
@@ -24,6 +24,7 @@ export interface SingleDropdownList extends CommonProps {
 	showMissing?: boolean;
 	missingLabel?: string;
 	showLoadMore?: boolean;
+	loadMoreLabel?: types.title;
 }
 
 declare const SingleDropdownList: React.ComponentType<SingleDropdownList>;

--- a/packages/web/src/components/list/SingleDropdownList.js
+++ b/packages/web/src/components/list/SingleDropdownList.js
@@ -227,7 +227,7 @@ class SingleDropdownList extends Component {
 	}
 
 	render() {
-		const { showLoadMore } = this.props;
+		const { showLoadMore, loadMoreLabel } = this.props;
 		const { isLastBucket } = this.state;
 		let selectAll = [];
 
@@ -266,7 +266,7 @@ class SingleDropdownList extends Component {
 					footer={
 						showLoadMore && !isLastBucket && (
 							<div css={loadMoreContainer}>
-								<Button onClick={this.handleLoadMore}>Load More</Button>
+								<Button onClick={this.handleLoadMore}>{loadMoreLabel}</Button>
 							</div>
 						)
 					}
@@ -313,6 +313,7 @@ SingleDropdownList.propTypes = {
 	missingLabel: types.string,
 	showSearch: types.bool,
 	showLoadMore: types.bool,
+	loadMoreLabel: types.title,
 };
 
 SingleDropdownList.defaultProps = {
@@ -328,6 +329,7 @@ SingleDropdownList.defaultProps = {
 	missingLabel: 'N/A',
 	showSearch: false,
 	showLoadMore: false,
+	loadMoreLabel: 'Load More',
 };
 
 const mapStateToProps = (state, props) => ({

--- a/packages/web/src/components/list/SingleList.d.ts
+++ b/packages/web/src/components/list/SingleList.d.ts
@@ -26,6 +26,7 @@ export interface SingleList extends CommonProps {
 	showMissing?: boolean;
 	missingLabel?: string;
 	showLoadMore?: boolean;
+	loadMoreLabel?: types.title;
 }
 
 declare const SingleList: React.ComponentType<SingleList>;

--- a/packages/web/src/components/list/SingleList.js
+++ b/packages/web/src/components/list/SingleList.js
@@ -264,7 +264,7 @@ class SingleList extends Component {
 	};
 
 	render() {
-		const { selectAllLabel, renderListItem, showLoadMore } = this.props;
+		const { selectAllLabel, renderListItem, showLoadMore, loadMoreLabel } = this.props;
 		const { isLastBucket } = this.state;
 
 		if (this.state.options.length === 0) {
@@ -363,7 +363,7 @@ class SingleList extends Component {
 					{
 						showLoadMore && !isLastBucket && (
 							<div css={loadMoreContainer}>
-								<Button onClick={this.handleLoadMore}>Load More</Button>
+								<Button onClick={this.handleLoadMore}>{loadMoreLabel}</Button>
 							</div>
 						)
 					}
@@ -411,6 +411,7 @@ SingleList.propTypes = {
 	showMissing: types.bool,
 	missingLabel: types.string,
 	showLoadMore: types.bool,
+	loadMoreLabel: types.title,
 };
 
 SingleList.defaultProps = {
@@ -427,6 +428,7 @@ SingleList.defaultProps = {
 	showMissing: false,
 	missingLabel: 'N/A',
 	showLoadMore: false,
+	loadMoreLabel: 'Load More',
 };
 
 const mapStateToProps = (state, props) => ({


### PR DESCRIPTION
See: https://github.com/appbaseio/reactivesearch/issues/515#issuecomment-425150797

The prop is a `string` to be consistent with `missingLabel`, `filterLabel`, etc. It's called `*Label` for the same reason. Still, I can edit the PR and change behavior.