### PR TITLE
feat(web): showClearAll as enum in SelectedFilters.js

### DIFF
--- a/packages/web/src/components/basic/SelectedFilters.d.ts
+++ b/packages/web/src/components/basic/SelectedFilters.d.ts
@@ -10,7 +10,7 @@ export interface SelectedFiltersProps {
 	className?: string;
 	clearAllLabel?: types.title;
 	innerClass?: types.style;
-	showClearAll?: boolean;
+	showClearAll?: types.showClearAll;
 	style?: types.style;
 	theme?: types.style;
 	title?: types.title;

--- a/packages/web/src/components/basic/SelectedFilters.js
+++ b/packages/web/src/components/basic/SelectedFilters.js
@@ -11,6 +11,19 @@ import Title from '../../styles/Title';
 import { connect } from '../../utils';
 
 class SelectedFilters extends Component {
+	constructor(props) {
+		super(props);
+		this.extracted(props);
+	}
+
+	extracted(props) {
+		if (props.showClearAll === true) {
+			this._showClearAll = 'always';
+		} else {
+			this._showClearAll = props.showClearAll === false ? 'never' : props.showClearAll;
+		}
+	}
+
 	componentDidUpdate = () => {
 		if (this.props.onChange) {
 			this.props.onChange(this.props.selectedValues);
@@ -107,7 +120,12 @@ class SelectedFilters extends Component {
 
 		const { theme } = this.props;
 		const filtersToRender = this.renderFilters();
-		const hasFilters = this.hasFilters();
+		let hasFilters;
+		if (this._showClearAll === 'always') {
+			hasFilters = this.hasFilters();
+		} else {
+			hasFilters = this._showClearAll === 'default' ? !!filtersToRender.length : false;
+		}
 
 		return (
 			<Container
@@ -144,7 +162,7 @@ SelectedFilters.propTypes = {
 	className: types.string,
 	clearAllLabel: types.title,
 	innerClass: types.style,
-	showClearAll: types.bool,
+	showClearAll: types.showClearAll,
 	style: types.style,
 	theme: types.style,
 	onClear: types.func,

--- a/packages/web/src/components/basic/SelectedFilters.js
+++ b/packages/web/src/components/basic/SelectedFilters.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { withTheme } from 'emotion-theming';
 
 import { setValue, clearValues } from '@appbaseio/reactivecore/lib/actions';
-import { componentTypes } from '@appbaseio/reactivecore/lib/utils/constants';
+import { componentTypes, CLEAR_ALL } from '@appbaseio/reactivecore/lib/utils/constants';
 import types from '@appbaseio/reactivecore/lib/utils/types';
 import { getClassName, handleA11yAction } from '@appbaseio/reactivecore/lib/utils/helper';
 import Button, { filters } from '../../styles/Button';
@@ -18,9 +18,10 @@ class SelectedFilters extends Component {
 
 	extracted(props) {
 		if (props.showClearAll === true) {
-			this._showClearAll = 'always';
+			this._showClearAll = CLEAR_ALL.ALWAYS;
 		} else {
-			this._showClearAll = props.showClearAll === false ? 'never' : props.showClearAll;
+			this._showClearAll
+				= props.showClearAll === false ? CLEAR_ALL.NEVER : props.showClearAll;
 		}
 	}
 
@@ -121,10 +122,11 @@ class SelectedFilters extends Component {
 		const { theme } = this.props;
 		const filtersToRender = this.renderFilters();
 		let hasFilters;
-		if (this._showClearAll === 'always') {
+		if (this._showClearAll === CLEAR_ALL.ALWAYS) {
 			hasFilters = this.hasFilters();
 		} else {
-			hasFilters = this._showClearAll === 'default' ? !!filtersToRender.length : false;
+			hasFilters
+				= this._showClearAll === CLEAR_ALL.DEFAULT ? !!filtersToRender.length : false;
 		}
 
 		return (

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -143,3 +143,5 @@ export interface analyticsConfig {
 	userId: string;
 	customEvents: object;
 }
+
+export type showClearAll = 'never' | 'always' | 'default' | true | false;


### PR DESCRIPTION
dependent on: https://github.com/appbaseio/reactivecore/pull/54

new behaviour:
1. when `showClearAll=always`: show filters even when `showFilter={false}` for a particular component. Based on whether value is `selected` or not.
2. when `showClearAll=default`: show filters only when `showFilter={true}` for a particular component
3. when `showClearAll=never`: never show clear all button
3. when `showClearAll=true`: identical to `showClearAll=always` (for backward compatiblity)
4. when `showClearAll=false`: identical to `showClearAll=never` (for backward compatiblity)