### PR TITLE
fix(web): daterange for different time-zones

### DIFF
--- a/packages/web/src/components/date/DateRange.js
+++ b/packages/web/src/components/date/DateRange.js
@@ -40,14 +40,14 @@ class DateRange extends Component {
 		if (props.selectedValue) {
 			if (Array.isArray(props.selectedValue)) {
 				currentDate = {
-					start: new Date(props.selectedValue[0]),
-					end: new Date(props.selectedValue[1]),
+					start: new XDate(props.selectedValue[0])[0],
+					end: new XDate(props.selectedValue[1])[0],
 				};
 			} else {
 				const { start, end } = props.selectedValue;
 				currentDate = {
-					start: new Date(start),
-					end: new Date(end),
+					start: new XDate(start)[0],
+					end: new XDate(end)[0],
 				};
 			}
 		}


### PR DESCRIPTION
fixes #1297 

How to test: open terminal and paste following commands to open browser with different time-zone
```
mkdir ~/chrome-profile
TZ='US/Pacific' open -na "Google Chrome" --args "--user-data-dir=$HOME/chrome-profile"
```

The URL with `URLParams` should render the same date in both your `local` and different `timezoned` browser