### PR TITLE
Fix `setSearchParams` type definition

### DIFF
--- a/packages/web/src/components/basic/ReactiveBase.d.ts
+++ b/packages/web/src/components/basic/ReactiveBase.d.ts
@@ -20,7 +20,7 @@ export interface ReactiveBaseProps {
 	transformResponse?: (...args: any[]) => any;
 	transformRequest?: (...args: any[]) => any;
 	getSearchParams?: () => string;
-	setSearchParams?: () => string;
+	setSearchParams?: (newURL: string) => void;
 	searchStateHeader?: boolean;
 	initialState?: types.children;
 	analytics?: boolean;


### PR DESCRIPTION
Hi there,

I just stumbled across this, it seems to me that the signature of `setSearchParams` in `ReactiveBase` is wrong. Probably a copy/paste error from the `get` equivalent. It should take the new URL and return nothing, not the other way around.

Hope I got it right!
