### PR TITLE
feat(web): add support for enableSynonyms in search components

### DIFF
--- a/packages/maps-native/package.json
+++ b/packages/maps-native/package.json
@@ -47,7 +47,7 @@
         "react-native": "~0.59.1"
     },
     "dependencies": {
-        "@appbaseio/reactivecore": "9.3.2",
+        "@appbaseio/reactivecore": "9.4.0",
         "@ptomasroos/react-native-multi-slider": "^0.0.13",
         "appbase-js": "^4.0.2-beta.11",
         "hoist-non-react-statics": "^3.3.0",

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -44,7 +44,7 @@
         "react-native": "~0.60.5"
     },
     "dependencies": {
-        "@appbaseio/reactivecore": "9.3.2",
+        "@appbaseio/reactivecore": "9.4.0",
         "@babel/polyfill": "^7.0.0-rc.3",
         "@ptomasroos/react-native-multi-slider": "^1.0.0",
         "appbase-js": "^4.0.2-beta.11",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -33,7 +33,7 @@
         "dist"
     ],
     "dependencies": {
-        "@appbaseio/reactivecore": "9.3.2",
+        "@appbaseio/reactivecore": "9.4.0",
         "@appbaseio/vue-emotion": "0.4.4",
         "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
         "appbase-js": "^4.0.2-beta.11",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -32,7 +32,7 @@
 	"author": "metagrover",
 	"license": "Apache-2.0",
 	"dependencies": {
-		"@appbaseio/reactivecore": "9.3.2",
+		"@appbaseio/reactivecore": "9.4.0",
 		"appbase-js": "4.0.2",
 		"cross-env": "^5.2.0",
 		"downshift": "^1.31.2",

--- a/packages/web/src/components/basic/ReactiveBase.js
+++ b/packages/web/src/components/basic/ReactiveBase.js
@@ -180,18 +180,7 @@ ReactiveBase.defaultProps = {
 	analytics: false,
 	graphQLUrl: '',
 	as: 'div',
-	analyticsConfig: {
-		searchStateHeader: false,
-		emptyQuery: true,
-		suggestionAnalytics: true,
-	},
 	enableAppbase: false,
-	appbaseConfig: {
-		searchStateHeader: false,
-		emptyQuery: true,
-		suggestionAnalytics: true,
-		enableQueryRules: true,
-	},
 };
 
 ReactiveBase.propTypes = {

--- a/packages/web/src/components/search/CategorySearch.js
+++ b/packages/web/src/components/search/CategorySearch.js
@@ -1110,6 +1110,7 @@ CategorySearch.propTypes = {
 	// component props
 	autoFocus: types.bool,
 	autosuggest: types.bool,
+	enableSynonyms: types.bool,
 	beforeValueChange: types.func,
 	categoryField: types.string,
 	className: types.string,
@@ -1175,6 +1176,7 @@ CategorySearch.defaultProps = {
 	className: null,
 	debounce: 0,
 	downShiftProps: {},
+	enableSynonyms: true,
 	iconPosition: 'left',
 	placeholder: 'Search',
 	queryFormat: 'or',

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -949,6 +949,7 @@ DataSearch.propTypes = {
 	// component props
 	autoFocus: types.bool,
 	autosuggest: types.bool,
+	enableSynonyms: types.bool,
 	beforeValueChange: types.func,
 	className: types.string,
 	clearIcon: types.children,
@@ -1017,6 +1018,7 @@ DataSearch.defaultProps = {
 	className: null,
 	debounce: 0,
 	downShiftProps: {},
+	enableSynonyms: true,
 	iconPosition: 'left',
 	placeholder: 'Search',
 	queryFormat: 'or',


### PR DESCRIPTION
This PR adds the `enableSynonyms` prop in search components which can be used to enable/disable the synonyms behavior for the query. This prop is only applicable when the `enableAppbase` is set to `true`.
Docs PR https://github.com/appbaseio/Docs/pull/127

**Before submitting a pull request,** please make sure the following is done:
- [x] Describe the proposed changes and how it'll improve the library experience.
- [x] Please make sure that there is no linting errors in the code.
- [x] Create a PR to add/update the docs (if needed) at [here](https://github.com/appbaseio/Docs).
- [ ] Create a PR to add/update the storybook (if needed) at [here](https://github.com/appbaseio/playground).

**Learn more about contributing:** [Contributing guides](https://github.com/appbaseio/reactivesearch/blob/next/.github/CONTRIBUTING.md)
