### PR TITLE
fix(web): controlled behavior of sort options

### DIFF
--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -676,7 +676,7 @@ class ReactiveList extends Component {
 			className={`${sortOptions} ${getClassName(this.props.innerClass, 'sortOptions')}`}
 			name="sort-options"
 			onChange={this.handleSortChange}
-			defaultValue={this.sortOptionIndex}
+			value={this.sortOptionIndex}
 		>
 			{this.props.sortOptions.map((sort, index) => (
 				<option key={sort.label} value={index}>


### PR DESCRIPTION
fixes https://github.com/appbaseio/reactivesearch/issues/1397

## fix
- instead of `defaultValue` it should be `value`, since we're using select as a controlled component

## Demo
![](http://recordit.co/mgjD0rBxDu.gif)

## Post merge
- We may need to deploy this `booksearch` demo again with updated rs-version