### PR TITLE
vue: Add tooltip props in RangeSlider

### DIFF
--- a/packages/vue/src/components/range/RangeSlider.jsx
+++ b/packages/vue/src/components/range/RangeSlider.jsx
@@ -18,8 +18,8 @@ const {
 
 const { isEqual, checkValueChange, getClassName, pushToAndClause } = helper;
 
-const RangeSlider = { 
- 
+const RangeSlider = {
+
   name: "RangeSlider",
   components: {
     vueSlider
@@ -51,7 +51,9 @@ const RangeSlider = {
     showFilter: VueTypes.bool.def(true),
     showCheckbox: VueTypes.bool.def(true),
     title: types.title,
-    URLParams: VueTypes.bool.def(false)
+		URLParams: VueTypes.bool.def(false),
+		tooltipTrigger: types.tooltipTrigger,
+		mergeTooltip: VueTypes.bool.def(true)
   },
 
   methods:{
@@ -61,7 +63,7 @@ const RangeSlider = {
         this.watchComponent(props.componentId, props.react);
       }
     },
-    handleSlider(values){ 
+    handleSlider(values){
       if (!isEqual(values.currentValue, this.state.currentValue)) {
         this.handleChange(values.currentValue);
       }
@@ -142,6 +144,7 @@ const RangeSlider = {
   },
 
   render(){
+		const tooltipTrigger = this.$props.tooltipTrigger === 'none' ? false : this.$props.tooltipTrigger;
     return(
       <Container class={this.$props.className}>
           {this.$props.title && (
@@ -151,7 +154,15 @@ const RangeSlider = {
           )}
 
         <Slider class={getClassName(this.$props.innerClass, "slider")}>
-          <vue-slider ref="slider" value={this.state.currentValue} min={this.$props.range.start} max={this.$props.range.end} onDrag-end={this.handleSlider}></vue-slider>
+          <vue-slider
+						ref="slider"
+						value={this.state.currentValue}
+						min={this.$props.range.start}
+						max={this.$props.range.end}
+						onDrag-end={this.handleSlider}
+						tooltip-merge={this.$props.mergeTooltip}
+						tooltip={tooltipTrigger}
+					/>
         </Slider>
       </Container>
     )
@@ -200,6 +211,3 @@ RangeSlider.install = function(Vue) {
   Vue.component(RangeSlider.name, RangeConnected);
 };
 export default RangeSlider;
-
-
-

--- a/packages/vue/src/utils/vueTypes.js
+++ b/packages/vue/src/utils/vueTypes.js
@@ -118,6 +118,7 @@ const types = {
 	props: VueTypes.object,
 	rangeLabelsAlign: VueTypes.oneOf(['left', 'right']),
 	title: VueTypes.oneOfType([VueTypes.string, VueTypes.any]),
+	tooltipTrigger: VueTypes.oneOf(['always', 'none', 'hover']),
 	location: VueTypes.shape({
 		lat: validateLocation,
 		lng: validateLocation


### PR DESCRIPTION
`mergeTooltip={ true }` // merges tooltip
`tooltipTrigger = "none"` // show tooltip in various events

`tooltipTrigger` can have 3 values - `always`, `hover`, `none`.

@divyanshu-rawat Can you please update the docs & Stories for this ?