### PR TITLE
fix(web): continue parsing URL params even if one fails

### DIFF
--- a/packages/web/src/components/basic/ReactiveBase.js
+++ b/packages/web/src/components/basic/ReactiveBase.js
@@ -81,8 +81,8 @@ class ReactiveBase extends Component {
 		const params = new URLSearchParams(queryParams);
 		let selectedValues = {};
 
-		try {
-			Array.from(params.keys()).forEach((key) => {
+		Array.from(params.keys()).forEach((key) => {
+			try {
 				const parsedParams = JSON.parse(params.get(key));
 				const selectedValue = {};
 				if (parsedParams.value) {
@@ -95,10 +95,10 @@ class ReactiveBase extends Component {
 					...selectedValues,
 					[key]: selectedValue,
 				};
-			});
-		} catch (e) {
-			// Do not add to selectedValues if JSON parsing fails.
-		}
+			} catch (e) {
+				// Do not add to selectedValues if JSON parsing fails.
+			}
+		});
 
 		const { headers = {}, themePreset } = props;
 		const appbaseRef = Appbase(config);


### PR DESCRIPTION
Similiar to code in #901, only fail on a single param, not the entire Array. This can happen if you have a custom param before or in the middle of reactivesearch filter params. This could also validate on a list of currently configured filter names, but I didn't see an easy way to add that. 