### PR TITLE
fix(web): customQuery not getting called when defaultValue is an empty array

### DIFF
--- a/packages/web/src/components/list/MultiList.js
+++ b/packages/web/src/components/list/MultiList.js
@@ -92,9 +92,7 @@ class MultiList extends Component {
 
 		const hasMounted = false;
 
-		if (currentValueArray.length) {
-			this.setValue(currentValueArray, true, props, hasMounted);
-		}
+		this.setValue(currentValueArray, true, props, hasMounted);
 	}
 
 	componentDidUpdate(prevProps) {


### PR DESCRIPTION
fixes #1402 

dependent on: https://github.com/appbaseio/reactivesearch/pull/1420

customQuery doesn't called initially when defaultValue is an empty array

```
<MultiList
    componentId="BookSensor"
    dataField="original_series.keyword"
    defaultValue={[]}
    size={100}
    customQuery={(value, props) => {
        console.log(value, props);
        if (value && value.length) {
            return {
                query: { terms: { [props.dataField]: value } }
            };
        }

        return {
            query: {
                bool: {
                    must_not: { term: { [props.dataField]: "comment" } }
                }
            }
        };
    }}
/>
```

Call MultiList with the following config and the customQuery with `comment` as value should get called on mount.
