### PR TITLE
Make Tileserver customizable from props

### DIFF
--- a/packages/maps/src/components/result/ReactiveOpenStreetMap.js
+++ b/packages/maps/src/components/result/ReactiveOpenStreetMap.js
@@ -160,7 +160,7 @@ class ReactiveOpenStreetMap extends Component {
 				}}
 				touchZoom
 			>
-				<OpenStreetLayer url={this.props.tileServer ? this.props.tileServer : 'http://{s}.tile.osm.org/{z}/{x}/{y}.png'} />
+				<OpenStreetLayer url={this.props.tileServer || 'https://{s}.tile.osm.org/{z}/{x}/{y}.png'} />
 				{markers}
 				{this.props.showMarkers && this.props.markers}
 			</OpenStreetMap>

--- a/packages/maps/src/components/result/ReactiveOpenStreetMap.js
+++ b/packages/maps/src/components/result/ReactiveOpenStreetMap.js
@@ -9,6 +9,7 @@ import {
 } from 'react-leaflet';
 import { Icon, DivIcon } from 'leaflet';
 import { MapPin, mapPinWrapper } from './addons/styles/MapPin';
+import types from '@appbaseio/reactivecore/lib/utils/types';
 
 import ReactiveMap from './ReactiveMap';
 
@@ -171,5 +172,9 @@ class ReactiveOpenStreetMap extends Component {
 		return <ReactiveMap {...this.props} renderMap={this.renderMap} />;
 	}
 }
+
+ReactiveOpenStreetMap.propTypes = {
+  tileServer: types.string,
+};
 
 export default ReactiveOpenStreetMap;

--- a/packages/maps/src/components/result/ReactiveOpenStreetMap.js
+++ b/packages/maps/src/components/result/ReactiveOpenStreetMap.js
@@ -160,7 +160,7 @@ class ReactiveOpenStreetMap extends Component {
 				}}
 				touchZoom
 			>
-				<OpenStreetLayer url="http://{s}.tile.osm.org/{z}/{x}/{y}.png" />
+				<OpenStreetLayer url={this.props.tileServer ? this.props.tileServer : 'http://{s}.tile.osm.org/{z}/{x}/{y}.png'} />
 				{markers}
 				{this.props.showMarkers && this.props.markers}
 			</OpenStreetMap>


### PR DESCRIPTION
IWLT propose an additional prop for ReactiveOpenStreetMap do change the tile server if needed. If the prop is not set ReactiveOpenStreetMap will default to `http://{s}.tile.osm.org/{z}/{x}/{y}.png`