### PR TITLE
feat(map): support exhaustive service options prop for geodistance

### DIFF
--- a/packages/maps/src/components/basic/GeoDistanceDropdown.js
+++ b/packages/maps/src/components/basic/GeoDistanceDropdown.js
@@ -353,6 +353,7 @@ class GeoDistanceDropdown extends Component {
 				{
 					input: value,
 					componentRestrictions: { country: restrictedCountries },
+					...this.props.serviceOptions,
 				},
 				(res) => {
 					const suggestionsList
@@ -568,6 +569,7 @@ GeoDistanceDropdown.propTypes = {
 	title: types.title,
 	unit: types.string,
 	URLParams: types.bool,
+	serviceOptions: types.props,
 };
 
 GeoDistanceDropdown.defaultProps = {

--- a/packages/maps/src/components/basic/GeoDistanceSlider.js
+++ b/packages/maps/src/components/basic/GeoDistanceSlider.js
@@ -584,7 +584,7 @@ GeoDistanceSlider.propTypes = {
 	value: types.selectedValue,
 	unit: types.string,
 	URLParams: types.bool,
-	...this.props.serviceOptions,
+	serviceOptions: types.props,
 };
 
 GeoDistanceSlider.defaultProps = {

--- a/packages/maps/src/components/basic/GeoDistanceSlider.js
+++ b/packages/maps/src/components/basic/GeoDistanceSlider.js
@@ -334,6 +334,7 @@ class GeoDistanceSlider extends Component {
 				{
 					input: value,
 					componentRestrictions: { country: restrictedCountries },
+					...this.props.serviceOptions,
 				},
 				(res) => {
 					const suggestionsList
@@ -583,6 +584,7 @@ GeoDistanceSlider.propTypes = {
 	value: types.selectedValue,
 	unit: types.string,
 	URLParams: types.bool,
+	...this.props.serviceOptions,
 };
 
 GeoDistanceSlider.defaultProps = {


### PR DESCRIPTION
Support other library options for `next` version of `GeoDistanceSlider` and `GeoDistanceDropDown`

Ref: #996 