### PR TITLE
Fixed CustomSelectedFilters behaviour upon removing filters

### DIFF
--- a/packages/web/examples/CustomSelectedFilters/src/index.js
+++ b/packages/web/examples/CustomSelectedFilters/src/index.js
@@ -30,7 +30,7 @@ class Main extends Component {
 								};
 
 								const filters = Object.keys(selectedValues).map((component) => {
-									if (!selectedValues[component].value) return null;
+									if (!selectedValues[component].value || !selectedValues[component].value.length>0) return null;
 									return (
 										<button
 											key={component}


### PR DESCRIPTION
Bug : When we remove a filter, there stays an empty button
Fixed behaviour: When we remove a filter, the button gets removed completely