### PR TITLE
fix(web): nestedField query for all components

### DIFF
--- a/packages/web/src/components/basic/NumberBox.js
+++ b/packages/web/src/components/basic/NumberBox.js
@@ -112,11 +112,9 @@ class NumberBox extends Component {
 		}
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}

--- a/packages/web/src/components/date/DatePicker.js
+++ b/packages/web/src/components/date/DatePicker.js
@@ -110,11 +110,9 @@ class DatePicker extends Component {
 
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}

--- a/packages/web/src/components/date/DateRange.js
+++ b/packages/web/src/components/date/DateRange.js
@@ -192,11 +192,9 @@ class DateRange extends Component {
 
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}

--- a/packages/web/src/components/list/MultiDataList.js
+++ b/packages/web/src/components/list/MultiDataList.js
@@ -204,11 +204,9 @@ class MultiDataList extends Component {
 
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}

--- a/packages/web/src/components/list/MultiDropdownList.js
+++ b/packages/web/src/components/list/MultiDropdownList.js
@@ -282,11 +282,9 @@ class MultiDropdownList extends Component {
 
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}

--- a/packages/web/src/components/list/MultiList.js
+++ b/packages/web/src/components/list/MultiList.js
@@ -295,11 +295,9 @@ class MultiList extends Component {
 
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}

--- a/packages/web/src/components/list/SingleDataList.js
+++ b/packages/web/src/components/list/SingleDataList.js
@@ -158,11 +158,9 @@ class SingleDataList extends Component {
 
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}

--- a/packages/web/src/components/list/SingleDropdownList.js
+++ b/packages/web/src/components/list/SingleDropdownList.js
@@ -210,11 +210,9 @@ class SingleDropdownList extends Component {
 
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}

--- a/packages/web/src/components/list/SingleList.js
+++ b/packages/web/src/components/list/SingleList.js
@@ -228,11 +228,9 @@ class SingleList extends Component {
 		}
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}

--- a/packages/web/src/components/list/TagCloud.js
+++ b/packages/web/src/components/list/TagCloud.js
@@ -182,11 +182,9 @@ class TagCloud extends Component {
 
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}

--- a/packages/web/src/components/list/ToggleButton.js
+++ b/packages/web/src/components/list/ToggleButton.js
@@ -151,11 +151,9 @@ class ToggleButton extends Component {
 
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}

--- a/packages/web/src/components/range/DynamicRangeSlider.js
+++ b/packages/web/src/components/range/DynamicRangeSlider.js
@@ -225,11 +225,9 @@ class DynamicRangeSlider extends Component {
 
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}

--- a/packages/web/src/components/range/MultiDropdownRange.js
+++ b/packages/web/src/components/range/MultiDropdownRange.js
@@ -145,11 +145,9 @@ class MultiDropdownRange extends Component {
 
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}

--- a/packages/web/src/components/range/MultiRange.js
+++ b/packages/web/src/components/range/MultiRange.js
@@ -154,11 +154,9 @@ class MultiRange extends Component {
 
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}

--- a/packages/web/src/components/range/RangeSlider.js
+++ b/packages/web/src/components/range/RangeSlider.js
@@ -163,11 +163,9 @@ class RangeSlider extends Component {
 
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}

--- a/packages/web/src/components/range/RatingsFilter.js
+++ b/packages/web/src/components/range/RatingsFilter.js
@@ -137,11 +137,9 @@ class RatingsFilter extends Component {
 
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}

--- a/packages/web/src/components/range/SingleDropdownRange.js
+++ b/packages/web/src/components/range/SingleDropdownRange.js
@@ -114,11 +114,9 @@ class SingleDropdownRange extends Component {
 
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}

--- a/packages/web/src/components/range/SingleRange.js
+++ b/packages/web/src/components/range/SingleRange.js
@@ -109,11 +109,9 @@ class SingleRange extends Component {
 
 		if (query && props.nestedField) {
 			return {
-				query: {
-					nested: {
-						path: props.nestedField,
-						query,
-					},
+				nested: {
+					path: props.nestedField,
+					query,
 				},
 			};
 		}


### PR DESCRIPTION
fixes #1388 along with all components having use-case of **nestedField**

## Logic fix
The nested query that was generated before:
```diff
{
  "query": {
    "bool": {
      "must": [
        {
          "bool": {
            "must": [
              {
-                "query": [
-                  {
-                    "nested": {
-                      "path": "genre_nested",
-                      "query": {
-                        "term": {
-                          "genre_nested.genre.keyword": "Crime"
-                        }
-                      }
-                    }
-                  }
-                ]
              }
            ]
          }
        }
      ]
    }
  }
}
```

Instead it should be:
```diff
{
  "query": {
    "bool": {
      "must": [
        {
          "bool": {
            "must": [
              {
+                "nested": {
+                  "path": "genre_nested",
+                  "query": {
+                    "term": {
+                      "genre_nested.genre.keyword": "Crime"
+                    }
+                  }
                }
              }
            ]
          }
        }
      ]
    }
  }
}
```

## How to test
Run `yarn dev` inside `web/examples/ssr` and replace `pages/index.js` with this code: https://gist.github.com/ShahAnuj2610/f341fef2560dcf0ad897bd3b9ca17065

## Extra tests
- [x] Tested all components along with storybook without nestedField (with & without URLParams)
- [x] Tested all components along with storybook with nestedField (with & without URLParams)
- [x] Tested ssr without nestedField (with & without URLParams)
- [x] Tested ssr with nestedField (with & without URLParams)

## Demo video
https://www.loom.com/share/fc954d0d38ce4e4f992c6c24e48009f4
