### PR TITLE
feat: SingleRange & SingleList accessiblility

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,43 +4,55 @@
 		"es6": true,
 		"node": true
 	},
-	"plugins": [
-		"jest"
-	],
+	"plugins": ["jest"],
 	"extends": ["airbnb", "plugin:jest/recommended"],
 	"parser": "babel-eslint",
 	"rules": {
-		"indent": [2, "tab", {
-			"SwitchCase": 1,
-			"VariableDeclarator": 1
-		}],
+		"indent": [
+			2,
+			"tab",
+			{
+				"SwitchCase": 1,
+				"VariableDeclarator": 1
+			}
+		],
 		"no-tabs": 0,
 		"no-underscore-dangle": 0,
 		"operator-linebreak": ["error", "before"],
 		"prefer-destructuring": 0,
-		"no-console": ["error", {
-			"allow": ["warn", "error"]
-		}],
+		"no-console": [
+			"error",
+			{
+				"allow": ["warn", "error"]
+			}
+		],
 		"class-methods-use-this": 0,
 		"function-paren-newline": 0,
 
 		"react/jsx-indent": [2, "tab"],
 		"react/jsx-indent-props": [2, "tab"],
 		"react/no-danger": 0,
-		"react/jsx-filename-extension": ["error", {
-			"extensions": [".js", ".jsx"]
-		}],
+		"react/jsx-filename-extension": [
+			"error",
+			{
+				"extensions": [".js", ".jsx"]
+			}
+		],
 		"react/no-typos": 0,
 		"react/require-default-props": 0,
 		"react/no-unused-prop-types": 0,
 		"react/sort-comp": 0,
 
-		"jsx-a11y/label-has-for": [2, {
-			"components": ["Label"],
-			"required": {
-				"every": ["id"]
-			},
-			"allowChildren": false
-		}]
+		"jsx-a11y/label-has-for": [
+			2,
+			{
+				"components": ["Label"],
+				"required": {
+					"every": ["id"]
+				},
+				"allowChildren": false
+			}
+		],
+		"jsx-a11y/no-noninteractive-element-to-interactive-role": 0
 	}
 }

--- a/packages/web/src/components/list/SingleList.js
+++ b/packages/web/src/components/list/SingleList.js
@@ -332,6 +332,7 @@ class SingleList extends Component {
 					className={getClassName(this.props.innerClass, 'input') || null}
 					onChange={this.handleInputChange}
 					value={this.state.searchTerm}
+					aria-labelledby={this.props.title}
 					placeholder={this.props.placeholder}
 					style={{
 						margin: '0 0 8px',
@@ -420,7 +421,10 @@ class SingleList extends Component {
 		return (
 			<Container style={this.props.style} className={this.props.className}>
 				{this.props.title && (
-					<Title className={getClassName(this.props.innerClass, 'title') || null}>
+					<Title
+						id={this.props.title}
+						className={getClassName(this.props.innerClass, 'title') || null}
+					>
 						{this.props.title}
 					</Title>
 				)}
@@ -428,13 +432,19 @@ class SingleList extends Component {
 				{this.hasCustomRenderer ? (
 					this.getComponent()
 				) : (
-					<UL className={getClassName(this.props.innerClass, 'list') || null}>
+					<UL
+						className={getClassName(this.props.innerClass, 'list') || null}
+						role="radiogroup"
+						aria-labelledby={this.props.title}
+					>
 						{selectAllLabel ? (
 							<li
 								key={selectAllLabel}
 								className={`${
 									this.state.currentValue === selectAllLabel ? 'active' : ''
 								}`}
+								role="radio"
+								aria-checked={this.state.currentValue === selectAllLabel}
 							>
 								<Radio
 									className={getClassName(this.props.innerClass, 'radio')}
@@ -458,7 +468,13 @@ class SingleList extends Component {
 							? this.listItems.map((item) => {
 								const isChecked = this.state.currentValue === String(item.key);
 								return (
-									<li key={item.key} className={`${isChecked ? 'active' : ''}`}>
+									<li
+										key={item.key}
+										className={`${isChecked ? 'active' : ''}`}
+										role="radio"
+										aria-checked={isChecked}
+										tabIndex={isChecked ? '0' : '-1'}
+									>
 										<Radio
 											className={getClassName(this.props.innerClass, 'radio')}
 											id={`${this.props.componentId}-${item.key}`}

--- a/packages/web/src/components/range/SingleRange.js
+++ b/packages/web/src/components/range/SingleRange.js
@@ -190,20 +190,34 @@ class SingleRange extends Component {
 	};
 
 	render() {
+		const { title } = this.props;
 		return (
 			<Container style={this.props.style} className={this.props.className}>
 				{this.props.title && (
-					<Title className={getClassName(this.props.innerClass, 'title') || null}>
+					<Title
+						id={title}
+						className={getClassName(this.props.innerClass, 'title') || null}
+					>
 						{this.props.title}
 					</Title>
 				)}
-				<UL className={getClassName(this.props.innerClass, 'list') || null}>
+				<UL
+					className={getClassName(this.props.innerClass, 'list') || null}
+					role="radiogroup"
+					aria-labelledby={title}
+				>
 					{this.props.data.map((item) => {
 						const selected
 							= !!this.state.currentValue
 							&& this.state.currentValue.label === item.label;
 						return (
-							<li key={item.label} className={`${selected ? 'active' : ''}`}>
+							<li
+								key={item.label}
+								role="radio"
+								aria-checked={selected}
+								tabIndex={selected ? '0' : '-1'}
+								className={`${selected ? 'active' : ''}`}
+							>
 								<Radio
 									className={getClassName(this.props.innerClass, 'radio')}
 									id={`${this.props.componentId}-${item.label}`}


### PR DESCRIPTION
Changes on `.eslintrc` are because we are using `li` as radio button so we will need to disable this rule. 

This changes can be also replicated in SingleList.

### SingleRange
Before :
![image](https://user-images.githubusercontent.com/22376783/60946075-e5af9280-a30a-11e9-84b2-57d5a7e39439.png)
After:
![image](https://user-images.githubusercontent.com/22376783/60946083-ea744680-a30a-11e9-8c77-955ab932a28a.png)

### SingleList
Before:
![image](https://user-images.githubusercontent.com/22376783/60946883-fcef7f80-a30c-11e9-8dde-42476d181920.png)

After:
![image](https://user-images.githubusercontent.com/22376783/60946899-0547ba80-a30d-11e9-8e67-76316384e31e.png)
