### PR TITLE
FIx controlled behavior for Date Components

### DIFF
--- a/packages/web/src/components/date/DatePicker.js
+++ b/packages/web/src/components/date/DatePicker.js
@@ -109,7 +109,19 @@ class DatePicker extends Component {
 
 	clearDayPicker = () => {
 		if (this.state.currentDate !== '') {
-			this.handleDateChange(''); // resets the day picker component
+			const { value, onChange } = this.props;
+
+			if (value === undefined) {
+				this.handleDateChange('', false); // resets the day picker component
+			} else if (onChange) {
+				onChange('');
+			} else {
+				// Since value prop is defined and onChange is not define
+				// we keep the same date as in store
+				this.setState({
+					currentDate: this.state.currentDate,
+				});
+			}
 		}
 	};
 
@@ -121,6 +133,8 @@ class DatePicker extends Component {
 		} else if (onChange) {
 			onChange(date || '');
 		} else {
+			// this will trigger a remount on the date component
+			// since DayPickerInput doesn't respect the controlled behavior setting on its own
 			this.setState(state => ({
 				key: state.key === 'on' ? 'off' : 'on',
 			}));

--- a/packages/web/src/components/date/DatePicker.js
+++ b/packages/web/src/components/date/DatePicker.js
@@ -35,6 +35,7 @@ class DatePicker extends Component {
 		const currentDate = props.selectedValue || props.value || props.defaultValue || '';
 		this.state = {
 			currentDate,
+			key: 'on',
 		};
 		this.locked = false;
 
@@ -120,9 +121,9 @@ class DatePicker extends Component {
 		} else if (onChange) {
 			onChange(date || '');
 		} else {
-			this.setState({
-				currentDate: this.state.currentDate,
-			});
+			this.setState(state => ({
+				key: state.key === 'on' ? 'off' : 'on',
+			}));
 		}
 	};
 
@@ -217,6 +218,7 @@ class DatePicker extends Component {
 							numberOfMonths: this.props.numberOfMonths,
 							initialMonth: this.props.initialMonth,
 						}}
+						key={this.state.key}
 						clickUnselectsDay={this.props.clickUnselectsDay}
 						onDayChange={this.handleDayPicker}
 						inputProps={{

--- a/packages/web/src/components/date/DatePicker.js
+++ b/packages/web/src/components/date/DatePicker.js
@@ -120,7 +120,9 @@ class DatePicker extends Component {
 		} else if (onChange) {
 			onChange(date || '');
 		} else {
-			this.handleDateChange(date || '');
+			this.setState({
+				currentDate: this.state.currentDate,
+			});
 		}
 	};
 

--- a/packages/web/src/components/date/DateRange.js
+++ b/packages/web/src/components/date/DateRange.js
@@ -52,6 +52,8 @@ class DateRange extends Component {
 		this.state = {
 			currentDate,
 			dateHovered: null,
+			startKey: 'onStart',
+			endKey: 'onEnd',
 		};
 		this.locked = false;
 		const hasMounted = false;
@@ -240,9 +242,9 @@ class DateRange extends Component {
 				end,
 			});
 		} else {
-			this.setState({
-				currentDate,
-			});
+			this.setState(state => ({
+				startKey: state.startKey === 'onStart' ? 'offStart' : 'onStart',
+			}));
 		}
 		// focus the end date DayPicker if its empty
 		if (this.props.autoFocusEnd && autoFocus) {
@@ -267,9 +269,9 @@ class DateRange extends Component {
 				end: date,
 			});
 		} else {
-			this.setState({
-				currentDate,
-			});
+			this.setState(state => ({
+				endKey: state.endKey === 'onEnd' ? 'offEnd' : 'onEnd',
+			}));
 		}
 	};
 
@@ -377,6 +379,7 @@ class DateRange extends Component {
 							showOverlay={this.props.focused}
 							formatDate={this.formatInputDate}
 							value={start}
+							key={this.state.startKey}
 							placeholder={this.props.placeholder.start}
 							dayPickerProps={{
 								numberOfMonths: this.props.numberOfMonths,
@@ -428,6 +431,7 @@ class DateRange extends Component {
 							showOverlay={this.props.focused}
 							formatDate={this.formatInputDate}
 							value={end}
+							key={this.state.endKey}
 							placeholder={this.props.placeholder.end}
 							dayPickerProps={{
 								numberOfMonths: this.props.numberOfMonths,

--- a/packages/web/src/components/date/DateRange.js
+++ b/packages/web/src/components/date/DateRange.js
@@ -52,8 +52,8 @@ class DateRange extends Component {
 		this.state = {
 			currentDate,
 			dateHovered: null,
-			startKey: 'onStart',
-			endKey: 'onEnd',
+			startKey: 'on-start',
+			endKey: 'on-end',
 		};
 		this.locked = false;
 		const hasMounted = false;
@@ -202,6 +202,8 @@ class DateRange extends Component {
 			} else if (onChange) {
 				onChange({ start: '', end: this.state.currentDate.end });
 			} else {
+				// Since value prop is defined and onChange is not define
+				// we keep the same date as in store
 				this.setState({
 					currentDate: this.state.currentDate,
 				});
@@ -219,6 +221,8 @@ class DateRange extends Component {
 			} else if (onChange) {
 				onChange({ start: this.state.currentDate.start, end: '' });
 			} else {
+				// Since value prop is defined and onChange is not define
+				// we keep the same date as in store
 				this.setState({
 					currentDate: this.state.currentDate,
 				});
@@ -242,8 +246,10 @@ class DateRange extends Component {
 				end,
 			});
 		} else {
+			// this will trigger a remount on the date component
+			// since DayPickerInput doesn't respect the controlled behavior setting on its own
 			this.setState(state => ({
-				startKey: state.startKey === 'onStart' ? 'offStart' : 'onStart',
+				startKey: state.startKey === 'on-start' ? 'off-start' : 'on-start',
 			}));
 		}
 		// focus the end date DayPicker if its empty
@@ -269,8 +275,10 @@ class DateRange extends Component {
 				end: date,
 			});
 		} else {
+			// this will trigger a remount on the date component
+			// since DayPickerInput doesn't respect the controlled behavior setting on its own
 			this.setState(state => ({
-				endKey: state.endKey === 'onEnd' ? 'offEnd' : 'onEnd',
+				endKey: state.endKey === 'on-end' ? 'off-end' : 'on-end',
 			}));
 		}
 	};

--- a/packages/web/src/components/date/DateRange.js
+++ b/packages/web/src/components/date/DateRange.js
@@ -200,7 +200,9 @@ class DateRange extends Component {
 			} else if (onChange) {
 				onChange({ start: '', end: this.state.currentDate.end });
 			} else {
-				this.handleStartDate('', false); // resets the day picker component
+				this.setState({
+					currentDate: this.state.currentDate,
+				});
 			}
 		}
 	};
@@ -215,7 +217,9 @@ class DateRange extends Component {
 			} else if (onChange) {
 				onChange({ start: this.state.currentDate.start, end: '' });
 			} else {
-				this.handleEndDate('', false); // resets the day picker component
+				this.setState({
+					currentDate: this.state.currentDate,
+				});
 			}
 		}
 	};
@@ -236,9 +240,8 @@ class DateRange extends Component {
 				end,
 			});
 		} else {
-			this.handleDateChange({
-				start: date,
-				end,
+			this.setState({
+				currentDate,
 			});
 		}
 		// focus the end date DayPicker if its empty
@@ -264,9 +267,8 @@ class DateRange extends Component {
 				end: date,
 			});
 		} else {
-			this.handleDateChange({
-				start,
-				end: date,
+			this.setState({
+				currentDate,
 			});
 		}
 	};


### PR DESCRIPTION
Note: 

If onChange is not defined we can still change the calendar date, it is due to `dayPickerInput`; the component is handling the date value. The query is not fired though.

Demo: 
SeletedFilter are not updated on changing dates because onChange is not defined.
![datepickeronchange](https://user-images.githubusercontent.com/22376783/51033831-aa860e00-15ca-11e9-97c3-466cabc9771e.gif)
