### PR TITLE
vue: Add toolipFormatter

### DIFF
--- a/packages/vue/src/components/range/RangeSlider.jsx
+++ b/packages/vue/src/components/range/RangeSlider.jsx
@@ -56,6 +56,7 @@ const RangeSlider = {
 		URLParams: VueTypes.bool.def(false),
 		tooltipTrigger: types.tooltipTrigger,
 		mergeTooltip: VueTypes.bool.def(true),
+		tooltipFormatter: types.func,
 	},
 
 	methods: {
@@ -172,6 +173,7 @@ const RangeSlider = {
 							enable-cross={false}
 							tooltip-merge={this.$props.mergeTooltip}
 							tooltip={tooltipTrigger}
+							formatter={this.$props.tooltipFormatter}
 						/>
 						{this.$props.rangeLabels && (
 							<div class="label-container">


### PR DESCRIPTION
Usage: 
```js
<RangeSlider
          ...
          :tooltipFormatter="function(value){
            return '$'+ value.toLocaleString();
          }"
/>
```

Demo:
![image](https://user-images.githubusercontent.com/22376783/50420880-ada99c00-085f-11e9-98f2-5e2016f9ab63.png)

Closes #728 