### PR TITLE
Fix unmounting of ReactiveList without scrollTarget

### DIFF
--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -300,7 +300,10 @@ class ReactiveList extends Component {
 	componentWillUnmount() {
 		this.props.removeComponent(this.props.componentId);
 		this.props.removeComponent(this.internalComponent);
-		this.domNode.removeEventListener('scroll', this.scrollHandler);
+
+		if (this.domNode) {
+			this.domNode.removeEventListener('scroll', this.scrollHandler);
+		}
 	}
 
 	setReact = (props) => {


### PR DESCRIPTION
Following error occurred, if scrollTarget was not mentioned for `ResultList` or `ReactiveList`

﻿https://www.dropbox.com/s/k47dv2nuacy15bg/Screenshot%202018-10-07%2008.49.30.png?dl=0