### PR TITLE
fix(vue): datasearch autosuggest select on android firefox

### DIFF
--- a/packages/vue/src/components/basic/DownShift.jsx
+++ b/packages/vue/src/components/basic/DownShift.jsx
@@ -213,16 +213,27 @@ export default {
 			}
 
 			const vm = this;
+			let eventCalled = false;
 
 			return {
 				mouseenter() {
 					vm.setHighlightedIndex(newIndex);
 				},
 
+				// for browsers not supporting click event (e.g. firefox android)
 				mousedown(event) {
+					if (eventCalled) return;
+					eventCalled = true;
 					event.stopPropagation();
 					vm.selectItemAtIndex(newIndex);
 				},
+
+				click(event) {
+					if (eventCalled) return;
+					eventCalled = true;
+					event.stopPropagation();
+					vm.selectItemAtIndex(newIndex);
+				}
 			};
 		},
 

--- a/packages/vue/src/components/basic/DownShift.jsx
+++ b/packages/vue/src/components/basic/DownShift.jsx
@@ -129,11 +129,19 @@ export default {
 			if (this.$props.handleChange) {
 				this.$props.handleChange(item);
 			}
+
+			function getInputValue() {
+				if (this.isControlledProp('selectedItem')) {
+					return '';
+				}
+				return typeof item === 'object' ? item.label || '' : item;
+			}
+
 			this.setState({
 				isOpen: false,
 				highlightedIndex: null,
 				selectedItem: item,
-				inputValue: this.isControlledProp('selectedItem') ? '' : item,
+				inputValue: getInputValue.call(this),
 			});
 		},
 
@@ -211,7 +219,7 @@ export default {
 					vm.setHighlightedIndex(newIndex);
 				},
 
-				click(event) {
+				mousedown(event) {
 					event.stopPropagation();
 					vm.selectItemAtIndex(newIndex);
 				},


### PR DESCRIPTION
fixes #1334 . Tested on `Firefox nightly` on android.