### PR TITLE
fix(web): defaultSortOption not getting applied for SSR

### DIFF
--- a/packages/web/examples/ssr/pages/index.js
+++ b/packages/web/examples/ssr/pages/index.js
@@ -98,6 +98,19 @@ const components = {
 			listItem: 'list-item',
 			image: 'image',
 		},
+		sortOptions: [
+			{
+				label: 'Bed Type',
+				dataField: 'bed_type',
+				sortBy: 'asc',
+			},
+			{
+				label: 'Bedrooms',
+				dataField: 'bedrooms',
+				sortBy: 'asc',
+			},
+		],
+		defaultSortOption: 'Bedrooms',
 	},
 };
 

--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -504,22 +504,39 @@ class ReactiveList extends Component {
 	static generateQueryOptions = (props) => {
 		// simulate default (includeFields and excludeFields) props to generate consistent query
 		const options = getQueryOptions({ includeFields: ['*'], excludeFields: [], ...props });
-		options.from = props.currentPage ? (props.currentPage - 1) * (props.size || 10) : 0;
-		options.size = props.size || 10;
+		const {
+			size, dataField, defaultSortOption, sortOptions: sortOptionsNew, currentPage, sortBy,
+		} = props;
+		options.from = currentPage ? (currentPage - 1) * (size || 10) : 0;
+		options.size = size || 10;
 
-		if (props.sortOptions) {
-			options.sort = [
-				{
-					[props.sortOptions[0].dataField]: {
-						order: props.sortOptions[0].sortBy,
-					},
+		const getSortOption = () => {
+			if (defaultSortOption) {
+				const sortOption = sortOptionsNew.find(option => (option.label === defaultSortOption));
+				if (sortOption) {
+					return {
+						[sortOption.dataField]: {
+							order: sortOption.sortBy,
+						},
+					};
+				}
+			}
+			return {
+				[sortOptionsNew[0].dataField]: {
+					order: sortOptionsNew[0].sortBy,
 				},
+			};
+		};
+
+		if (sortOptionsNew) {
+			options.sort = [
+				getSortOption(),
 			];
-		} else if (props.sortBy) {
+		} else if (sortBy) {
 			options.sort = [
 				{
-					[props.dataField]: {
-						order: props.sortBy,
+					[dataField]: {
+						order: sortBy,
 					},
 				},
 			];


### PR DESCRIPTION
this PR fixes defaultSortOption not getting applied in SSR.

fixes #1411 

## How to test:
- run `yarn dev` inside `packages/web/examples/ssr`

## Expected:
In the network tab the initial preview of the request `localhost` should show sorted results as per defaultSortOption applied.

## Demo video
https://www.loom.com/share/163f05efaa3d4099bbfd9e02861854ab