### PR TITLE
Fix issue where controlled inputs don't work for RangeInput component

### DIFF
--- a/packages/web/src/components/range/RangeInput.js
+++ b/packages/web/src/components/range/RangeInput.js
@@ -112,15 +112,19 @@ class RangeInput extends Component {
 		const {
 			className, style, themePreset, ...rest
 		} = this.props;
+
+		const value = {
+			start: this.props.onChange ? Number(this.props.value.start) : Number(this.state.start),
+			end: this.props.onChange ? Number(this.props.value.end) : Number(this.state.end),
+		};
+
 		return (
 			<Container style={style} className={className}>
 				<RangeSlider
 					{...rest}
 					value={{
-						start: this.state.isStartValid
-							? Number(this.state.start)
-							: this.props.range.start,
-						end: this.state.isEndValid ? Number(this.state.end) : this.props.range.end,
+						start: this.state.isStartValid ? value.start : this.props.range.start,
+						end: this.state.isEndValid ? value.end : this.props.range.end,
 					}}
 					onChange={this.handleSliderChange}
 					className={getClassName(this.props.innerClass, 'slider-container') || null}
@@ -131,7 +135,7 @@ class RangeInput extends Component {
 							name="start"
 							type="number"
 							onChange={this.handleInputChange}
-							value={this.state.start}
+							value={value.start}
 							step={this.props.stepValue}
 							alert={!this.state.isStartValid}
 							className={getClassName(this.props.innerClass, 'input') || null}
@@ -150,7 +154,7 @@ class RangeInput extends Component {
 							name="end"
 							type="number"
 							onChange={this.handleInputChange}
-							value={this.state.end}
+							value={value.end}
 							step={this.props.stepValue}
 							alert={!this.state.isEndValid}
 							className={getClassName(this.props.innerClass, 'input') || null}


### PR DESCRIPTION
This PR fixes an issue where RangeInput does not work as a controlled component.

The following code, a modified version of the `RangeInput` example, replicates this issue:

```js
import React, { Component } from 'react';
import ReactDOM from 'react-dom';

import { ReactiveBase, ResultList, RangeInput } from '@appbaseio/reactivesearch';

import './index.css';

export class Range extends React.Component {
	constructor() {
		super();
		this.state = {
			start: 3000,
			end: 5000,
		};
	}

	handleChange(change) {
		this.setState({
			start: Number(change.start),
			end: Number(change.end),
		});
	}

	render() {
		return (
			<RangeInput
				dataField="ratings_count"
				componentId="BookSensor"
				value={{
					start: this.state.start,
					end: this.state.end,
				}}
				range={{
					start: 0,
					end: 50000,
				}}
				onChange={this.handleChange.bind(this)}
				rangeLabels={{
					start: '3K',
					end: '50K',
				}}
			/>
		);
	}
}

class Main extends Component {
	render() {
		return (
			<ReactiveBase
				app="good-books-ds"
				credentials="nY6NNTZZ6:27b76b9f-18ea-456c-bc5e-3a5263ebc63d"
			>
				<div className="row">
					<div className="col">
						<Range />
					</div>
					<div className="col">
						<ResultList
							componentId="SearchResult"
							dataField="original_title"
							from={0}
							size={3}
							className="result-list-container"
							renderData={this.booksList}
							pagination
							react={{
								and: 'BookSensor',
							}}
						/>
					</div>
				</div>
			</ReactiveBase>
		);
	}

	booksList(data) {
		return {
			title: (
				<div
					className="book-title"
					dangerouslySetInnerHTML={{ __html: data.original_title }}
				/>
			),
			description: (
				<div className="flex column justify-space-between">
					<div>
						<div>
							by <span className="authors-list">{data.authors}</span>
						</div>
						<div className="ratings-list flex align-center">
							<span className="stars">
								{Array(data.average_rating_rounded)
									.fill('x')
									.map((item, index) => (
										<i className="fas fa-star" key={index} />
									)) // eslint-disable-line
								}
							</span>
							<span className="avg-rating">({data.average_rating} avg)</span>
						</div>
					</div>
					<span className="pub-year">Pub {data.original_publication_year}</span>
				</div>
			),
			image: data.image,
		};
	}
}

ReactDOM.render(<Main />, document.getElementById('root'));
```

There are two ways to modify the value of the `RangeInput` in this component
1. Move the slider
2. Adjust the start or end input values by typing in a value or by click the up and down increments

Both strategies successfully invoke the `onChange` prop, but neither correctly uses the `value` prop passed in when the component is controlled.

Interesting the bug does not manifest itself when adjusting the slider, despite the fact that the code does not use the `value` prop. This is because of a `componentDidUpdate` function that maintains the internal state when the slider moves regardless of whether the component is controlled or not. I wasn't sure if this behavior was intentional or not, but it definitely seemed peculiar to me

I would really like to get this PR merged in the next few days if possible. I'm trying to present a demo using `reactivesearch`, and it hinges on getting `RangeInput` to work as a controlled component. I'm happy to work with the maintainers to make adjustments to get this merged.

Thank you!