### PR TITLE
Fix default size in query options when value is 0

### DIFF
--- a/packages/web/src/server/index.js
+++ b/packages/web/src/server/index.js
@@ -140,7 +140,7 @@ export default function initReactivesearch(componentCollection, searchState, set
 						queryOptions = queryOptionsReducer(queryOptions, {
 							type: 'SET_QUERY_OPTIONS',
 							component: internalComponent,
-							options: { aggs, size: size || 100 },
+							options: { aggs, size: typeof size === 'undefined' ? 100 : size },
 						});
 					}
 


### PR DESCRIPTION
When creating the initial query for server side rendering, numeric `0` values for the size are interpreted as falsey and thus defaulting to `100`. This PR fixes that.