### PR TITLE
fix(web): DynamicRangeSlider Fix for Start Value of Zero

### DIFF
--- a/packages/web/src/components/range/DynamicRangeSlider.js
+++ b/packages/web/src/components/range/DynamicRangeSlider.js
@@ -64,9 +64,9 @@ class DynamicRangeSlider extends Component {
 			this.props.updateComponentProps(this.props.componentId, this.props);
 		});
 		if (
-			!isEqual(this.props.range, prevProps.range)
-			&& this.props.range
-			&& this.props.range.start
+			!isEqual(this.props.range, prevProps.range) &&
+			this.props.range &&
+			this.props.range.start >= 0
 		) {
 			// when range prop is changed
 			// it will happen due to initial mount (or) due to subscription
@@ -93,8 +93,8 @@ class DynamicRangeSlider extends Component {
 				]);
 			}
 		} else if (
-			this.props.range
-			&& !isEqual(
+			this.props.range &&
+			!isEqual(
 				this.props.value && this.props.value(this.props.range.start, this.props.range.end),
 				prevProps.value && prevProps.value(this.props.range.start, this.props.range.end),
 			)
@@ -103,9 +103,9 @@ class DynamicRangeSlider extends Component {
 			const { start, end } = this.props.value(this.props.range.start, this.props.range.end);
 			this.handleChange([start, end]);
 		} else if (
-			this.props.range
-			&& this.props.selectedValue === null
-			&& prevProps.selectedValue
+			this.props.range &&
+			this.props.selectedValue === null &&
+			prevProps.selectedValue
 		) {
 			// when the filter is reset
 			this.handleChange([this.props.range.start, this.props.range.end]);
@@ -158,7 +158,7 @@ class DynamicRangeSlider extends Component {
 		this.props.removeComponent(this.internalMatchAllComponent);
 	}
 
-	setReact = (props) => {
+	setReact = props => {
 		const { react } = props;
 		if (react) {
 			props.watchComponent(this.internalRangeComponent, props.react);
@@ -183,7 +183,7 @@ class DynamicRangeSlider extends Component {
 	};
 
 	// value parser for SSR
-	static parseValue = (value) => {
+	static parseValue = value => {
 		if (Array.isArray(value)) return value;
 		return value ? [value().start, value().end] : null;
 	};
@@ -300,7 +300,7 @@ class DynamicRangeSlider extends Component {
 		}
 	};
 
-	handleDrag = (values) => {
+	handleDrag = values => {
 		if (this.props.onDrag) {
 			const { min, max, values: currentValue } = values;
 			this.props.onDrag(currentValue, [min, max]);
@@ -359,13 +359,13 @@ class DynamicRangeSlider extends Component {
 		}
 	};
 
-	updateRange = (range) => {
+	updateRange = range => {
 		this.setState({
 			range,
 		});
 	};
 
-	updateRangeQueryOptions = (props) => {
+	updateRangeQueryOptions = props => {
 		let queryOptions = {};
 		const { nestedField } = props;
 		if (nestedField) {
@@ -532,32 +532,32 @@ DynamicRangeSlider.defaultProps = {
 };
 
 const mapStateToProps = (state, props) => {
-	let options
-		= state.aggregations[props.componentId]
-		&& state.aggregations[props.componentId][props.dataField];
+	let options =
+		state.aggregations[props.componentId] &&
+		state.aggregations[props.componentId][props.dataField];
 	let range = state.aggregations[`${props.componentId}__range__internal`];
 	if (props.nestedField) {
-		options
-			= options
-			&& state.aggregations[props.componentId][props.dataField][props.nestedField]
-			&& state.aggregations[props.componentId][props.dataField][props.nestedField].buckets
+		options =
+			options &&
+			state.aggregations[props.componentId][props.dataField][props.nestedField] &&
+			state.aggregations[props.componentId][props.dataField][props.nestedField].buckets
 				? state.aggregations[props.componentId][props.dataField][props.nestedField].buckets
 				: [];
-		range
-			= range
-			&& state.aggregations[`${props.componentId}__range__internal`][props.nestedField].min
+		range =
+			range &&
+			state.aggregations[`${props.componentId}__range__internal`][props.nestedField].min
 				? {
 					start: state.aggregations[`${props.componentId}__range__internal`][props.nestedField].min.value,
 					end: state.aggregations[`${props.componentId}__range__internal`][props.nestedField].max.value,
 				} // prettier-ignore
 				: null;
 	} else {
-		options
-			= options && state.aggregations[props.componentId][props.dataField].buckets
+		options =
+			options && state.aggregations[props.componentId][props.dataField].buckets
 				? state.aggregations[props.componentId][props.dataField].buckets
 				: [];
-		range
-			= range && state.aggregations[`${props.componentId}__range__internal`].min
+		range =
+			range && state.aggregations[`${props.componentId}__range__internal`].min
 				? {
 					start: state.aggregations[`${props.componentId}__range__internal`].min.value,
 					end: state.aggregations[`${props.componentId}__range__internal`].max.value,

--- a/packages/web/src/components/range/DynamicRangeSlider.js
+++ b/packages/web/src/components/range/DynamicRangeSlider.js
@@ -64,9 +64,9 @@ class DynamicRangeSlider extends Component {
 			this.props.updateComponentProps(this.props.componentId, this.props);
 		});
 		if (
-			!isEqual(this.props.range, prevProps.range) &&
-			this.props.range &&
-			this.props.range.start >= 0
+			!isEqual(this.props.range, prevProps.range)
+			&& this.props.range
+			&& this.props.range.start >= 0
 		) {
 			// when range prop is changed
 			// it will happen due to initial mount (or) due to subscription
@@ -93,8 +93,8 @@ class DynamicRangeSlider extends Component {
 				]);
 			}
 		} else if (
-			this.props.range &&
-			!isEqual(
+			this.props.range
+			&& !isEqual(
 				this.props.value && this.props.value(this.props.range.start, this.props.range.end),
 				prevProps.value && prevProps.value(this.props.range.start, this.props.range.end),
 			)
@@ -103,9 +103,9 @@ class DynamicRangeSlider extends Component {
 			const { start, end } = this.props.value(this.props.range.start, this.props.range.end);
 			this.handleChange([start, end]);
 		} else if (
-			this.props.range &&
-			this.props.selectedValue === null &&
-			prevProps.selectedValue
+			this.props.range
+			&& this.props.selectedValue === null
+			&& prevProps.selectedValue
 		) {
 			// when the filter is reset
 			this.handleChange([this.props.range.start, this.props.range.end]);
@@ -158,7 +158,7 @@ class DynamicRangeSlider extends Component {
 		this.props.removeComponent(this.internalMatchAllComponent);
 	}
 
-	setReact = props => {
+	setReact = (props) => {
 		const { react } = props;
 		if (react) {
 			props.watchComponent(this.internalRangeComponent, props.react);
@@ -183,7 +183,7 @@ class DynamicRangeSlider extends Component {
 	};
 
 	// value parser for SSR
-	static parseValue = value => {
+	static parseValue = (value) => {
 		if (Array.isArray(value)) return value;
 		return value ? [value().start, value().end] : null;
 	};
@@ -300,7 +300,7 @@ class DynamicRangeSlider extends Component {
 		}
 	};
 
-	handleDrag = values => {
+	handleDrag = (values) => {
 		if (this.props.onDrag) {
 			const { min, max, values: currentValue } = values;
 			this.props.onDrag(currentValue, [min, max]);
@@ -359,13 +359,13 @@ class DynamicRangeSlider extends Component {
 		}
 	};
 
-	updateRange = range => {
+	updateRange = (range) => {
 		this.setState({
 			range,
 		});
 	};
 
-	updateRangeQueryOptions = props => {
+	updateRangeQueryOptions = (props) => {
 		let queryOptions = {};
 		const { nestedField } = props;
 		if (nestedField) {
@@ -532,32 +532,32 @@ DynamicRangeSlider.defaultProps = {
 };
 
 const mapStateToProps = (state, props) => {
-	let options =
-		state.aggregations[props.componentId] &&
-		state.aggregations[props.componentId][props.dataField];
+	let options
+		= state.aggregations[props.componentId]
+		&& state.aggregations[props.componentId][props.dataField];
 	let range = state.aggregations[`${props.componentId}__range__internal`];
 	if (props.nestedField) {
-		options =
-			options &&
-			state.aggregations[props.componentId][props.dataField][props.nestedField] &&
-			state.aggregations[props.componentId][props.dataField][props.nestedField].buckets
+		options
+			= options
+			&& state.aggregations[props.componentId][props.dataField][props.nestedField]
+			&& state.aggregations[props.componentId][props.dataField][props.nestedField].buckets
 				? state.aggregations[props.componentId][props.dataField][props.nestedField].buckets
 				: [];
-		range =
-			range &&
-			state.aggregations[`${props.componentId}__range__internal`][props.nestedField].min
+		range
+			= range
+			&& state.aggregations[`${props.componentId}__range__internal`][props.nestedField].min
 				? {
 					start: state.aggregations[`${props.componentId}__range__internal`][props.nestedField].min.value,
 					end: state.aggregations[`${props.componentId}__range__internal`][props.nestedField].max.value,
 				} // prettier-ignore
 				: null;
 	} else {
-		options =
-			options && state.aggregations[props.componentId][props.dataField].buckets
+		options
+			= options && state.aggregations[props.componentId][props.dataField].buckets
 				? state.aggregations[props.componentId][props.dataField].buckets
 				: [];
-		range =
-			range && state.aggregations[`${props.componentId}__range__internal`].min
+		range
+			= range && state.aggregations[`${props.componentId}__range__internal`].min
 				? {
 					start: state.aggregations[`${props.componentId}__range__internal`].min.value,
 					end: state.aggregations[`${props.componentId}__range__internal`].max.value,

--- a/packages/web/src/components/range/DynamicRangeSlider.js
+++ b/packages/web/src/components/range/DynamicRangeSlider.js
@@ -67,6 +67,7 @@ class DynamicRangeSlider extends Component {
 			!isEqual(this.props.range, prevProps.range)
 			&& this.props.range
 			&& this.props.range.start >= 0
+			&& this.props.range.end > 0
 		) {
 			// when range prop is changed
 			// it will happen due to initial mount (or) due to subscription


### PR DESCRIPTION
[Relevant Issue](https://github.com/appbaseio/reactivesearch/issues/1205)

# Description
Adds a numerical check for `range.start`, previously having a zero value for `range.start` resulted in the component not being rendered as values never propagated into the component state due to this check erroneously being false.