### PR TITLE
Fix bug with sort returning to default

### DIFF
--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -530,6 +530,7 @@ class ReactiveList extends Component {
 			},
 		];
 		this.props.setQueryOptions(this.props.componentId, options, true);
+		this.sortOptionIndex = index;
 
 		this.setState(
 			{


### PR DESCRIPTION
sortOptionIndex was never update in handleSortChange causing the sort to return to the default in cases where query options were rebuilt in componentDidUpdate.