### PR TITLE
feat(vue): reactive defaultQuery and customQuery

### DIFF
--- a/packages/vue/src/components/list/MultiDropdownList.jsx
+++ b/packages/vue/src/components/list/MultiDropdownList.jsx
@@ -16,6 +16,7 @@ import {
 	getValidPropsKeys,
 	updateCustomQuery,
 	updateDefaultQuery,
+	isQueryIdentical,
 } from '../../utils/index';
 
 const {
@@ -96,7 +97,11 @@ const MultiDropdownList = {
 		});
 		// Update props in store
 		this.setComponentProps(this.componentId, this.$props, componentTypes.multiDropdownList);
-		this.setComponentProps(this.internalComponent, this.$props, componentTypes.multiDropdownList);
+		this.setComponentProps(
+			this.internalComponent,
+			this.$props,
+			componentTypes.multiDropdownList,
+		);
 		// Set custom and default queries in store
 		updateCustomQuery(this.componentId, this.setCustomQuery, this.$props, this.currentValue);
 		updateDefaultQuery(this.componentId, this.setDefaultQuery, this.$props, this.currentValue);
@@ -195,6 +200,16 @@ const MultiDropdownList = {
 		value(newVal, oldVal) {
 			if (!isEqual(newVal, oldVal)) {
 				this.setValue(newVal, true);
+			}
+		},
+		defaultQuery(newVal, oldVal) {
+			if (!isQueryIdentical(newVal, oldVal, this.$data.currentValue, this.$props)) {
+				this.updateDefaultQueryHandler(this.$data.currentValue, this.$props);
+			}
+		},
+		customQuery(newVal, oldVal) {
+			if (!isQueryIdentical(newVal, oldVal, this.$data.currentValue, this.$props)) {
+				this.updateQueryHandler(this.componentId, this.$data.currentValue, this.$props);
 			}
 		},
 	},
@@ -356,6 +371,27 @@ const MultiDropdownList = {
 			);
 		},
 
+		updateDefaultQueryHandler(value, props) {
+			let defaultQueryOptions;
+			let query = MultiDropdownList.defaultQuery(value, props);
+			if (this.defaultQuery) {
+				const defaultQueryToBeSet = this.defaultQuery(value, props) || {};
+				if (defaultQueryToBeSet.query) {
+					({ query } = defaultQueryToBeSet);
+				}
+				defaultQueryOptions = getOptionsFromQuery(defaultQueryToBeSet);
+				// Update calculated default query in store
+				updateDefaultQuery(props.componentId, this.setDefaultQuery, props, value);
+			}
+			this.setQueryOptions(this.internalComponent, defaultQueryOptions);
+			this.updateQuery({
+				componentId: this.internalComponent,
+				query,
+				value,
+				componentType: componentTypes.multiDropdownList,
+			});
+		},
+
 		updateQueryHandler(value, props) {
 			const { customQuery } = props;
 			let query = MultiDropdownList.defaultQuery(value, props);
@@ -373,7 +409,7 @@ const MultiDropdownList = {
 				label: props.filterLabel,
 				showFilter: props.showFilter,
 				URLParams: props.URLParams,
-				componentType: 'MULTIDROPDOWNLIST',
+				componentType: componentTypes.multiDropdownList,
 			});
 		},
 

--- a/packages/vue/src/components/list/MultiList.jsx
+++ b/packages/vue/src/components/list/MultiList.jsx
@@ -14,6 +14,7 @@ import {
 	getValidPropsKeys,
 	updateCustomQuery,
 	updateDefaultQuery,
+	isQueryIdentical,
 } from '../../utils/index';
 import types from '../../utils/vueTypes';
 import { UL, Checkbox } from '../../styles/FormControlList';
@@ -105,11 +106,7 @@ const MultiList = {
 		const propsKeys = getValidPropsKeys(this.$props);
 		this.$watch(propsKeys.join('.'), (newVal, oldVal) => {
 			checkSomePropChange(newVal, oldVal, propsKeys, () => {
-				this.updateComponentProps(
-					this.componentId,
-					this.$props,
-					componentTypes.multiList,
-				);
+				this.updateComponentProps(this.componentId, this.$props, componentTypes.multiList);
 				this.updateComponentProps(
 					this.internalComponent,
 					this.$props,
@@ -177,6 +174,16 @@ const MultiList = {
 			}
 			if (!isEqual(selectedValue, newVal)) {
 				this.setValue(newVal || [], true);
+			}
+		},
+		defaultQuery(newVal, oldVal) {
+			if (!isQueryIdentical(newVal, oldVal, this.$data.currentValue, this.$props)) {
+				this.updateDefaultQueryHandler(this.$data.currentValue, this.$props);
+			}
+		},
+		customQuery(newVal, oldVal) {
+			if (!isQueryIdentical(newVal, oldVal, this.$data.currentValue, this.$props)) {
+				this.updateQueryHandler(this.componentId, this.$data.currentValue, this.$props);
 			}
 		},
 	},
@@ -386,6 +393,27 @@ const MultiList = {
 			);
 		},
 
+		updateDefaultQueryHandler(value, props) {
+			let defaultQueryOptions;
+			let query = MultiList.defaultQuery(value, props);
+			if (this.defaultQuery) {
+				const defaultQueryToBeSet = this.defaultQuery(value, props) || {};
+				if (defaultQueryToBeSet.query) {
+					({ query } = defaultQueryToBeSet);
+				}
+				defaultQueryOptions = getOptionsFromQuery(defaultQueryToBeSet);
+				// Update calculated default query in store
+				updateDefaultQuery(props.componentId, this.setDefaultQuery, props, value);
+			}
+			this.setQueryOptions(this.internalComponent, defaultQueryOptions);
+			this.updateQuery({
+				componentId: this.internalComponent,
+				query,
+				value,
+				componentType: componentTypes.multiList,
+			});
+		},
+
 		updateQueryHandler(value, props) {
 			const { customQuery } = props;
 			let query = MultiList.defaultQuery(value, props);
@@ -404,7 +432,7 @@ const MultiList = {
 				label: props.filterLabel,
 				showFilter: props.showFilter,
 				URLParams: props.URLParams,
-				componentType: 'MULTILIST',
+				componentType: componentTypes.multiList,
 			});
 		},
 

--- a/packages/vue/src/components/list/SingleDropdownList.jsx
+++ b/packages/vue/src/components/list/SingleDropdownList.jsx
@@ -15,6 +15,7 @@ import {
 	getValidPropsKeys,
 	updateCustomQuery,
 	updateDefaultQuery,
+	isQueryIdentical,
 } from '../../utils/index';
 
 const {
@@ -94,7 +95,11 @@ const SingleDropdownList = {
 		});
 		// Update props in store
 		this.setComponentProps(this.componentId, this.$props, componentTypes.singleDropdownList);
-		this.setComponentProps(this.internalComponent, this.$props, componentTypes.singleDropdownList);
+		this.setComponentProps(
+			this.internalComponent,
+			this.$props,
+			componentTypes.singleDropdownList,
+		);
 		// Set custom and default queries in store
 		updateCustomQuery(this.componentId, this.setCustomQuery, this.$props, this.currentValue);
 		updateDefaultQuery(this.componentId, this.setDefaultQuery, this.$props, this.currentValue);
@@ -185,6 +190,16 @@ const SingleDropdownList = {
 		selectedValue(newVal) {
 			if (this.$data.currentValue !== newVal) {
 				this.setValue(newVal || '');
+			}
+		},
+		defaultQuery(newVal, oldVal) {
+			if (!isQueryIdentical(newVal, oldVal, this.$data.currentValue, this.$props)) {
+				this.updateDefaultQueryHandler(this.$data.currentValue, this.$props);
+			}
+		},
+		customQuery(newVal, oldVal) {
+			if (!isQueryIdentical(newVal, oldVal, this.$data.currentValue, this.$props)) {
+				this.updateQueryHandler(this.componentId, this.$data.currentValue, this.$props);
 			}
 		},
 	},
@@ -289,6 +304,27 @@ const SingleDropdownList = {
 			}
 		},
 
+		updateDefaultQueryHandler(value, props) {
+			let defaultQueryOptions;
+			let query = SingleDropdownList.defaultQuery(value, props);
+			if (this.defaultQuery) {
+				const defaultQueryToBeSet = this.defaultQuery(value, props) || {};
+				if (defaultQueryToBeSet.query) {
+					({ query } = defaultQueryToBeSet);
+				}
+				defaultQueryOptions = getOptionsFromQuery(defaultQueryToBeSet);
+				// Update calculated default query in store
+				updateDefaultQuery(props.componentId, this.setDefaultQuery, props, value);
+			}
+			this.setQueryOptions(this.internalComponent, defaultQueryOptions);
+			this.updateQuery({
+				componentId: this.internalComponent,
+				query,
+				value,
+				componentType: componentTypes.singleDropdownList,
+			});
+		},
+
 		updateQueryHandler(value, props) {
 			const { customQuery } = props;
 			let query = SingleDropdownList.defaultQuery(value, props);
@@ -306,7 +342,7 @@ const SingleDropdownList = {
 				label: props.filterLabel,
 				showFilter: props.showFilter,
 				URLParams: props.URLParams,
-				componentType: 'SINGLEDROPDOWNLIST',
+				componentType: componentTypes.singleDropdownList,
 			});
 		},
 

--- a/packages/vue/src/components/list/SingleList.jsx
+++ b/packages/vue/src/components/list/SingleList.jsx
@@ -13,6 +13,7 @@ import {
 	getValidPropsKeys,
 	updateCustomQuery,
 	updateDefaultQuery,
+	isQueryIdentical,
 } from '../../utils/index';
 import types from '../../utils/vueTypes';
 import { UL, Radio } from '../../styles/FormControlList';
@@ -102,11 +103,7 @@ const SingleList = {
 		const propsKeys = getValidPropsKeys(this.$props);
 		this.$watch(propsKeys.join('.'), (newVal, oldVal) => {
 			checkSomePropChange(newVal, oldVal, propsKeys, () => {
-				this.updateComponentProps(
-					this.componentId,
-					this.$props,
-					componentTypes.singleList,
-				);
+				this.updateComponentProps(this.componentId, this.$props, componentTypes.singleList);
 				this.updateComponentProps(
 					this.internalComponent,
 					this.$props,
@@ -164,6 +161,16 @@ const SingleList = {
 		selectedValue(newVal) {
 			if (this.$data.currentValue !== newVal) {
 				this.setValue(newVal || '');
+			}
+		},
+		defaultQuery(newVal, oldVal) {
+			if (!isQueryIdentical(newVal, oldVal, this.$data.currentValue, this.$props)) {
+				this.updateDefaultQueryHandler(this.$data.currentValue, this.$props);
+			}
+		},
+		customQuery(newVal, oldVal) {
+			if (!isQueryIdentical(newVal, oldVal, this.$data.currentValue, this.$props)) {
+				this.updateQueryHandler(this.componentId, this.$data.currentValue, this.$props);
 			}
 		},
 	},
@@ -331,6 +338,27 @@ const SingleList = {
 			checkValueChange(props.componentId, value, props.beforeValueChange, performUpdate);
 		},
 
+		updateDefaultQueryHandler(value, props) {
+			let defaultQueryOptions;
+			let query = SingleList.defaultQuery(value, props);
+			if (this.defaultQuery) {
+				const defaultQueryToBeSet = this.defaultQuery(value, props) || {};
+				if (defaultQueryToBeSet.query) {
+					({ query } = defaultQueryToBeSet);
+				}
+				defaultQueryOptions = getOptionsFromQuery(defaultQueryToBeSet);
+				// Update calculated default query in store
+				updateDefaultQuery(props.componentId, this.setDefaultQuery, props, value);
+			}
+			this.setQueryOptions(this.internalComponent, defaultQueryOptions);
+			this.updateQuery({
+				componentId: this.internalComponent,
+				query,
+				value,
+				componentType: componentTypes.singleList,
+			});
+		},
+
 		updateQueryHandler(value, props) {
 			const { customQuery } = props;
 			let query = SingleList.defaultQuery(value, props);
@@ -348,7 +376,7 @@ const SingleList = {
 				label: props.filterLabel,
 				showFilter: props.showFilter,
 				URLParams: props.URLParams,
-				componentType: 'SINGLELIST',
+				componentType: componentTypes.singleList,
 			});
 		},
 

--- a/packages/vue/src/components/list/ToggleButton.jsx
+++ b/packages/vue/src/components/list/ToggleButton.jsx
@@ -4,7 +4,7 @@ import types from '../../utils/vueTypes';
 import Title from '../../styles/Title';
 import Container from '../../styles/Container';
 import Button, { toggleButtons } from '../../styles/Button';
-import { connect, updateCustomQuery, getValidPropsKeys } from '../../utils/index';
+import { connect, updateCustomQuery, getValidPropsKeys, isQueryIdentical } from '../../utils/index';
 
 const {
 	addComponent,
@@ -128,6 +128,11 @@ const ToggleButton = {
 				}
 			}
 		},
+		customQuery(newVal, oldVal) {
+			if (!isQueryIdentical(newVal, oldVal, this.$data.currentValue, this.$props)) {
+				this.updateQuery(this.$data.currentValue, this.$props);
+			}
+		},
 	},
 	methods: {
 		handleToggle(value, isDefaultValue = false, props = this.$props, hasMounted = true) {
@@ -206,7 +211,7 @@ const ToggleButton = {
 				label: props.filterLabel,
 				showFilter: props.showFilter,
 				URLParams: props.URLParams,
-				componentType: 'TOGGLEBUTTON',
+				componentType: componentTypes.toggleButton,
 			});
 		},
 

--- a/packages/vue/src/components/list/utils.js
+++ b/packages/vue/src/components/list/utils.js
@@ -2,10 +2,10 @@ import { helper } from '@appbaseio/reactivecore';
 
 const { getAggsOrder } = helper;
 
-const extractQuery = (defaultQuery) => {
+const extractQuery = props => {
 	const queryToBeReturned = {};
-	if (defaultQuery) {
-		const evaluateQuery = defaultQuery();
+	if (props.defaultQuery) {
+		const evaluateQuery = props.defaultQuery([], props);
 		if (evaluateQuery) {
 			if (evaluateQuery.query) {
 				queryToBeReturned.query = evaluateQuery.query;
@@ -19,9 +19,7 @@ const extractQuery = (defaultQuery) => {
 };
 const getAggsQuery = (query, props) => {
 	const clonedQuery = query;
-	const {
-		dataField, size, sortBy, showMissing, missingLabel,
-	} = props;
+	const { dataField, size, sortBy, showMissing, missingLabel } = props;
 	clonedQuery.size = 0;
 	clonedQuery.aggs = {
 		[dataField]: {
@@ -44,15 +42,13 @@ const getAggsQuery = (query, props) => {
 			},
 		};
 	}
-	return { ...clonedQuery, ...extractQuery(props.defaultQuery) };
+	return { ...clonedQuery, ...extractQuery(props) };
 };
 
 const getCompositeAggsQuery = (query, props, after) => {
 	const clonedQuery = query;
 	// missing label not available in composite aggs
-	const {
-		dataField, size, sortBy, showMissing,
-	} = props;
+	const { dataField, size, sortBy, showMissing } = props;
 
 	// composite aggs only allows asc and desc
 	const order = sortBy === 'count' ? {} : { order: sortBy };
@@ -88,7 +84,7 @@ const getCompositeAggsQuery = (query, props, after) => {
 			},
 		};
 	}
-	return { ...clonedQuery, ...extractQuery(props.defaultQuery) };
+	return { ...clonedQuery, ...extractQuery(props) };
 };
 
 export { getAggsQuery, getCompositeAggsQuery };

--- a/packages/vue/src/components/range/DynamicRangeSlider.jsx
+++ b/packages/vue/src/components/range/DynamicRangeSlider.jsx
@@ -3,7 +3,7 @@ import NoSSR from 'vue-no-ssr';
 import { Actions, helper } from '@appbaseio/reactivecore';
 import { componentTypes } from '@appbaseio/reactivecore/lib/utils/constants';
 import Container from '../../styles/Container';
-import { connect, updateCustomQuery, getValidPropsKeys } from '../../utils/index';
+import { connect, updateCustomQuery, getValidPropsKeys, isQueryIdentical } from '../../utils/index';
 import Title from '../../styles/Title';
 import Slider from '../../styles/Slider';
 import types from '../../utils/vueTypes';
@@ -227,7 +227,7 @@ const DynamicRangeSlider = {
 				label: this.$props.filterLabel,
 				showFilter: this.$props.showFilter && !isInitialValue,
 				URLParams: this.$props.URLParams,
-				componentType: 'DYNAMICRANGESLIDER',
+				componentType: componentTypes.dynamicRangeSlider,
 			});
 		},
 	},
@@ -266,6 +266,11 @@ const DynamicRangeSlider = {
 
 			this.handleChange([newStart, newEnd]);
 		},
+		customQuery(newVal, oldVal) {
+			if (!isQueryIdentical(newVal, oldVal, this.$data.currentValue, this.$props)) {
+				this.updateQueryHandler(this.$data.currentValue);
+			}
+		},
 	},
 
 	render() {
@@ -300,16 +305,16 @@ const DynamicRangeSlider = {
 							<div class="label-container">
 								<label
 									class={
-										getClassName(this.$props.innerClass, 'label') ||
-										'range-label-left'
+										getClassName(this.$props.innerClass, 'label')
+										|| 'range-label-left'
 									}
 								>
 									{this.labels.start}
 								</label>
 								<label
 									class={
-										getClassName(this.$props.innerClass, 'label') ||
-										'range-label-right'
+										getClassName(this.$props.innerClass, 'label')
+										|| 'range-label-right'
 									}
 								>
 									{this.labels.end}
@@ -362,26 +367,26 @@ const mapStateToProps = (state, props) => {
 	let range = state.aggregations[`${props.componentId}__range__internal`];
 
 	if (props.nestedField) {
-		options =
-			options &&
-			componentId[props.dataField][props.nestedField] &&
-			componentId[props.dataField][props.nestedField].buckets
+		options
+			= options
+			&& componentId[props.dataField][props.nestedField]
+			&& componentId[props.dataField][props.nestedField].buckets
 				? componentId[props.dataField][props.nestedField].buckets
 				: [];
-		range =
-			range && internalRange[props.nestedField].min
+		range
+			= range && internalRange[props.nestedField].min
 				? {
-						start: internalRange[props.nestedField].min.value,
-						end: internalRange[props.nestedField].max.value,
+					start: internalRange[props.nestedField].min.value,
+					end: internalRange[props.nestedField].max.value,
 				  }
 				: null;
 	} else {
-		options =
-			options && componentId[props.dataField].buckets
+		options
+			= options && componentId[props.dataField].buckets
 				? componentId[props.dataField].buckets
 				: [];
-		range =
-			range && internalRange.min
+		range
+			= range && internalRange.min
 				? { start: internalRange.min.value, end: internalRange.max.value }
 				: null;
 	}

--- a/packages/vue/src/components/range/DynamicRangeSlider.jsx
+++ b/packages/vue/src/components/range/DynamicRangeSlider.jsx
@@ -80,7 +80,7 @@ const DynamicRangeSlider = {
 			this.componentId,
 			this.setCustomQuery,
 			this.$props,
-			this.state.currentValue,
+			this.currentValue,
 		);
 	},
 	mounted() {

--- a/packages/vue/src/components/range/MultiRange.jsx
+++ b/packages/vue/src/components/range/MultiRange.jsx
@@ -4,7 +4,13 @@ import VueTypes from 'vue-types';
 import Title from '../../styles/Title';
 import Container from '../../styles/Container';
 import { UL, Checkbox } from '../../styles/FormControlList';
-import { connect, parseValueArray, updateCustomQuery, getValidPropsKeys } from '../../utils/index';
+import {
+	connect,
+	parseValueArray,
+	updateCustomQuery,
+	getValidPropsKeys,
+	isQueryIdentical,
+} from '../../utils/index';
 import types from '../../utils/vueTypes';
 
 const {
@@ -137,7 +143,7 @@ const MultiRange = {
 				label: props.filterLabel,
 				showFilter: props.showFilter,
 				URLParams: props.URLParams,
-				componentType: 'MULTIRANGE',
+				componentType: componentTypes.multiRange,
 			});
 		},
 	},
@@ -160,6 +166,11 @@ const MultiRange = {
 		selectedValue(newVal) {
 			if (!isEqual(this.$data.currentValue, newVal)) {
 				this.selectItem(newVal);
+			}
+		},
+		customQuery(newVal, oldVal) {
+			if (!isQueryIdentical(newVal, oldVal, this.$data.currentValue, this.$props)) {
+				this.updateQueryHandler(this.$data.currentValue, this.$props);
 			}
 		},
 	},
@@ -208,9 +219,9 @@ const MultiRange = {
 				)}
 				<UL class={getClassName(this.$props.innerClass, 'list')}>
 					{this.$props.data.map(item => {
-						const selected =
-							!!this.$data.currentValue &&
-							this.$data.currentValue.label === item.label;
+						const selected
+							= !!this.$data.currentValue
+							&& this.$data.currentValue.label === item.label;
 						return (
 							<li key={item.label} class={`${selected ? 'active' : ''}`}>
 								<Checkbox
@@ -290,9 +301,9 @@ MultiRange.defaultQuery = (values, props) => {
 
 const mapStateToProps = (state, props) => ({
 	selectedValue:
-		(state.selectedValues[props.componentId] &&
-			state.selectedValues[props.componentId].value) ||
-		null,
+		(state.selectedValues[props.componentId]
+			&& state.selectedValues[props.componentId].value)
+		|| null,
 });
 
 const mapDispatchtoProps = {

--- a/packages/vue/src/components/range/RangeSlider.jsx
+++ b/packages/vue/src/components/range/RangeSlider.jsx
@@ -3,7 +3,7 @@ import { Actions, helper } from '@appbaseio/reactivecore';
 import { componentTypes } from '@appbaseio/reactivecore/lib/utils/constants';
 import NoSSR from 'vue-no-ssr';
 import Container from '../../styles/Container';
-import { connect, updateCustomQuery, getValidPropsKeys } from '../../utils/index';
+import { connect, updateCustomQuery, getValidPropsKeys, isQueryIdentical } from '../../utils/index';
 import Title from '../../styles/Title';
 import Slider from '../../styles/Slider';
 import types from '../../utils/vueTypes';
@@ -137,7 +137,7 @@ const RangeSlider = {
 				label: props.filterLabel,
 				showFilter: showFilter && !isInitialValue,
 				URLParams: props.URLParams,
-				componentType: 'RANGESLIDER',
+				componentType: componentTypes.rangeSlider,
 			});
 		},
 	},
@@ -159,6 +159,12 @@ const RangeSlider = {
 		selectedValue(newVal) {
 			if (!isEqual(this.$data.currentValue, newVal)) {
 				this.handleChange(RangeSlider.parseValue(newVal, this.$props));
+			}
+		},
+
+		customQuery(newVal, oldVal) {
+			if (!isQueryIdentical(newVal, oldVal, this.$data.currentValue, this.$props)) {
+				this.updateQueryHandler(this.$data.currentValue, this.$props);
 			}
 		},
 	},
@@ -240,16 +246,16 @@ const RangeSlider = {
 								<div class="label-container">
 									<label
 										class={
-											getClassName(this.$props.innerClass, 'label') ||
-											'range-label-left'
+											getClassName(this.$props.innerClass, 'label')
+											|| 'range-label-left'
 										}
 									>
 										{this.$props.rangeLabels.start}
 									</label>
 									<label
 										class={
-											getClassName(this.$props.innerClass, 'label') ||
-											'range-label-right'
+											getClassName(this.$props.innerClass, 'label')
+											|| 'range-label-right'
 										}
 									>
 										{this.$props.rangeLabels.end}
@@ -302,8 +308,8 @@ RangeSlider.parseValue = (value, props) => {
 
 const mapStateToProps = (state, props) => ({
 	options: state.aggregations[props.componentId]
-		? state.aggregations[props.componentId][props.dataField] &&
-		  state.aggregations[props.componentId][props.dataField].buckets // eslint-disable-line
+		? state.aggregations[props.componentId][props.dataField]
+		  && state.aggregations[props.componentId][props.dataField].buckets // eslint-disable-line
 		: [],
 	selectedValue: state.selectedValues[props.componentId]
 		? state.selectedValues[props.componentId].value

--- a/packages/vue/src/components/range/SingleRange.jsx
+++ b/packages/vue/src/components/range/SingleRange.jsx
@@ -4,7 +4,7 @@ import VueTypes from 'vue-types';
 import Title from '../../styles/Title';
 import Container from '../../styles/Container';
 import { UL, Radio } from '../../styles/FormControlList';
-import { connect, updateCustomQuery, getValidPropsKeys } from '../../utils/index';
+import { connect, updateCustomQuery, getValidPropsKeys, isQueryIdentical } from '../../utils/index';
 import types from '../../utils/vueTypes';
 
 const {
@@ -111,6 +111,11 @@ const SingleRange = {
 				this.setValue(newVal);
 			}
 		},
+		customQuery(newVal, oldVal) {
+			if (!isQueryIdentical(newVal, oldVal, this.$data.currentValue, this.$props)) {
+				this.updateQueryHandler(this.$data.currentValue, this.$props);
+			}
+		},
 	},
 
 	render() {
@@ -199,7 +204,7 @@ const SingleRange = {
 				label: props.filterLabel,
 				showFilter: props.showFilter,
 				URLParams: props.URLParams,
-				componentType: 'SINGLERANGE',
+				componentType: componentTypes.singleRange,
 			});
 		},
 

--- a/packages/vue/src/components/result/ReactiveList.jsx
+++ b/packages/vue/src/components/result/ReactiveList.jsx
@@ -12,6 +12,7 @@ import {
 	getComponent,
 	getValidPropsKeys,
 	updateDefaultQuery,
+	isQueryIdentical,
 } from '../../utils/index';
 import Flex from '../../styles/Flex';
 import types from '../../utils/vueTypes';
@@ -175,10 +176,10 @@ const ReactiveList = {
 			}
 		},
 		defaultQuery(newVal, oldVal) {
-			if (newVal && !isEqual(newVal(), oldVal)) {
+			if (!isQueryIdentical(newVal, oldVal, null, this.$props)) {
 				let options = getQueryOptions(this.$props);
 				options.from = 0;
-				this.$defaultQuery = newVal();
+				this.$defaultQuery = newVal(null, this.$props);
 				const { sort, ...query } = this.$defaultQuery;
 
 				if (sort) {
@@ -382,8 +383,16 @@ const ReactiveList = {
 		const propsKeys = getValidPropsKeys(this.$props);
 		this.$watch(propsKeys.join('.'), (newVal, oldVal) => {
 			checkSomePropChange(newVal, oldVal, propsKeys, () => {
-				this.updateComponentProps(this.componentId, this.$props, componentTypes.reactiveList);
-				this.updateComponentProps(this.internalComponent, this.$props, componentTypes.reactiveList);
+				this.updateComponentProps(
+					this.componentId,
+					this.$props,
+					componentTypes.reactiveList,
+				);
+				this.updateComponentProps(
+					this.internalComponent,
+					this.$props,
+					componentTypes.reactiveList,
+				);
 			});
 		});
 	},
@@ -710,7 +719,15 @@ const ReactiveList = {
 		},
 		// Shape of the object to be returned in onData & render
 		getAllData() {
-			const { size, promotedResults, aggregationData, customData, currentPage, hits, streamHits } = this;
+			const {
+				size,
+				promotedResults,
+				aggregationData,
+				customData,
+				currentPage,
+				hits,
+				streamHits,
+			} = this;
 			const results = parseHits(hits) || [];
 			const streamResults = parseHits(streamHits) || [];
 			const parsedPromotedResults = parseHits(promotedResults) || [];


### PR DESCRIPTION
## Changes

- [x] make defaultQuery and customQuery prop reactive for all components
- [x] remove hardcoded component names used in queries and use constants

## Testing

![](http://recordit.co/4y7e0vMpAX.gif)