### PR TITLE
fix(web): customQuery for ssr

### DIFF
--- a/packages/web/src/server/index.js
+++ b/packages/web/src/server/index.js
@@ -53,7 +53,8 @@ function getQuery(component, value, componentType) {
 	// get custom or default query of sensor components
 	const currentValue = parseValue(value, component);
 	if (component.customQuery) {
-		return component.customQuery(currentValue, component);
+		const customQuery = component.customQuery(currentValue, component);
+		return customQuery && customQuery.query;
 	}
 	return component.source.defaultQuery
 		? component.source.defaultQuery(currentValue, component)


### PR DESCRIPTION
fixes #1439 

## Change
`customQuery` in ssr was appending `query` key along with the finalQuery, due to which query was failing

## Test
https://www.loom.com/share/c0e3f84cab1b404f95b5c4e9da838fc4
