### PR TITLE
feat(web): support for dom node in  ReactiveList's scrollTarget prop

### DIFF
--- a/packages/web/src/components/result/ReactiveList.d.ts
+++ b/packages/web/src/components/result/ReactiveList.d.ts
@@ -35,7 +35,7 @@ declare namespace ReactiveListTree {
 		onPageClick?: (...args: any[]) => any;
 		defaultPage?: number;
 		listClass?: string;
-		scrollTarget?: string;
+		scrollTarget?: string | Element | HTMLDocument;
 		onData?: (...args: any[]) => any;
 		renderNoResults?: types.title;
 		scrollOnChange?: boolean;

--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -150,8 +150,10 @@ class ReactiveList extends Component {
 		this.domNode = window;
 		if (this.showInfiniteScroll) {
 			const { scrollTarget } = this.props;
-			if (scrollTarget) {
+			if (typeof scrollTarget === 'string' || scrollTarget instanceof String) {
 				this.domNode = document.getElementById(scrollTarget);
+			} else if (scrollTarget instanceof Element || scrollTarget instanceof HTMLDocument) {
+				this.domNode = scrollTarget;
 			}
 			this.domNode.addEventListener('scroll', this.scrollHandler);
 		}


### PR DESCRIPTION
- [x] This will allow ReactiveList's scrollTarget prop to accept a dom node. The purposed change will implement #1063 .
- [x] Please make sure that there is no linting errors in the code.
- [x] Documentation PR: appbaseio/reactive-manual#190 and appbaseio/Docs#63
- [ ] Create a PR to add/update the storybook (if needed) at [here](https://github.com/appbaseio/playground).