### PR TITLE
web: Fix controlled behavior in List  when onChange is not defined

### DIFF
--- a/packages/web/src/components/list/MultiDataList.js
+++ b/packages/web/src/components/list/MultiDataList.js
@@ -366,8 +366,6 @@ class MultiDataList extends Component {
 			this.setValue(listValue);
 		} else if (onChange) {
 			onChange(listValue);
-		} else {
-			this.setValue(listValue);
 		}
 	};
 

--- a/packages/web/src/components/list/MultiDropdownList.js
+++ b/packages/web/src/components/list/MultiDropdownList.js
@@ -385,8 +385,6 @@ class MultiDropdownList extends Component {
 			this.setValue(item);
 		} else if (onChange) {
 			onChange(item);
-		} else {
-			this.setValue(item);
 		}
 	};
 

--- a/packages/web/src/components/list/MultiList.js
+++ b/packages/web/src/components/list/MultiList.js
@@ -418,8 +418,6 @@ class MultiList extends Component {
 			this.setValue(listValue);
 		} else if (onChange) {
 			onChange(listValue);
-		} else {
-			this.setValue(listValue);
 		}
 	};
 

--- a/packages/web/src/components/list/SingleDataList.js
+++ b/packages/web/src/components/list/SingleDataList.js
@@ -32,7 +32,8 @@ class SingleDataList extends Component {
 	constructor(props) {
 		super(props);
 
-		const currentValue = props.selectedValue || props.defaultValue || '';
+		const defaultValue = props.defaultValue || props.value;
+		const currentValue = props.selectedValue || defaultValue;
 		this.state = {
 			currentValue,
 			searchTerm: '',
@@ -84,7 +85,7 @@ class SingleDataList extends Component {
 		});
 
 		if (this.props.value !== prevProps.value) {
-			this.setValue(this.props.defaultValue);
+			this.setValue(this.props.value);
 		} else if (
 			this.state.currentValue !== this.props.selectedValue
 			&& this.props.selectedValue !== prevProps.selectedValue
@@ -277,8 +278,6 @@ class SingleDataList extends Component {
 			this.setValue(listValue);
 		} else if (onChange) {
 			onChange(listValue);
-		} else {
-			this.setValue(listValue);
 		}
 	};
 

--- a/packages/web/src/components/list/SingleDataList.js
+++ b/packages/web/src/components/list/SingleDataList.js
@@ -33,7 +33,7 @@ class SingleDataList extends Component {
 		super(props);
 
 		const defaultValue = props.defaultValue || props.value;
-		const currentValue = props.selectedValue || defaultValue;
+		const currentValue = props.selectedValue || defaultValue || '';
 		this.state = {
 			currentValue,
 			searchTerm: '',

--- a/packages/web/src/components/list/SingleDropdownList.js
+++ b/packages/web/src/components/list/SingleDropdownList.js
@@ -257,8 +257,6 @@ class SingleDropdownList extends Component {
 			this.setValue(item);
 		} else if (onChange) {
 			onChange(item);
-		} else {
-			this.setValue(item);
 		}
 	};
 

--- a/packages/web/src/components/list/SingleList.js
+++ b/packages/web/src/components/list/SingleList.js
@@ -301,8 +301,6 @@ class SingleList extends Component {
 			this.setValue(listValue);
 		} else if (onChange) {
 			onChange(listValue);
-		} else {
-			this.setValue(listValue);
 		}
 	};
 


### PR DESCRIPTION
NOTE:

1. When `onChange` is not defined in `SingleDropdownList` and we select a value the dropdown closes because `Dropdown` component uses the state to control dropdown.
2. Currently, on clearing `SelectedFilters` the value is getting reset as we haven't implemented that SelectedFitler behavior in the controlled environment.
3. `SingleDataList`  initial value in controlled behavior.