### PR TITLE
feat(web): rawData to provide as-is response from es in render prop

### DIFF
--- a/packages/web/src/components/basic/ReactiveComponent.js
+++ b/packages/web/src/components/basic/ReactiveComponent.js
@@ -216,7 +216,7 @@ class ReactiveComponent extends Component {
 
 	getData() {
 		const {
-			hits, aggregations, aggregationData, promotedResults,
+			hits, aggregations, aggregationData, promotedResults, rawData,
 		} = this.props;
 		let filteredResults = parseHits(hits);
 		if (promotedResults.length) {
@@ -230,7 +230,7 @@ class ReactiveComponent extends Component {
 			data: filteredResults,
 			promotedData: promotedResults,
 			aggregationData: aggregationData || [],
-			rawData: hits,
+			rawData,
 			aggregations,
 			resultStats: this.stats,
 		};
@@ -275,6 +275,7 @@ ReactiveComponent.propTypes = {
 	aggregations: types.selectedValues,
 	aggregationData: types.aggregationData,
 	hits: types.data,
+	rawData: types.rawData,
 	promotedResults: types.hits,
 	isLoading: types.bool,
 	selectedValue: types.selectedValue,
@@ -302,6 +303,7 @@ const mapStateToProps = (state, props) => ({
 		(state.aggregations[props.componentId] && state.aggregations[props.componentId]) || null,
 	aggregationData: state.compositeAggregations[props.componentId] || [],
 	hits: (state.hits[props.componentId] && state.hits[props.componentId].hits) || [],
+	rawData: state.rawData[props.componentId],
 	selectedValue:
 		(state.selectedValues[props.componentId]
 			&& state.selectedValues[props.componentId].value)

--- a/packages/web/src/components/basic/StateProvider.js
+++ b/packages/web/src/components/basic/StateProvider.js
@@ -94,6 +94,7 @@ StateProvider.propTypes = {
 	isLoading: types.componentObject,
 	error: types.componentObject,
 	promotedResults: types.componentObject,
+	rawData: types.rawData,
 };
 
 const mapStateToProps = (state, props) => ({
@@ -106,6 +107,7 @@ const mapStateToProps = (state, props) => ({
 	isLoading: filterByComponentIds(state.isLoading, props),
 	error: filterByComponentIds(state.error, props),
 	promotedResults: filterByComponentIds(state.promotedResults, props),
+	rawData: filterByComponentIds(state.rawData, props),
 });
 
 export default connect(mapStateToProps, null)(StateProvider);

--- a/packages/web/src/components/list/MultiDataList.js
+++ b/packages/web/src/components/list/MultiDataList.js
@@ -394,6 +394,7 @@ class MultiDataList extends Component {
 			value: currentValue,
 			data: this.listItems,
 			handleChange: this.handleClick,
+			rawData: this.props.rawData,
 		};
 		return getComponent(data, this.props);
 	}
@@ -538,6 +539,7 @@ MultiDataList.propTypes = {
 	updateQuery: types.funcRequired,
 	watchComponent: types.funcRequired,
 	selectedValue: types.selectedValue,
+	rawData: types.rawData,
 	options: types.options,
 	setComponentProps: types.funcRequired,
 	updateComponentProps: types.funcRequired,
@@ -588,6 +590,7 @@ MultiDataList.defaultProps = {
 };
 
 const mapStateToProps = (state, props) => ({
+	rawData: state.rawData[props.componentId],
 	selectedValue:
 		(state.selectedValues[props.componentId]
 			&& state.selectedValues[props.componentId].value)

--- a/packages/web/src/components/list/MultiDropdownList.js
+++ b/packages/web/src/components/list/MultiDropdownList.js
@@ -57,9 +57,8 @@ class MultiDropdownList extends Component {
 
 		this.state = {
 			currentValue,
-			options: props.options && props.options[dataField]
-				? props.options[dataField].buckets
-				: [],
+			options:
+				props.options && props.options[dataField] ? props.options[dataField].buckets : [],
 			after: {}, // for composite aggs
 			isLastBucket: false,
 		};
@@ -422,13 +421,14 @@ class MultiDropdownList extends Component {
 	}
 
 	getComponent = (items, downshiftProps) => {
-		const { error, isLoading } = this.props;
+		const { error, isLoading, rawData } = this.props;
 		const { currentValue } = this.state;
 		const data = {
 			error,
 			loading: isLoading,
 			value: currentValue,
 			data: items || [],
+			rawData,
 			handleChange: this.handleChange,
 			downshiftProps,
 		};
@@ -499,7 +499,9 @@ class MultiDropdownList extends Component {
 						showLoadMore
 						&& !isLastBucket && (
 							<div css={loadMoreContainer}>
-								<Button disabled={isLoading} onClick={this.handleLoadMore}>{loadMoreLabel}</Button>
+								<Button disabled={isLoading} onClick={this.handleLoadMore}>
+									{loadMoreLabel}
+								</Button>
 							</div>
 						)
 					}
@@ -517,6 +519,7 @@ MultiDropdownList.propTypes = {
 	updateQuery: types.funcRequired,
 	watchComponent: types.funcRequired,
 	options: types.options,
+	rawData: types.rawData,
 	selectedValue: types.selectedValue,
 	setComponentProps: types.funcRequired,
 	updateComponentProps: types.funcRequired,
@@ -588,6 +591,7 @@ const mapStateToProps = (state, props) => ({
 		props.nestedField && state.aggregations[props.componentId]
 			? state.aggregations[props.componentId].reactivesearch_nested
 			: state.aggregations[props.componentId],
+	rawData: state.rawData[props.componentId],
 	selectedValue:
 		(state.selectedValues[props.componentId]
 			&& state.selectedValues[props.componentId].value)

--- a/packages/web/src/components/list/MultiList.js
+++ b/packages/web/src/components/list/MultiList.js
@@ -482,7 +482,7 @@ class MultiList extends Component {
 	}
 
 	getComponent() {
-		const { error, isLoading } = this.props;
+		const { error, isLoading, rawData } = this.props;
 		const { currentValue } = this.state;
 		const data = {
 			error,
@@ -490,6 +490,7 @@ class MultiList extends Component {
 			value: currentValue,
 			data: this.listItems,
 			handleChange: this.handleClick,
+			rawData,
 		};
 		return getComponent(data, this.props);
 	}
@@ -625,7 +626,9 @@ class MultiList extends Component {
 							: this.props.renderNoResults && this.props.renderNoResults()}
 						{showLoadMore && !isLastBucket && (
 							<div css={loadMoreContainer}>
-								<Button disabled={isLoading} onClick={this.handleLoadMore}>{loadMoreLabel}</Button>
+								<Button disabled={isLoading} onClick={this.handleLoadMore}>
+									{loadMoreLabel}
+								</Button>
 							</div>
 						)}
 					</UL>
@@ -644,6 +647,7 @@ MultiList.propTypes = {
 	updateQuery: types.funcRequired,
 	watchComponent: types.funcRequired,
 	options: types.options,
+	rawData: types.rawData,
 	selectedValue: types.selectedValue,
 	setComponentProps: types.funcRequired,
 	updateComponentProps: types.funcRequired,
@@ -713,6 +717,7 @@ const mapStateToProps = (state, props) => ({
 		props.nestedField && state.aggregations[props.componentId]
 			? state.aggregations[props.componentId].reactivesearch_nested
 			: state.aggregations[props.componentId],
+	rawData: state.rawData[props.componentId],
 	selectedValue:
 		(state.selectedValues[props.componentId]
 			&& state.selectedValues[props.componentId].value)

--- a/packages/web/src/components/list/SingleDataList.js
+++ b/packages/web/src/components/list/SingleDataList.js
@@ -306,6 +306,7 @@ class SingleDataList extends Component {
 			value: currentValue,
 			data: this.listItems,
 			handleChange: this.handleClick,
+			rawData: this.props.rawData,
 		};
 		return getComponent(data, this.props);
 	}
@@ -445,6 +446,7 @@ SingleDataList.propTypes = {
 	watchComponent: types.funcRequired,
 	selectedValue: types.selectedValue,
 	options: types.options,
+	rawData: types.rawData,
 	setComponentProps: types.funcRequired,
 	updateComponentProps: types.funcRequired,
 	// component props
@@ -491,6 +493,7 @@ SingleDataList.defaultProps = {
 };
 
 const mapStateToProps = (state, props) => ({
+	rawData: state.rawData[props.componentId],
 	selectedValue:
 		(state.selectedValues[props.componentId]
 			&& state.selectedValues[props.componentId].value)

--- a/packages/web/src/components/list/SingleDropdownList.js
+++ b/packages/web/src/components/list/SingleDropdownList.js
@@ -50,9 +50,8 @@ class SingleDropdownList extends Component {
 
 		this.state = {
 			currentValue: currentValue || '',
-			options: props.options && props.options[dataField]
-				? props.options[dataField].buckets
-				: [],
+			options:
+				props.options && props.options[dataField] ? props.options[dataField].buckets : [],
 			after: {}, // for composite aggs
 			isLastBucket: false,
 		};
@@ -308,13 +307,14 @@ class SingleDropdownList extends Component {
 	}
 
 	getComponent = (items, downshiftProps) => {
-		const { error, isLoading } = this.props;
+		const { error, isLoading, rawData } = this.props;
 		const { currentValue } = this.state;
 		const data = {
 			error,
 			loading: isLoading,
 			value: currentValue,
 			data: items || [],
+			rawData,
 			handleChange: this.handleChange,
 			downshiftProps,
 		};
@@ -385,7 +385,9 @@ class SingleDropdownList extends Component {
 						showLoadMore
 						&& !isLastBucket && (
 							<div css={loadMoreContainer}>
-								<Button disabled={isLoading} onClick={this.handleLoadMore}>{loadMoreLabel}</Button>
+								<Button disabled={isLoading} onClick={this.handleLoadMore}>
+									{loadMoreLabel}
+								</Button>
 							</div>
 						)
 					}
@@ -403,6 +405,7 @@ SingleDropdownList.propTypes = {
 	updateQuery: types.funcRequired,
 	watchComponent: types.funcRequired,
 	options: types.options,
+	rawData: types.rawData,
 	selectedValue: types.selectedValue,
 	setComponentProps: types.funcRequired,
 	updateComponentProps: types.funcRequired,
@@ -468,6 +471,7 @@ SingleDropdownList.defaultProps = {
 };
 
 const mapStateToProps = (state, props) => ({
+	rawData: state.rawData[props.componentId],
 	options:
 		props.nestedField && state.aggregations[props.componentId]
 			? state.aggregations[props.componentId].reactivesearch_nested

--- a/packages/web/src/components/list/SingleList.js
+++ b/packages/web/src/components/list/SingleList.js
@@ -375,13 +375,14 @@ class SingleList extends Component {
 	}
 
 	getComponent() {
-		const { error, isLoading } = this.props;
+		const { error, isLoading, rawData } = this.props;
 		const { currentValue } = this.state;
 		const data = {
 			error,
 			loading: isLoading,
 			value: currentValue,
 			data: this.listItems,
+			rawData,
 			handleChange: this.handleClick,
 		};
 		return getComponent(data, this.props);
@@ -505,7 +506,9 @@ class SingleList extends Component {
 							: this.props.renderNoResults && this.props.renderNoResults()}
 						{showLoadMore && !isLastBucket && (
 							<div css={loadMoreContainer}>
-								<Button disabled={isLoading} onClick={this.handleLoadMore}>{loadMoreLabel}</Button>
+								<Button disabled={isLoading} onClick={this.handleLoadMore}>
+									{loadMoreLabel}
+								</Button>
 							</div>
 						)}
 					</UL>
@@ -524,6 +527,7 @@ SingleList.propTypes = {
 	updateQuery: types.funcRequired,
 	watchComponent: types.funcRequired,
 	options: types.options,
+	rawData: types.rawData,
 	selectedValue: types.selectedValue,
 	setComponentProps: types.funcRequired,
 	updateComponentProps: types.funcRequired,
@@ -589,6 +593,7 @@ SingleList.defaultProps = {
 };
 
 const mapStateToProps = (state, props) => ({
+	rawData: state.rawData[props.componentId],
 	options:
 		props.nestedField && state.aggregations[props.componentId]
 			? state.aggregations[props.componentId].reactivesearch_nested

--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -557,7 +557,8 @@ class ReactiveList extends Component {
 	renderResultStats = () => {
 		const { hits, promotedResults, total } = this.props;
 
-		const shouldStatsVisible = hits && promotedResults && (hits.length || promotedResults.length);
+		const shouldStatsVisible
+			= hits && promotedResults && (hits.length || promotedResults.length);
 		if (this.props.renderResultStats && shouldStatsVisible) {
 			return this.props.renderResultStats(this.stats);
 		} else if (total) {
@@ -656,7 +657,6 @@ class ReactiveList extends Component {
 	};
 	getData = () => {
 		const {
-			results,
 			streamResults,
 			filteredResults,
 			promotedResults,
@@ -667,7 +667,7 @@ class ReactiveList extends Component {
 			aggregationData: this.withClickIds(aggregationData || []),
 			streamData: this.withClickIds(streamResults),
 			promotedData: this.withClickIds(promotedResults),
-			rawData: this.withClickIds(results),
+			rawData: this.props.rawData,
 			resultStats: this.stats,
 		};
 	};
@@ -781,6 +781,7 @@ ReactiveList.propTypes = {
 	watchComponent: types.funcRequired,
 	currentPage: types.number,
 	hits: types.hits,
+	rawData: types.rawData,
 	isLoading: types.bool,
 	includeFields: types.includeFields,
 	streamHits: types.hits,
@@ -863,6 +864,7 @@ const mapStateToProps = (state, props) => ({
 			&& state.selectedValues[props.componentId].value - 1)
 		|| -1,
 	hits: state.hits[props.componentId] && state.hits[props.componentId].hits,
+	rawData: state.rawData[props.componentId],
 	aggregationData: state.compositeAggregations[props.componentId],
 	isLoading: state.isLoading[props.componentId] || false,
 	streamHits: state.streamHits[props.componentId],

--- a/packages/web/src/components/search/CategorySearch.js
+++ b/packages/web/src/components/search/CategorySearch.js
@@ -822,7 +822,7 @@ class CategorySearch extends Component {
 
 	getComponent = (downshiftProps = {}) => {
 		const {
-			error, isLoading, aggregationData, promotedResults,
+			error, isLoading, aggregationData, promotedResults, rawData,
 		} = this.props;
 		const { currentValue } = this.state;
 		const data = {
@@ -830,6 +830,7 @@ class CategorySearch extends Component {
 			loading: isLoading,
 			downshiftProps,
 			data: this.parsedSuggestions,
+			rawData,
 			promotedData: promotedResults,
 			aggregationData: aggregationData || [],
 			value: currentValue,
@@ -1056,6 +1057,7 @@ CategorySearch.propTypes = {
 	setSuggestionsSearchValue: types.funcRequired,
 	options: types.options,
 	categories: types.data,
+	rawData: types.rawData,
 	promotedResults: types.hits,
 	selectedValue: types.selectedValue,
 	selectedCategory: types.selectedValue,
@@ -1157,6 +1159,7 @@ const mapStateToProps = (state, props) => ({
 			&& state.aggregations[props.componentId][props.categoryField]
 			&& state.aggregations[props.componentId][props.categoryField].buckets)
 		|| [],
+	rawData: state.rawData[props.componentId],
 	selectedValue:
 		(state.selectedValues[props.componentId]
 			&& state.selectedValues[props.componentId].value)

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -722,7 +722,7 @@ class DataSearch extends Component {
 
 	getComponent = (downshiftProps = {}) => {
 		const {
-			error, isLoading, aggregationData, promotedResults,
+			error, isLoading, aggregationData, promotedResults, rawData,
 		} = this.props;
 		const { currentValue } = this.state;
 		const data = {
@@ -732,7 +732,7 @@ class DataSearch extends Component {
 			data: this.parsedSuggestions,
 			promotedData: promotedResults,
 			aggregationData: aggregationData || [],
-			rawData: this.props.suggestions || [],
+			rawData,
 			value: currentValue,
 			triggerClickAnalytics: this.triggerClickAnalytics,
 			resultStats: this.stats,
@@ -903,6 +903,7 @@ DataSearch.propTypes = {
 	options: types.options,
 	selectedValue: types.selectedValue,
 	suggestions: types.suggestions,
+	rawData: types.rawData,
 	aggregationData: types.aggregationData,
 	setComponentProps: types.funcRequired,
 	updateComponentProps: types.funcRequired,
@@ -1002,6 +1003,7 @@ const mapStateToProps = (state, props) => ({
 			&& state.selectedValues[props.componentId].value)
 		|| null,
 	suggestions: state.hits[props.componentId] && state.hits[props.componentId].hits,
+	rawData: state.rawData[props.componentId],
 	aggregationData: state.compositeAggregations[props.componentId],
 	themePreset: state.config.themePreset,
 	isLoading: state.isLoading[props.componentId] || false,


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

- [x] Describe the proposed changes and how it'll improve the library experience.
- [x] Please make sure that there is no linting errors in the code.
- [ ] Create a PR to add/update the docs (if needed) at [here](https://github.com/appbaseio/Docs).
- [ ] Create a PR to add/update the storybook (if needed) at [here](https://github.com/appbaseio/playground).

**Breaking change**
Now `rawData` will expose as-is response from `elasticsearch`

How to test this for `StateProvider`
```javascript
                         <StateProvider
				includeKeys={['rawData']}
				render={props => {
					console.log("state provider props", props)
					return <div>Search State</div>;
				}}
			/>
```

dependent on: https://github.com/appbaseio/reactivecore/pull/71

Docs: https://github.com/appbaseio/Docs/pull/122
