### PR TITLE
web: Add renderTooltipData for custom tooltip content

### DIFF
--- a/packages/maps/src/components/basic/GeoDistanceSlider.js
+++ b/packages/maps/src/components/basic/GeoDistanceSlider.js
@@ -428,6 +428,7 @@ class GeoDistanceSlider extends Component {
 								style={style}
 								className={className}
 								{...passProps}
+								renderTooltipData={this.props.renderTooltipData}
 								tooltipTrigger={this.props.tooltipTrigger}
 							/>
 						)
@@ -496,6 +497,7 @@ GeoDistanceSlider.propTypes = {
 	showFilter: types.bool,
 	showIcon: types.bool,
 	tooltipTrigger: types.tooltipTrigger,
+	renderTooltipData: types.func,
 	style: types.style,
 	theme: types.style,
 	title: types.title,

--- a/packages/web/src/components/range/DynamicRangeSlider.js
+++ b/packages/web/src/components/range/DynamicRangeSlider.js
@@ -373,6 +373,7 @@ class DynamicRangeSlider extends Component {
 								style={style}
 								className={className}
 								{...passProps}
+								renderTooltipData={this.props.renderTooltipData}
 								tooltipTrigger={this.props.tooltipTrigger}
 							/>
 						)
@@ -425,6 +426,7 @@ DynamicRangeSlider.propTypes = {
 	showHistogram: types.bool,
 	showFilter: types.bool,
 	tooltipTrigger: types.tooltipTrigger,
+	renderTooltipData: types.func,
 	snap: types.bool,
 	stepValue: types.number,
 	style: types.style,

--- a/packages/web/src/components/range/RangeSlider.js
+++ b/packages/web/src/components/range/RangeSlider.js
@@ -293,6 +293,7 @@ class RangeSlider extends Component {
 									style={style}
 									className={className}
 									{...passProps}
+									renderTooltipData={this.props.renderTooltipData}
 									tooltipTrigger={this.props.tooltipTrigger}
 								/>
 							)
@@ -350,6 +351,7 @@ RangeSlider.propTypes = {
 	showFilter: types.bool,
 	showSlider: types.bool,
 	tooltipTrigger: types.tooltipTrigger,
+	renderTooltipData: types.func,
 	snap: types.bool,
 	stepValue: types.number,
 	style: types.style,

--- a/packages/web/src/components/range/addons/SliderHandle.js
+++ b/packages/web/src/components/range/addons/SliderHandle.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const SliderHandle = ({
-	className, style, tooltipTrigger, ...passProps
+	className, style, tooltipTrigger, renderTooltipData, ...passProps
 }) => {
 	if (tooltipTrigger) {
 		let tooltipClassname = '';
@@ -19,9 +19,12 @@ const SliderHandle = ({
 			default:
 				return <button style={style} className={className} {...passProps} />;
 		}
+		const tooltipContent = passProps['aria-valuenow'];
 		return (
 			<button style={style} className={className} {...passProps} >
-				<span className={tooltipClassname}>{passProps['aria-valuenow']}</span>
+				<span className={tooltipClassname}>
+					{renderTooltipData ? renderTooltipData(tooltipContent) : tooltipContent}
+				</span>
 			</button>
 		);
 	}


### PR DESCRIPTION
Close #597 

Custom Content:
```js
<RangeSlider
    dataField="ratings_count"
    componentId="BookSensor"
    range={{
	start: 3000,
	end: 50000,
    }}
   rangeLabels={{
	start: '3K',
	end: '50K',
   }}
   tooltipTrigger="always"
   renderTooltipData={
        data => <h5 style={{color: 'papayawhip',textDecoration:'underline'}}>{data}</h5>
   }
/>
```

For `toLocaleString`

`data.toLocaleString('ar-EG')`

---
**DEMO**
![rendertooltipdata](https://user-images.githubusercontent.com/22376783/48397889-3acbe200-e745-11e8-8b89-13b1f044bb07.gif)
