### PR TITLE
Add customQuery prop to DatePickerProps typescript definition

### DIFF
--- a/packages/web/src/components/date/DatePicker.d.ts
+++ b/packages/web/src/components/date/DatePicker.d.ts
@@ -23,6 +23,7 @@ export interface DatePickerProps extends CommonProps {
 	title?: string;
 	onChange?: (...args: any[]) => any;
 	parseDate?: (...args: any[]) => any;
+	customQuery?: (...args: any[]) => any;
 }
 
 declare const DatePicker: React.ComponentClass<DatePickerProps>;


### PR DESCRIPTION
Add missing customQuery prop to DatePickerProps in the DatePicker typescript definition file.