### PR TITLE
Add support for icon & dimmedIcon

### DIFF
--- a/packages/web/src/components/range/RatingsFilter.js
+++ b/packages/web/src/components/range/RatingsFilter.js
@@ -19,6 +19,7 @@ import {
 	getOptionsFromQuery,
 } from '@appbaseio/reactivecore/lib/utils/helper';
 import types from '@appbaseio/reactivecore/lib/utils/types';
+import { element } from 'prop-types';
 
 import Title from '../../styles/Title';
 import Container from '../../styles/Container';
@@ -202,7 +203,11 @@ class RatingsFilter extends Component {
 							}
 							key={`${this.props.componentId}-${item.start}-${item.end}`}
 						>
-							<StarRating stars={item.start} />
+							<StarRating
+								icon={this.props.icon}
+								dimmedIcon={this.props.dimmedIcon}
+								stars={item.start}
+							/>
 							{item.label ? <span>{item.label}</span> : null}
 						</li>
 					))}
@@ -228,8 +233,10 @@ RatingsFilter.propTypes = {
 	data: types.data,
 	dataField: types.stringRequired,
 	defaultValue: types.range,
+	dimmedIcon: element,
 	value: types.range,
 	filterLabel: types.string,
+	icon: element,
 	innerClass: types.style,
 	nestedField: types.string,
 	onQueryChange: types.func,

--- a/packages/web/src/components/range/addons/StarRating.js
+++ b/packages/web/src/components/range/addons/StarRating.js
@@ -1,28 +1,40 @@
 import React from 'react';
 import types from '@appbaseio/reactivecore/lib/utils/types';
+import { element } from 'prop-types';
 
 import Star from './Star';
 import { starRow, whiteStar } from '../../../styles/ratingsList';
 
 function StarRating(props) {
+	const { icon, dimmedIcon } = props;
 	return (
 		<div className={starRow}>
 			{Array(props.stars)
 				.fill('')
-				.map((item, index) => (
-					<Star key={index} /> // eslint-disable-line
-				))}
+				.map((_, index) =>
+					(icon ? (
+						<React.Fragment key={index}>{icon}</React.Fragment> // eslint-disable-line
+					) : (
+						<Star key={index} /> // eslint-disable-line
+					)),
+				)}
 			{Array(5 - props.stars)
 				.fill('')
-				.map((item, index) => (
-					<Star key={index} className={whiteStar} /> // eslint-disable-line
-				))}
+				.map((_, index) =>
+					(dimmedIcon ? (
+						<React.Fragment key={index}>{dimmedIcon}</React.Fragment> // eslint-disable-line
+					) : (
+						<Star key={index} className={whiteStar} /> // eslint-disable-line
+					)),
+				)}
 		</div>
 	);
 }
 
 StarRating.propTypes = {
 	stars: types.number,
+	icon: element,
+	dimmedIcon: element,
 };
 
 export default StarRating;


### PR DESCRIPTION
React Feather Icon used:

Api: 
```
<RatingsFilter
    componentId="RatingsSensor"
    dataField="average_rating_rounded"
    title="RatingsFilter"
    icon={<Star style={{ color: 'yellow' }} />}
    dimmedIcon={<Star style={{ color: 'grey' }} />}
    data={[
        { start: 4, end: 5, label: '4 stars and up' },
        { start: 3, end: 5, label: '3 stars and up' },
        { start: 2, end: 5, label: '2 stars and up' },
        { start: 1, end: 5, label: '> 1 stars' },
    ]}
/>
```

Demo:
![image](https://user-images.githubusercontent.com/22376783/55419040-96322b80-5591-11e9-9ebf-fb27673ade4c.png)

Closes #839 
