### PR TITLE
fix(web): handle edge cases for pagination

### DIFF
--- a/packages/web/src/components/result/addons/Pagination.js
+++ b/packages/web/src/components/result/addons/Pagination.js
@@ -33,7 +33,7 @@ const buildPaginationDOM = (props, position) => {
 					? start + (Math.ceil(pages / 2) - (pages % 2))
 					: totalPages + 1;
 		}
-		if (currentPage > (totalPages - pages) + 2) {
+		if (showEndPage && currentPage > (totalPages - pages) + 2) {
 			start = (totalPages - pages) + 2;
 		}
 		if (totalPages <= pages) start = 2;
@@ -68,6 +68,18 @@ const buildPaginationDOM = (props, position) => {
 };
 
 class Pagination extends React.PureComponent {
+	buildIntermediatePaginationDOM() {
+		const {
+			showEndPage, currentPage, totalPages, pages,
+		} = this.props;
+		// build pagination dom every time when there is no showEndPage
+		if (!showEndPage) return buildPaginationDOM(this.props, 'start');
+		// last two pages are computed dynamically if showEndPage
+		if (currentPage <= (totalPages - pages) + 2 || totalPages <= pages) {
+			return buildPaginationDOM(this.props, 'start');
+		}
+		return null;
+	}
 	render() {
 		const {
 			pages,
@@ -150,7 +162,7 @@ class Pagination extends React.PureComponent {
 				{showEndPage && currentPage >= Math.floor(pages / 2) + !!(pages % 2) ? (
 					<span>...</span>
 				) : null}
-				{(currentPage <= (totalPages - pages) + 2 || totalPages <= pages) && buildPaginationDOM(this.props, 'start')}
+				{this.buildIntermediatePaginationDOM()}
 				{showEndPage && pages > 2 && currentPage <= totalPages - Math.ceil(pages * 0.75) ? (
 					<span>...</span>
 				) : null}


### PR DESCRIPTION
This PR attempts to fix bugs of #1218 

**What it covers:**
- When `showEndPage={false}`, the last 2 pages do not display the pagination buttons properly
- on clicking `Next` button the last pages do not render

**What it does not cover (this is more of a feature):**

![](https://i.imgur.com/FIfjNHL.png)

when `showEndPage={true}`, does not render as per point `6`

**Testing to do:**
- [ ] `showEndPage={true}` and `totalPages <= pageSize`
- [ ] `showEndPage={false}` and `totalPages <= pageSize`
- [ ] `showEndPage={true}` and `totalPages > pageSize`
- [ ] `showEndPage={false}` and `totalPages > pageSize`
- [ ] `showEndPage={true}` and clicking on first, second, last and second_last page
- [ ] `showEndPage={false}` and clicking on first, second, last and second_last page
- [ ] `showEndPage={true}` and clicking on next, prev
- [ ] `showEndPage={false}` and clicking on next, prev
- [ ] test with combination of filter and search component