### PR TITLE
fix(web): voice search stops too soon

### DIFF
--- a/packages/web/src/components/search/addons/Mic.js
+++ b/packages/web/src/components/search/addons/Mic.js
@@ -74,7 +74,7 @@ class Mic extends React.Component {
 			}
 			this.instance = new SpeechRecognition();
 			this.instance.continuous = true;
-			this.instance.interimResults = true;
+			this.instance.interimResults = false;
 			this.instance.lang = lang;
 			if (getInstance) {
 				getInstance(this.instance);


### PR DESCRIPTION
the mic was not able to detect sentences with multiple words. It was just taking first word and processing. This PR fixes the same.

Check the video with this fix: https://www.loom.com/share/6bd5ce6e211f4403aefec9036e9c72f8

Read more about interim results over here: https://wicg.github.io/speech-api/#dom-speechrecognition-interimresults