### PR TITLE
chore: add release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,11 @@
+categories:
+    - title: 🚀 Features
+      label: feature
+    - title: 🐛 Bug Fixes
+      label: fix
+    - title: 🔧 Maintenance
+      label: chore
+template: |
+    ## Changes
+
+    $CHANGES


### PR DESCRIPTION
### Setup

* For release drafter to work correctly, we need to make `next` branch as the default branch or need to merge all changes into `dev`.
* In order to categories commits into `feature`, `fix` and `chore` we need to add respective labels to PR before merging them.