### PR TITLE
add exhaustive service options prop for geodistance

### DIFF
--- a/packages/maps/src/components/basic/GeoDistanceDropdown.js
+++ b/packages/maps/src/components/basic/GeoDistanceDropdown.js
@@ -315,6 +315,7 @@ class GeoDistanceDropdown extends Component {
 				{
 					input: value,
 					componentRestrictions: { country: restrictedCountries },
+					...this.props.serviceOptions,
 				},
 				(res) => {
 					const suggestionsList
@@ -498,6 +499,7 @@ GeoDistanceDropdown.propTypes = {
 	onValueChange: types.func,
 	placeholder: types.string,
 	react: types.react,
+	serviceOptions: types.props,
 	showFilter: types.bool,
 	showIcon: types.bool,
 	style: types.style,

--- a/packages/maps/src/components/basic/GeoDistanceSlider.js
+++ b/packages/maps/src/components/basic/GeoDistanceSlider.js
@@ -317,6 +317,7 @@ class GeoDistanceSlider extends Component {
 				{
 					input: value,
 					componentRestrictions: { country: restrictedCountries },
+					...this.props.serviceOptions,
 				},
 				(res) => {
 					const suggestionsList
@@ -530,6 +531,7 @@ GeoDistanceSlider.propTypes = {
 	range: types.range,
 	rangeLabels: types.rangeLabels,
 	react: types.react,
+	serviceOptions: types.props,
 	showFilter: types.bool,
 	showIcon: types.bool,
 	tooltipTrigger: types.tooltipTrigger,


### PR DESCRIPTION
Minimal implementation that closes #991.

### The problem

- At the moment both **GeoDistanceSlider** and **GeoDistanceDropdown** components only support control of a single [AutocompleteService.getPlacePredictions](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompleteService.getPlacePredictions) request options property, namely `componentRestrictions: { country: restrictedCountries }`.
- The request options supports way more properties than `componentRestrictions`, that are current not accessible, viz. [the docs](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletionRequest)

### Proposed/Draft solution

- Both of the components now accept a property `serviceOptions` that contains config object for the call
- The solution is very minimal as I'd like to avoid breaking changes to the API. Will add Storybook examples and potentially stronger typings before further actions.