### PR TITLE
feat(reactivemap): allow GeoDistance tools without Google Map

### DIFF
--- a/packages/maps/src/components/basic/GeoCode.js
+++ b/packages/maps/src/components/basic/GeoCode.js
@@ -8,37 +8,45 @@ class GeoCode extends Component {
 				lng: location.coords.longitude,
 			};
 
-			this.geocoder.geocode({ location: coordinatesObj }, (results, status) => {
-				if (status === 'OK') {
-					if (Array.isArray(results) && results.length) {
-						const userLocation = results[0].formatted_address;
-						this.setState({
-							// eslint-disable-next-line react/no-unused-state
-							userLocation,
-						});
+			if (this.geocoder) {
+				this.geocoder.geocode({ location: coordinatesObj }, (results, status) => {
+					if (status === 'OK') {
+						if (Array.isArray(results) && results.length) {
+							const userLocation = results[0].formatted_address;
+							this.setState({
+								// eslint-disable-next-line react/no-unused-state
+								userLocation,
+							});
+						}
+					} else {
+						console.error(`Geocode was not successful for the following reason: ${status}`);
 					}
-				} else {
-					console.error(`Geocode was not successful for the following reason: ${status}`);
-				}
-			});
+				});
+			} else {
+				console.error('No Geocoder found or defined');
+			}
 		});
 	}
 
 	getCoordinates(value, cb) {
 		if (value) {
-			this.geocoder.geocode({ address: value }, (results, status) => {
-				if (status === 'OK') {
-					if (Array.isArray(results) && results.length) {
+			if (this.geocoder) {
+				this.geocoder.geocode({ address: value }, (results, status) => {
+					if (status === 'OK') {
 						if (Array.isArray(results) && results.length) {
-							const { location } = results[0].geometry;
-							this.coordinates = `${location.lat()}, ${location.lng()}`;
-							if (cb) cb();
+							if (Array.isArray(results) && results.length) {
+								const { location } = results[0].geometry;
+								this.coordinates = `${location.lat()}, ${location.lng()}`;
+								if (cb) cb();
+							}
 						}
+					} else {
+						console.error(`Geocode was not successful for the following reason: ${status}`);
 					}
-				} else {
-					console.error(`Geocode was not successful for the following reason: ${status}`);
-				}
-			});
+				});
+			} else {
+				console.error('No Geocoder found or defined');
+			}
 		}
 	}
 }

--- a/packages/maps/src/components/basic/GeoDistanceDropdown.js
+++ b/packages/maps/src/components/basic/GeoDistanceDropdown.js
@@ -43,7 +43,7 @@ class GeoDistanceDropdown extends GeoCode {
 
 		if (props.geocoder) {
 			this.geocoder = props.geocoder;
-		} else {
+		} else if (typeof window.google === 'object' && typeof window.google.maps === 'object') {
 			this.geocoder = new window.google.maps.Geocoder();
 		}
 
@@ -87,7 +87,9 @@ class GeoDistanceDropdown extends GeoCode {
 	}
 
 	componentDidMount() {
-		this.autocompleteService = new window.google.maps.places.AutocompleteService();
+		if (typeof window.google === 'object' && typeof window.google.maps === 'object') {
+			this.autocompleteService = new window.google.maps.places.AutocompleteService();
+		}
 	}
 
 	componentDidUpdate(prevProps) {
@@ -293,7 +295,7 @@ class GeoDistanceDropdown extends GeoCode {
 				label: this.props.value.label,
 			});
 		}
-		if (value.trim()) {
+		if (value.trim() && typeof window.google === 'object' && typeof window.google.maps === 'object') {
 			if (!this.autocompleteService) {
 				this.autocompleteService = new window.google.maps.places.AutocompleteService();
 			}

--- a/packages/maps/src/components/basic/GeoDistanceDropdown.js
+++ b/packages/maps/src/components/basic/GeoDistanceDropdown.js
@@ -40,7 +40,12 @@ class GeoDistanceDropdown extends GeoCode {
 		this.type = 'geo_distance';
 		this.coordinates = null;
 		this.autocompleteService = null;
-		this.geocoder = new window.google.maps.Geocoder();
+
+		if (props.geocoder) {
+			this.geocoder = props.geocoder;
+		} else {
+			this.geocoder = new window.google.maps.Geocoder();
+		}
 
 		if (props.autoLocation) {
 			this.getUserLocation();
@@ -516,6 +521,7 @@ GeoDistanceDropdown.propTypes = {
 	unit: types.string,
 	URLParams: types.bool,
 	serviceOptions: types.props,
+	geocoder: types.shape,
 };
 
 GeoDistanceDropdown.defaultProps = {

--- a/packages/maps/src/components/basic/GeoDistanceSlider.js
+++ b/packages/maps/src/components/basic/GeoDistanceSlider.js
@@ -46,7 +46,7 @@ class GeoDistanceSlider extends GeoCode {
 
 		if (props.geocoder) {
 			this.geocoder = props.geocoder;
-		} else {
+		} else if (typeof window.google === 'object' && typeof window.google.maps === 'object') {
 			this.geocoder = new window.google.maps.Geocoder();
 		}
 
@@ -88,7 +88,9 @@ class GeoDistanceSlider extends GeoCode {
 	}
 
 	componentDidMount() {
-		this.autocompleteService = new window.google.maps.places.AutocompleteService();
+		if (typeof window.google === 'object' && typeof window.google.maps === 'object') {
+			this.autocompleteService = new window.google.maps.places.AutocompleteService();
+		}
 	}
 
 	componentDidUpdate(prevProps) {
@@ -274,7 +276,7 @@ class GeoDistanceSlider extends GeoCode {
 		} else if (onChange) {
 			onChange({ location: value, distance: this.state.currentDistance });
 		}
-		if (value.trim()) {
+		if (value.trim() && typeof window.google === 'object' && typeof window.google.maps === 'object') {
 			if (!this.autocompleteService) {
 				this.autocompleteService = new window.google.maps.places.AutocompleteService();
 			}

--- a/packages/maps/src/components/basic/GeoDistanceSlider.js
+++ b/packages/maps/src/components/basic/GeoDistanceSlider.js
@@ -43,7 +43,12 @@ class GeoDistanceSlider extends GeoCode {
 		this.type = 'geo_distance';
 		this.coordinates = null;
 		this.autocompleteService = null;
-		this.geocoder = new window.google.maps.Geocoder();
+
+		if (props.geocoder) {
+			this.geocoder = props.geocoder;
+		} else {
+			this.geocoder = new window.google.maps.Geocoder();
+		}
 
 		if (props.autoLocation) {
 			this.getUserLocation();
@@ -531,6 +536,7 @@ GeoDistanceSlider.propTypes = {
 	unit: types.string,
 	URLParams: types.bool,
 	serviceOptions: types.props,
+	geocoder: types.shape,
 };
 
 GeoDistanceSlider.defaultProps = {


### PR DESCRIPTION
GeoDistance tools doesn't work without GoogleMap. Examples shown on the Internet give the feeling it's alright because google map is already present in the page. But when using OpenStreetMap only, you may want to totally remove the need for Google Map.

Now look if Google Map is loaded before calling its functions. Avoid undefined error.

Add a `geocoder` prop to define your own geocoder. Should be an object with at least a `geocode` function which mimic Google's one. If tou have positioned data in your elastic, you could for instance just use their position string. Example:
```
geocoder={{geocode: function (coordinatesObj, todo) {
       const [tlat,tlng] = coordinatesObj.address.split(',');
             todo([{geometry: {location: {lat: () => tlat, lng: () => tlng}}}],'OK');
       }
}}
``` 