### PR TITLE
feat: add support for mapOptions to pass props

### DIFF
--- a/packages/maps/src/components/result/ReactiveGoogleMap.js
+++ b/packages/maps/src/components/result/ReactiveGoogleMap.js
@@ -125,6 +125,7 @@ class ReactiveGoogleMap extends Component {
 					options={{
 						styles: this.state.currentMapStyle.value,
 						...getInnerKey(this.props.mapProps, 'options'),
+						...this.props.mapOptions,
 					}}
 				>
 					{this.props.showMarkers && this.props.showMarkerClusters ? (
@@ -191,6 +192,7 @@ ReactiveGoogleMap.propTypes = {
 	innerRef: types.func,
 	loader: types.title,
 	mapProps: types.props,
+	mapOptions: types.props,
 	markerProps: types.props,
 	markers: types.children,
 	renderAllData: types.func,


### PR DESCRIPTION
App option in GoogleMap to apss props directly to the Google MapComponent. Like for eg if we want to set `minZoom` currently we don't have an option to do that.