### PR TITLE
style(web): normalize end of line rule across platform

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,10 @@
 		"no-tabs": 0,
 		"no-underscore-dangle": 0,
 		"operator-linebreak": ["error", "before"],
+		"linebreak-style": [
+			"error",
+			"unix"
+		  ], 
 		"prefer-destructuring": 0,
 		"no-console": [
 			"error",

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+
+*.js text eol=lf
+
+# The test fixtures are text files.
+/tests/fixtures/**/* text eol=lf
+/tests/fixtures/ignored-paths/crlf/.eslintignore text eol=crlf

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,2 @@
+[core]
+    autocrlf = false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,6 @@
 	"files.exclude": {
 		"node_modules": true
 	},
-	"files.eol": "\n",
 	"javascript.validate.enable": false,
 	"editor.codeActionsOnSave": {
 		"source.fixAll.tslint": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
 	"files.exclude": {
 		"node_modules": true
 	},
+	"files.eol": "\n",
 	// to resolve flow issues - Refer: https://github.com/flowtype/flow-for-vscode#setup
 	"javascript.validate.enable": false,
 	"editor.codeActionsOnSave": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,6 @@
 		"node_modules": true
 	},
 	"files.eol": "\n",
-	// to resolve flow issues - Refer: https://github.com/flowtype/flow-for-vscode#setup
 	"javascript.validate.enable": false,
 	"editor.codeActionsOnSave": {
 		"source.fixAll.tslint": true,

--- a/packages/web/.gitattributes
+++ b/packages/web/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+
+*.js text eol=lf
+
+# The test fixtures are text files.
+/tests/fixtures/**/* text eol=lf
+/tests/fixtures/ignored-paths/crlf/.eslintignore text eol=crlf

--- a/packages/web/.gitconfig
+++ b/packages/web/.gitconfig
@@ -1,0 +1,2 @@
+[core]
+    autocrlf = false


### PR DESCRIPTION
The current End of line rules does not go well with Windows and eslint shows ton of errors. This deteriorate the developer experience. VSCode auto converts line ending to CLRF which does not adhere to the eslint rules. A quick fix from Microsoft is in works but enforcing in project-wide would be much more cleaner and independent of the IDE.

**Before submitting a pull request,** please make sure the following is done:

- [x] Describe the proposed changes and how it'll improve the library experience.
- [x] Please make sure that there are no linting errors in the code.
- [ ] Add a demo video/gif/screenshot to explain how did you test the fix.
- [ ] If it is a global change, try to add any side effects that it could have.
- [ ] Create a PR to add/update the docs (if needed) at [here](https://github.com/appbaseio/Docs).
- [ ] Create a PR to add/update the storybook (if needed) at [here](https://github.com/appbaseio/playground).

**Learn more about contributing:** [Contributing guides](https://github.com/appbaseio/reactivesearch/blob/next/.github/CONTRIBUTING.md)
