### PR TITLE
fix: customQuery for category and data search.

### DIFF
--- a/packages/web/src/components/search/CategorySearch.js
+++ b/packages/web/src/components/search/CategorySearch.js
@@ -473,6 +473,9 @@ class CategorySearch extends Component {
 			this.updateDefaultQuery(value, this.props);
 		} else {
 			this.updateQuery(value, this.props);
+			if (this.props.customQuery) {
+				this.props.customQuery(value, this.props);
+			}
 		}
 	}, this.props.debounce);
 

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -396,6 +396,9 @@ class DataSearch extends Component {
 			this.updateDefaultQuery(value, this.props);
 		} else {
 			this.updateQuery(value, this.props);
+			if (this.props.customQuery) {
+				this.props.customQuery(value, this.props);
+			}
 		}
 	}, this.props.debounce);
 


### PR DESCRIPTION
## Issue

`customQuery` prop on `DataSearch` and `CategorySearch` was always returning null value and did not apply query DSL passed in `customQuery`

https://codesandbox.io/s/muddy-lake-bjkdu