### PR TITLE
fix(web): fix SSR for Dropdowns

### DIFF
--- a/packages/web/src/components/list/MultiDropdownList.js
+++ b/packages/web/src/components/list/MultiDropdownList.js
@@ -51,10 +51,13 @@ class MultiDropdownList extends Component {
 		currentValueArray.forEach((item) => {
 			currentValue[item] = true;
 		});
+		const dataField = props.dataField;
 
 		this.state = {
 			currentValue,
-			options: [],
+			options: props.options && props.options[dataField]
+				? props.options[dataField].buckets
+				: [],
 			after: {}, // for composite aggs
 			isLastBucket: false,
 		};

--- a/packages/web/src/components/list/SingleDropdownList.js
+++ b/packages/web/src/components/list/SingleDropdownList.js
@@ -44,10 +44,13 @@ class SingleDropdownList extends Component {
 
 		const defaultValue = props.defaultValue || props.value;
 		const currentValue = props.selectedValue || defaultValue;
+		const dataField = props.dataField;
 
 		this.state = {
 			currentValue: currentValue || '',
-			options: [],
+			options: props.options && props.options[dataField]
+				? props.options[dataField].buckets
+				: [],
 			after: {}, // for composite aggs
 			isLastBucket: false,
 		};


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

- [x] Describe the proposed changes and how it'll improve the library experience.
- [x] Please make sure that there is no linting errors in the code.
- [ ] Create a PR to add/update the docs (if needed) at [here](https://github.com/appbaseio/Docs). Not needed since this is a bug fix
- [ ] Create a PR to add/update the storybook (if needed) at [here](https://github.com/appbaseio/playground). Not needed as storybook doesn't use SSR AFAICT

When using SSR together with the `*DropdownList` components, the initial server-side render did not render the dropdown as the options were only ever set if the props changed. This PR changes it so that the options will be used on the first render, if they are available.

When the components get mounted on the client side it still makes all of the requests which I don't know whether to consider a feature since the server-side-rendered content could be cached and stale.