### PR TITLE
add renderSuggestions as props on DataSearch and CategorySearch (#591)

### DIFF
--- a/packages/web/src/components/search/CategorySearch.d.ts
+++ b/packages/web/src/components/search/CategorySearch.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import { CommonProps } from '../../';
 import * as types from '../../types';
 
@@ -35,6 +36,7 @@ export interface CategorySearchProps extends CommonProps {
 	placeholder?: string;
 	queryFormat?: types.queryFormatSearch;
 	react?: types.react;
+	renderSuggestions: (...args: any[]) => any;
 	showFilter?: boolean;
 	showIcon?: boolean;
 	title?: types.title;

--- a/packages/web/src/components/search/CategorySearch.js
+++ b/packages/web/src/components/search/CategorySearch.js
@@ -703,6 +703,7 @@ CategorySearch.propTypes = {
 	placeholder: types.string,
 	queryFormat: types.queryFormatSearch,
 	react: types.react,
+	renderSuggestions: types.func,
 	showClear: types.bool,
 	showFilter: types.bool,
 	showIcon: types.bool,

--- a/packages/web/src/components/search/DataSearch.d.ts
+++ b/packages/web/src/components/search/DataSearch.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import { CommonProps } from '../../';
 import * as types from '../../types';
 
@@ -34,6 +35,7 @@ export interface DataSearchProps extends CommonProps {
 	placeholder?: string;
 	queryFormat?: types.queryFormatSearch;
 	react?: types.react;
+	renderSuggestions: (...args: any[]) => any;
 	showFilter?: boolean;
 	showIcon?: boolean;
 	title?: types.title;

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -612,6 +612,7 @@ DataSearch.propTypes = {
 	placeholder: types.string,
 	queryFormat: types.queryFormatSearch,
 	react: types.react,
+	renderSuggestions: types.func,
 	showClear: types.bool,
 	showFilter: types.bool,
 	showIcon: types.bool,


### PR DESCRIPTION
This PR is to resolve missing props on `DataSearch` and `CategorySearch` as documented in #591 