### PR TITLE
Bug Fix: When the categoryField is not specified on the Category?Sear…

### DIFF
--- a/packages/web/src/components/search/CategorySearch.js
+++ b/packages/web/src/components/search/CategorySearch.js
@@ -732,7 +732,7 @@ class CategorySearch extends Component {
 	get parsedSuggestions() {
 		let finalSuggestionsList = [];
 		let suggestionsList = [];
-
+        let categorySuggestions = [];
 		// filter out empty categories
 		const filteredCategories = this.filteredCategories;
 
@@ -747,7 +747,7 @@ class CategorySearch extends Component {
 		}
 
 		if (this.state.currentValue && this.state.suggestions.length && filteredCategories.length) {
-			let categorySuggestions = [
+			categorySuggestions = [
 				{
 					label: `${this.state.currentValue} in all categories`,
 					value: this.state.currentValue,
@@ -774,8 +774,8 @@ class CategorySearch extends Component {
 					},
 				];
 			}
-			finalSuggestionsList = [...categorySuggestions, ...suggestionsList];
 		}
+		finalSuggestionsList = [...categorySuggestions, ...suggestionsList];
 		return finalSuggestionsList;
 	}
 


### PR DESCRIPTION
…ch component, auto suggest is broken. Given that the category search field is optional according to the documentation here

https://opensource.appbase.io/reactive-manual/search-components/categorysearch.html#props

This should have worked, but the code that recommends the final suggesiton list is only merging the two results when category search is enabled. This can be replicated in the demo example from the documentation site by removing the category field. I have created a codesandbox.io that showcases the broken search functionality here
https://codesandbox.io/embed/2orqz6rryn

The fix ensures the the parsedSuggestions getter always merges the categoriesResults and the suggestionsResults.