### PR TITLE
fix(web): force ReactiveList to re-render if customRender changes

### DIFF
--- a/packages/web/src/components/result/addons/Results.js
+++ b/packages/web/src/components/result/addons/Results.js
@@ -10,7 +10,12 @@ class Results extends React.Component {
 			deeper differences.
 		*/
 
-		return !isEqual(nextProps.filteredResults, this.props.filteredResults);
+		return !(
+			isEqual(nextProps.filteredResults, this.props.filteredResults)
+			&& isEqual(nextProps.hasCustomRender, this.props.hasCustomRender)
+			&& isEqual(nextProps.getComponent, this.props.getComponent)
+			&& isEqual(nextProps.renderItem, this.props.renderItem)
+		);
 	}
 
 	render() {

--- a/packages/web/src/components/result/addons/Results.js
+++ b/packages/web/src/components/result/addons/Results.js
@@ -1,23 +1,8 @@
 import React from 'react';
-import { getClassName, isEqual } from '@appbaseio/reactivecore/lib/utils/helper';
+import { getClassName } from '@appbaseio/reactivecore/lib/utils/helper';
 import types from '@appbaseio/reactivecore/lib/utils/types';
 
 class Results extends React.Component {
-	shouldComponentUpdate(nextProps) {
-		/*
-			Use shouldComponentUpdate because PureComponent uses shallow comparison of objects.
-			If props contain complex data structures, it may produce false-negatives for
-			deeper differences.
-		*/
-
-		return !(
-			isEqual(nextProps.filteredResults, this.props.filteredResults)
-			&& isEqual(nextProps.hasCustomRender, this.props.hasCustomRender)
-			&& isEqual(nextProps.getComponent, this.props.getComponent)
-			&& isEqual(nextProps.renderItem, this.props.renderItem)
-		);
-	}
-
 	render() {
 		if (this.props.hasCustomRender) {
 			return this.props.getComponent();


### PR DESCRIPTION
When using ReactiveList with a render function, the component does not update if the render function changes. (this also applies to `renderItem`)

This is problematic because the render function could depend on props from outside. When those props change, the update is swallowed by the Results component, since in it's eyes nothing changed.

I've added the relevant props to the `shouldComponentUpdate` function of the Results component.

Maybe there should be a note added to the docs about using `useCallback`/`useMemo` together with these functions in order to better control their update behavior.