### PR TITLE
feat(web): renderLabel prop in Single- and MultiDropdownList (#1057)

### DIFF
--- a/packages/web/src/components/list/MultiDropdownList.d.ts
+++ b/packages/web/src/components/list/MultiDropdownList.d.ts
@@ -19,6 +19,7 @@ export interface MultiDropdownList extends CommonProps {
 	react?: types.react;
 	render?: (...args: any[]) => any;
 	renderItem?: (...args: any[]) => any;
+	renderLabel?: (...args: any[]) => any;
 	renderError?: types.title;
 	transformData?: (...args: any[]) => any;
 	selectAllLabel?: string;

--- a/packages/web/src/components/list/MultiDropdownList.js
+++ b/packages/web/src/components/list/MultiDropdownList.js
@@ -490,6 +490,7 @@ class MultiDropdownList extends Component {
 					renderItem={this.props.renderItem}
 					hasCustomRenderer={this.hasCustomRenderer}
 					customRenderer={this.getComponent}
+					customLabelRenderer={this.props.renderLabel}
 					renderNoResults={this.props.renderNoResults}
 					showSearch={this.props.showSearch}
 					transformData={this.props.transformData}
@@ -543,6 +544,7 @@ MultiDropdownList.propTypes = {
 	render: types.func,
 	renderItem: types.func,
 	renderNoResults: types.func,
+	renderLabel: types.func,
 	renderError: types.title,
 	transformData: types.func,
 	selectAllLabel: types.string,

--- a/packages/web/src/components/list/SingleDropdownList.d.ts
+++ b/packages/web/src/components/list/SingleDropdownList.d.ts
@@ -19,6 +19,7 @@ export interface SingleDropdownList extends CommonProps {
 	react?: types.react;
 	render?: (...args: any[]) => any;
 	renderItem?: (...args: any[]) => any;
+	renderLabel?: (...args: any[]) => any;
 	renderError?: types.title;
 	transformData?: (...args: any[]) => any;
 	selectAllLabel?: string;

--- a/packages/web/src/components/list/SingleDropdownList.js
+++ b/packages/web/src/components/list/SingleDropdownList.js
@@ -379,6 +379,7 @@ class SingleDropdownList extends Component {
 					renderItem={this.props.renderItem}
 					hasCustomRenderer={this.hasCustomRenderer}
 					customRenderer={this.getComponent}
+					customLabelRenderer={this.props.renderLabel}
 					renderNoResults={this.props.renderNoResults}
 					showSearch={this.props.showSearch}
 					transformData={this.props.transformData}
@@ -430,6 +431,7 @@ SingleDropdownList.propTypes = {
 	react: types.react,
 	render: types.func,
 	renderItem: types.func,
+	renderLabel: types.func,
 	renderError: types.title,
 	renderNoResults: types.func,
 	transformData: types.func,

--- a/packages/web/src/components/range/MultiDropdownRange.d.ts
+++ b/packages/web/src/components/range/MultiDropdownRange.d.ts
@@ -19,6 +19,7 @@ export interface MultiDropdownRangeProps extends CommonProps {
 	showFilter?: boolean;
 	title?: types.title;
 	themePreset?: types.themePreset;
+	renderLabel?: (...args: any[]) => any;
 }
 
 declare const MultiDropdownRange: React.ComponentClass<MultiDropdownRangeProps>;

--- a/packages/web/src/components/range/MultiDropdownRange.js
+++ b/packages/web/src/components/range/MultiDropdownRange.js
@@ -249,6 +249,7 @@ class MultiDropdownRange extends Component {
 					keyField="label"
 					multi
 					returnsObject
+					customLabelRenderer={this.props.renderLabel}
 					themePreset={this.props.themePreset}
 				/>
 			</Container>
@@ -288,6 +289,7 @@ MultiDropdownRange.propTypes = {
 	title: types.title,
 	themePreset: types.themePreset,
 	URLParams: types.bool,
+	renderLabel: types.func,
 };
 
 MultiDropdownRange.defaultProps = {

--- a/packages/web/src/components/range/SingleDropdownRange.d.ts
+++ b/packages/web/src/components/range/SingleDropdownRange.d.ts
@@ -19,6 +19,7 @@ export interface SingleDropdownRangeProps extends CommonProps {
 	showFilter?: boolean;
 	title?: types.title;
 	themePreset?: types.themePreset;
+	renderLabel?: (...args: any[]) => any;
 }
 
 declare const SingleDropdownRange: React.ComponentClass<SingleDropdownRangeProps>;

--- a/packages/web/src/components/range/SingleDropdownRange.js
+++ b/packages/web/src/components/range/SingleDropdownRange.js
@@ -208,6 +208,7 @@ class SingleDropdownRange extends Component {
 					keyField="label"
 					returnsObject
 					themePreset={this.props.themePreset}
+					customLabelRenderer={this.props.renderLabel}
 				/>
 			</Container>
 		);
@@ -246,6 +247,7 @@ SingleDropdownRange.propTypes = {
 	title: types.title,
 	themePreset: types.themePreset,
 	URLParams: types.bool,
+	renderLabel: types.func,
 };
 
 SingleDropdownRange.defaultProps = {

--- a/packages/web/src/components/shared/Dropdown.js
+++ b/packages/web/src/components/shared/Dropdown.js
@@ -73,6 +73,12 @@ class Dropdown extends Component {
 	};
 
 	renderToString = (value) => {
+		if (this.props.customLabelRenderer) {
+			const customLabel = this.props.customLabelRenderer(value);
+			if (typeof customLabel === 'string') {
+				return customLabel;
+			}
+		}
 		if (Array.isArray(value) && value.length) {
 			const arrayToRender = value.map(item => this.renderToString(item));
 			return arrayToRender.join(', ');
@@ -143,9 +149,13 @@ class Dropdown extends Component {
 							small={this.props.small}
 							themePreset={this.props.themePreset}
 						>
-							<div>
-								{selectedItem ? this.renderToString(selectedItem) : placeholder}
-							</div>
+							{this.props.customLabelRenderer
+								? this.props.customLabelRenderer(selectedItem)
+								: (
+									<div>
+										{selectedItem ? this.renderToString(selectedItem) : placeholder}
+									</div>
+								)}
 							<Chevron open={isOpen} />
 						</Select>
 						{
@@ -198,7 +208,11 @@ class Dropdown extends Component {
 													}}
 												>
 													{renderItem ? (
-														renderItem(item[labelField], item.doc_count, selected && this.props.multi)
+														renderItem(
+															item[labelField],
+															item.doc_count,
+															selected && this.props.multi,
+														)
 													) : (
 														<div>
 															{typeof item[labelField] === 'string' ? (
@@ -269,6 +283,7 @@ Dropdown.propTypes = {
 	transformData: types.func,
 	renderNoResults: types.func,
 	customRenderer: types.func,
+	customLabelRenderer: types.func,
 	selectedItem: types.selectedValue,
 	showCount: types.bool,
 	single: types.bool,
@@ -276,6 +291,8 @@ Dropdown.propTypes = {
 	theme: types.style,
 	themePreset: types.themePreset,
 	showSearch: types.bool,
+	footer: types.children,
+	componentId: types.string,
 };
 
 export default withTheme(Dropdown);


### PR DESCRIPTION
I took a stab at implementing my proposed solution for #1057.  

This PR adds a `renderLabel`-prop to render the label of the dropdown similarly to the `renderItems`-prop. Allowing for better UX by being able to show translated values as opposed to just the 'raw' items from the database.

I wanted this function to be able to return React elements as well as strings which posed the interesting challenge of whether or not the `title`-attribute should be influenced by the `renderLabel`-prop. The solution I settled on was to use the return value of the function, if that return value is a string, otherwise fall back to the normal behavior.

There were some linting errors in `Dropdown.js` complaining of missing prop-types, which I had to add in order to commit. I hope I guessed those two types correctly.

Let me know if you have any comments or changes.
