### PR TITLE
Remove input validation onChange of slider

### DIFF
--- a/packages/web/src/components/range/RangeInput.js
+++ b/packages/web/src/components/range/RangeInput.js
@@ -22,8 +22,8 @@ class RangeInput extends Component {
 			isEndValid: true,
 		};
 
-		this.startInputRef = null;
-		this.endInputRef = null;
+		this.startInputRef = React.createRef();
+		this.endInputRef = React.createRef();
 	}
 
 	componentWillReceiveProps(nextProps) {
@@ -70,8 +70,8 @@ class RangeInput extends Component {
 
 	handleSlider = ({ start, end }) => {
 		if (
-			document.activeElement !== this.startInputRef
-			&& document.activeElement !== this.endInputRef
+			document.activeElement !== this.startInputRef.current
+			&& document.activeElement !== this.endInputRef.current
 		) {
 			this.setState({
 				start,
@@ -84,14 +84,6 @@ class RangeInput extends Component {
 				end,
 			});
 		}
-	};
-
-	setStartInputRef = (ref) => {
-		this.startInputRef = ref;
-	};
-
-	setEndInputRef = (ref) => {
-		this.endInputRef = ref;
 	};
 
 	render() {
@@ -122,7 +114,7 @@ class RangeInput extends Component {
 							alert={!this.state.isStartValid}
 							className={getClassName(this.props.innerClass, 'input') || null}
 							themePreset={themePreset}
-							innerRef={this.setStartInputRef}
+							innerRef={this.startInputRef}
 							id="startInput"
 						/>
 						{!this.state.isStartValid && (
@@ -142,7 +134,7 @@ class RangeInput extends Component {
 							alert={!this.state.isEndValid}
 							className={getClassName(this.props.innerClass, 'input') || null}
 							themePreset={themePreset}
-							innerRef={this.setEndInputRef}
+							innerRef={this.endInputRef}
 							id="endInput"
 						/>
 						{!this.state.isEndValid && <Content alert>Input range is invalid</Content>}

--- a/packages/web/src/components/range/RangeInput.js
+++ b/packages/web/src/components/range/RangeInput.js
@@ -21,6 +21,9 @@ class RangeInput extends Component {
 			isStartValid: true,
 			isEndValid: true,
 		};
+
+		this.startInputRef = null;
+		this.endInputRef = null;
 	}
 
 	componentWillReceiveProps(nextProps) {
@@ -66,16 +69,29 @@ class RangeInput extends Component {
 	};
 
 	handleSlider = ({ start, end }) => {
-		this.setState({
-			start,
-			end,
-		});
+		if (
+			document.activeElement !== this.startInputRef
+			&& document.activeElement !== this.endInputRef
+		) {
+			this.setState({
+				start,
+				end,
+			});
+		}
 		if (this.props.onValueChange) {
 			this.props.onValueChange({
 				start,
 				end,
 			});
 		}
+	};
+
+	setStartInputRef = (ref) => {
+		this.startInputRef = ref;
+	};
+
+	setEndInputRef = (ref) => {
+		this.endInputRef = ref;
 	};
 
 	render() {
@@ -106,6 +122,8 @@ class RangeInput extends Component {
 							alert={!this.state.isStartValid}
 							className={getClassName(this.props.innerClass, 'input') || null}
 							themePreset={themePreset}
+							innerRef={this.setStartInputRef}
+							id="startInput"
 						/>
 						{!this.state.isStartValid && (
 							<Content alert>Input range is invalid</Content>
@@ -124,6 +142,8 @@ class RangeInput extends Component {
 							alert={!this.state.isEndValid}
 							className={getClassName(this.props.innerClass, 'input') || null}
 							themePreset={themePreset}
+							innerRef={this.setEndInputRef}
+							id="endInput"
 						/>
 						{!this.state.isEndValid && <Content alert>Input range is invalid</Content>}
 					</Flex>


### PR DESCRIPTION
**Issue**
- While typing value in end input, it doesn't allow the user to enter value less than start value, because `RangeSlider` change handler resets it to start value.

![ejtxgox16y](https://user-images.githubusercontent.com/6964334/50265567-354d7000-0446-11e9-9195-5c0d143c97da.gif)
