### PR TITLE
feat(DropDown): add data param to render item

### DIFF
--- a/packages/vue/src/components/shared/DropDown.jsx
+++ b/packages/vue/src/components/shared/DropDown.jsx
@@ -168,6 +168,7 @@ const Dropdown = {
 															count: item.doc_count,
 															isChecked:
 																selected && this.$props.multi,
+															data: itemsToRender,
 														})
 													) : (
 														<div>

--- a/packages/vue/src/components/shared/DropDown.jsx
+++ b/packages/vue/src/components/shared/DropDown.jsx
@@ -168,7 +168,7 @@ const Dropdown = {
 															count: item.doc_count,
 															isChecked:
 																selected && this.$props.multi,
-															data: itemsToRender,
+															data: item,
 														})
 													) : (
 														<div>

--- a/packages/web/src/components/shared/Dropdown.js
+++ b/packages/web/src/components/shared/Dropdown.js
@@ -217,6 +217,7 @@ class Dropdown extends Component {
 															item[labelField],
 															item.doc_count,
 															selected && this.props.multi,
+															itemsToRender,
 														)
 													) : (
 														<div>

--- a/packages/web/src/components/shared/Dropdown.js
+++ b/packages/web/src/components/shared/Dropdown.js
@@ -217,7 +217,7 @@ class Dropdown extends Component {
 															item[labelField],
 															item.doc_count,
 															selected && this.props.multi,
-															itemsToRender,
+															item,
 														)
 													) : (
 														<div>


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #1170 
- [x] enhancement
- [ ] Includes tests
- [x] Documentation update: appbaseio/Docs#64 .

#### Overview of change:
pass current `item` to `renderItem` prop in `DropDown`
