### PR TITLE
feat(reactivemap): better support for OpenStreetMap (zoom, refresh...)

### DIFF
--- a/packages/maps/src/components/result/ReactiveGoogleMap.js
+++ b/packages/maps/src/components/result/ReactiveGoogleMap.js
@@ -219,6 +219,7 @@ ReactiveGoogleMap.propTypes = {
 	renderMap: types.func,
 	updaterKey: types.number,
 	mapRef: types.any, // eslint-disable-line
+	mapService: types.string,
 };
 
 ReactiveGoogleMap.defaultProps = {
@@ -242,6 +243,7 @@ ReactiveGoogleMap.defaultProps = {
 	showMarkerClusters: true,
 	unit: 'mi',
 	defaultRadius: 100,
+	mapService: 'GoogleMap',
 };
 
 export default ReactiveGoogleMap;

--- a/packages/maps/src/components/result/ReactiveOpenStreetMap.js
+++ b/packages/maps/src/components/result/ReactiveOpenStreetMap.js
@@ -17,6 +17,14 @@ let DivIcon;
 class ReactiveOpenStreetMap extends Component {
 	static contextType = ReactReduxContext;
 
+	constructor(props) {
+		super(props);
+
+		this.state = {
+			mapRef: null,
+		};
+	}
+
 	componentDidMount() {
 		/* eslint-disable */
 		OpenStreetMap = require('react-leaflet').Map;
@@ -183,6 +191,7 @@ class ReactiveOpenStreetMap extends Component {
 				style={style}
 				zoom={params.zoom}
 				center={[params.center.lat, params.center.lng]}
+				viewport={{}}
 				css={{
 					'.leaflet-div-icon': {
 						width: 'auto !important',
@@ -193,9 +202,15 @@ class ReactiveOpenStreetMap extends Component {
 					},
 				}}
 				touchZoom
-				onDragend={obj => {
-					params.handleOpenStreetOnDragEnd(obj.target.getBounds());
+				ref={(elem) => {
+					if (!this.state.mapRef) {
+						this.setState({
+							mapRef: elem.leafletElement,
+						});
+					}
 				}}
+				onZoomEnd={params.handleZoomChange}
+				onDragend={params.handleOnDragEnd}
 			>
 				<OpenStreetLayer
 					url={this.props.tileServer || 'https://{s}.tile.osm.org/{z}/{x}/{y}.png'}
@@ -208,7 +223,7 @@ class ReactiveOpenStreetMap extends Component {
 	};
 
 	render() {
-		return <ReactiveMap {...this.props} renderMap={this.renderMap} />;
+		return <ReactiveMap {...this.props} renderMap={this.renderMap} mapRef={this.state.mapRef} />;
 	}
 }
 
@@ -244,6 +259,7 @@ ReactiveOpenStreetMap.propTypes = {
 	config: types.props,
 	analytics: types.props,
 	headers: types.headers,
+	mapService: types.string,
 };
 
 ReactiveOpenStreetMap.defaultProps = {
@@ -265,6 +281,7 @@ ReactiveOpenStreetMap.defaultProps = {
 	showMarkerClusters: true,
 	unit: 'mi',
 	defaultRadius: 100,
+	mapService: 'OpenStreetMap'
 };
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
In fact we can get a kind of "Google" mapRef with react-leaflet. So I followed the same way as ReactiveGoogleMap with a mapRef state.
```
ref={(elem) => {
	if (!this.state.mapRef) {
		this.setState({
			mapRef: elem.leafletElement,
		});
	}
}}
```

I added a mapService string prop to both Reactive(Google|OpenStreet)Map tools. They get a default value 'GoogleMap' or 'OpenStreetMap' during loading. We need this to have specific treatment in ReactiveMap component. Maybe we could get this information directly from mapRef.

I changed mapRef existence test `!!this.props.mapRef` (not lint compliant)  to function existence test in this mapRef "object". Bye the way, `!!this.props.mapRef` gave me unexplained behaviour with OpenStreetMap whereas function test works really well. 

I added onZoomEnd event to handle zoom change for OpenStreetMap (main reason I did all this).

I added `viewport={{}}` due to this https://react-leaflet.js.org/docs/en/components "Manipulating viewport" chapter. Without it, sometimes, changing center and zoom was not handle. 
