### PR TITLE
fix(web): condition for rendering result stats

### DIFF
--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -554,9 +554,12 @@ class ReactiveList extends Component {
 	};
 
 	renderResultStats = () => {
-		if (this.props.renderResultStats && this.props.total) {
+		const { hits, promotedResults, total } = this.props;
+
+		const shouldStatsVisible = hits && promotedResults && (hits.length || promotedResults.length);
+		if (this.props.renderResultStats && shouldStatsVisible) {
 			return this.props.renderResultStats(this.stats);
-		} else if (this.props.total) {
+		} else if (total) {
 			return (
 				<p
 					className={`${resultStats} ${getClassName(


### PR DESCRIPTION
- Fix  invoking `renderResultStats` when no hits are present but promoted results are available