### PR TITLE
fix(web): data field validation for rs-api

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -33,7 +33,7 @@
 	"license": "Apache-2.0",
 	"dependencies": {
 		"@appbaseio/reactivecore": "9.5.7",
-		"appbase-js": "^4.0.4",
+		"appbase-js": "^4.0.5",
 		"cross-env": "^5.2.0",
 		"downshift": "^1.31.2",
 		"emotion": "^9.0.0",

--- a/packages/web/src/components/basic/NumberBox.js
+++ b/packages/web/src/components/basic/NumberBox.js
@@ -251,7 +251,7 @@ NumberBox.propTypes = {
 	className: types.string,
 	componentId: types.stringRequired,
 	data: types.dataNumberBox,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	defaultValue: types.number,
 	value: types.number,
 	innerClass: types.style,

--- a/packages/web/src/components/date/DatePicker.js
+++ b/packages/web/src/components/date/DatePicker.js
@@ -288,7 +288,7 @@ DatePicker.propTypes = {
 	className: types.string,
 	clickUnselectsDay: types.bool,
 	componentId: types.stringRequired,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	dayPickerInputProps: types.props,
 	defaultValue: types.date,
 	value: types.date,

--- a/packages/web/src/components/date/DateRange.js
+++ b/packages/web/src/components/date/DateRange.js
@@ -529,7 +529,7 @@ DateRange.propTypes = {
 	beforeValueChange: types.func,
 	className: types.string,
 	componentId: types.stringRequired,
-	dataField: types.dataFieldArray,
+	dataField: types.dataFieldValidator,
 	dayPickerInputProps: types.props,
 	defaultValue: types.dateObject,
 	value: types.dateObject,

--- a/packages/web/src/components/list/MultiDataList.js
+++ b/packages/web/src/components/list/MultiDataList.js
@@ -567,7 +567,7 @@ MultiDataList.propTypes = {
 	customQuery: types.func,
 	defaultQuery: types.func,
 	data: types.data,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	defaultValue: types.stringArray,
 	value: types.stringArray,
 	filterLabel: types.string,

--- a/packages/web/src/components/list/MultiDropdownList.js
+++ b/packages/web/src/components/list/MultiDropdownList.js
@@ -547,7 +547,7 @@ MultiDropdownList.propTypes = {
 	componentId: types.stringRequired,
 	customQuery: types.func,
 	defaultQuery: types.func,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	defaultValue: types.stringArray,
 	value: types.stringArray,
 	filterLabel: types.string,

--- a/packages/web/src/components/list/MultiList.js
+++ b/packages/web/src/components/list/MultiList.js
@@ -688,7 +688,7 @@ MultiList.propTypes = {
 	componentId: types.stringRequired,
 	customQuery: types.func,
 	defaultQuery: types.func,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	nestedField: types.string,
 	defaultValue: types.stringArray,
 	value: types.stringArray,

--- a/packages/web/src/components/list/SingleDataList.js
+++ b/packages/web/src/components/list/SingleDataList.js
@@ -471,7 +471,7 @@ SingleDataList.propTypes = {
 	componentId: types.stringRequired,
 	customQuery: types.func,
 	data: types.data,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	defaultValue: types.string,
 	value: types.string,
 	filterLabel: types.string,

--- a/packages/web/src/components/list/SingleDropdownList.js
+++ b/packages/web/src/components/list/SingleDropdownList.js
@@ -433,7 +433,7 @@ SingleDropdownList.propTypes = {
 	componentId: types.stringRequired,
 	customQuery: types.func,
 	defaultQuery: types.func,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	defaultValue: types.string,
 	value: types.string,
 	filterLabel: types.string,

--- a/packages/web/src/components/list/SingleList.js
+++ b/packages/web/src/components/list/SingleList.js
@@ -561,7 +561,7 @@ SingleList.propTypes = {
 	componentId: types.stringRequired,
 	customQuery: types.func,
 	defaultQuery: types.func,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	defaultValue: types.string,
 	value: types.string,
 	filterLabel: types.string,

--- a/packages/web/src/components/list/TagCloud.js
+++ b/packages/web/src/components/list/TagCloud.js
@@ -364,7 +364,7 @@ TagCloud.propTypes = {
 	className: types.string,
 	componentId: types.stringRequired,
 	customQuery: types.func,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	defaultValue: types.stringOrArray,
 	value: types.stringOrArray,
 	filterLabel: types.string,

--- a/packages/web/src/components/list/ToggleButton.js
+++ b/packages/web/src/components/list/ToggleButton.js
@@ -298,7 +298,7 @@ ToggleButton.propTypes = {
 	className: types.string,
 	componentId: types.stringRequired,
 	data: types.data,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	defaultValue: types.stringOrArray,
 	value: types.stringOrArray,
 	filterLabel: types.string,

--- a/packages/web/src/components/range/DynamicRangeSlider.js
+++ b/packages/web/src/components/range/DynamicRangeSlider.js
@@ -536,7 +536,7 @@ DynamicRangeSlider.propTypes = {
 	className: types.string,
 	componentId: types.stringRequired,
 	customQuery: types.func,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	defaultValue: types.func,
 	value: types.func,
 	filterLabel: types.string,

--- a/packages/web/src/components/range/MultiDropdownRange.js
+++ b/packages/web/src/components/range/MultiDropdownRange.js
@@ -278,7 +278,7 @@ MultiDropdownRange.propTypes = {
 	componentId: types.stringRequired,
 	customQuery: types.func,
 	data: types.data,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	defaultValue: types.stringArray,
 	value: types.stringArray,
 	filterLabel: types.filterLabel,

--- a/packages/web/src/components/range/MultiRange.js
+++ b/packages/web/src/components/range/MultiRange.js
@@ -311,7 +311,7 @@ MultiRange.propTypes = {
 	componentId: types.stringRequired,
 	customQuery: types.func,
 	data: types.data,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	defaultValue: types.stringArray,
 	value: types.stringArray,
 	filterLabel: types.filterLabel,

--- a/packages/web/src/components/range/RangeSlider.js
+++ b/packages/web/src/components/range/RangeSlider.js
@@ -425,7 +425,7 @@ RangeSlider.propTypes = {
 	className: types.string,
 	componentId: types.stringRequired,
 	customQuery: types.func,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	defaultValue: types.range,
 	value: types.range,
 	filterLabel: types.string,

--- a/packages/web/src/components/range/RatingsFilter.js
+++ b/packages/web/src/components/range/RatingsFilter.js
@@ -261,7 +261,7 @@ RatingsFilter.propTypes = {
 	componentId: types.stringRequired,
 	customQuery: types.func,
 	data: types.data,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	defaultValue: types.range,
 	dimmedIcon: element,
 	value: types.range,

--- a/packages/web/src/components/range/SingleDropdownRange.js
+++ b/packages/web/src/components/range/SingleDropdownRange.js
@@ -225,7 +225,7 @@ SingleDropdownRange.propTypes = {
 	componentId: types.stringRequired,
 	customQuery: types.func,
 	data: types.data,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	defaultValue: types.string,
 	value: types.string,
 	filterLabel: types.string,

--- a/packages/web/src/components/range/SingleRange.js
+++ b/packages/web/src/components/range/SingleRange.js
@@ -241,7 +241,7 @@ SingleRange.propTypes = {
 	componentId: types.stringRequired,
 	customQuery: types.func,
 	data: types.data,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	defaultValue: types.string,
 	value: types.string,
 	filterLabel: types.string,

--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -848,7 +848,7 @@ ReactiveList.propTypes = {
 	className: types.string,
 	componentId: types.stringRequired,
 	children: types.func,
-	dataField: types.stringRequired,
+	dataField: types.dataFieldValidator,
 	aggregationField: types.string,
 	aggregationData: types.aggregationData,
 	defaultPage: types.number,

--- a/packages/web/src/components/search/CategorySearch.js
+++ b/packages/web/src/components/search/CategorySearch.js
@@ -1119,7 +1119,7 @@ CategorySearch.propTypes = {
 	customHighlight: types.func,
 	customQuery: types.func,
 	defaultQuery: types.func,
-	dataField: types.dataFieldArray,
+	dataField: types.dataFieldValidator,
 	aggregationField: types.string,
 	size: types.number,
 	debounce: types.number,

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -957,7 +957,7 @@ DataSearch.propTypes = {
 	customHighlight: types.func,
 	customQuery: types.func,
 	defaultQuery: types.func,
-	dataField: types.dataFieldArray,
+	dataField: types.dataFieldValidator,
 	aggregationField: types.string,
 	size: types.number,
 	debounce: types.number,

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,6 +164,17 @@
     string.prototype.repeat "^0.2.0"
     unist-util-visit "^1.1.3"
 
+"@appbaseio/reactivecore@9.5.5":
+  version "9.5.5"
+  resolved "https://registry.yarnpkg.com/@appbaseio/reactivecore/-/reactivecore-9.5.5.tgz#153bd0fe2b9669c038670a67ea385d5370d03050"
+  integrity sha512-F7O3Ni/spj9YuAfnwWBsnuWkTX1L1yI2cSBGpE/myReinjSNWIpyG8xZs7nmy16xxxMp0Xq+YWW3O/99wtv4UQ==
+  dependencies:
+    cross-fetch "^3.0.4"
+    prop-types "^15.6.0"
+    redux "^4.0.0"
+    redux-thunk "^2.3.0"
+    xdate "^0.8.2"
+
 "@appbaseio/reactivemaps@3.0.0-beta.4":
   version "3.0.0-beta.4"
   resolved "https://registry.yarnpkg.com/@appbaseio/reactivemaps/-/reactivemaps-3.0.0-beta.4.tgz#e6a2c2424025fdab670c3bf56c368c7496eb1577"
@@ -179,6 +190,48 @@
     react-google-maps "^9.4.5"
     react-leaflet "^2.1.3"
     rheostat "^2.1.1"
+
+"@appbaseio/reactivesearch@3.7.12":
+  version "3.7.12"
+  resolved "https://registry.yarnpkg.com/@appbaseio/reactivesearch/-/reactivesearch-3.7.12.tgz#28d28abd07a70fce2b68ec037bd3cfffa7128251"
+  integrity sha512-r9WgAIEEY+EhXnQISujzv7/xm45hvZb2TrJ2woc1yq8LZQf80bHniNFJ/pKp+CzENsM7e6OTeWkpBkuHbh29DA==
+  dependencies:
+    "@appbaseio/reactivecore" "9.5.5"
+    appbase-js "4.0.2"
+    cross-env "^5.2.0"
+    downshift "^1.31.2"
+    emotion "^9.0.0"
+    emotion-theming "^9.0.0"
+    hoist-non-react-statics "^3.2.1"
+    polished "^1.9.3"
+    prop-types "^15.6.0"
+    react-day-picker "^7.0.5"
+    react-emotion "^9.0.0"
+    react-redux "^6.0.1"
+    rheostat "^2.1.1"
+    url-search-params-polyfill "^7.0.0"
+    xdate "^0.8.2"
+
+"@appbaseio/reactivesearch@3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@appbaseio/reactivesearch/-/reactivesearch-3.8.0.tgz#cc454e63d828c394b591976649da708eb47d1259"
+  integrity sha512-VyFnbYtooXCEbZzgl+GS+NHoBB7cUZ6HUSHjpD6D2xZXQ9A3uKsFLuFpLMFsRkDGkW/BI129rxNyVgpR5TRQGw==
+  dependencies:
+    "@appbaseio/reactivecore" "9.5.7"
+    appbase-js "^4.0.4"
+    cross-env "^5.2.0"
+    downshift "^1.31.2"
+    emotion "^9.0.0"
+    emotion-theming "^9.0.0"
+    hoist-non-react-statics "^3.2.1"
+    polished "^1.9.3"
+    prop-types "^15.6.0"
+    react-day-picker "^7.0.5"
+    react-emotion "^9.0.0"
+    react-redux "^6.0.1"
+    rheostat "^2.1.1"
+    url-search-params-polyfill "^7.0.0"
+    xdate "^0.8.2"
 
 "@appbaseio/vue-emotion@0.4.4":
   version "0.4.4"
@@ -5468,10 +5521,34 @@ app-root-dir@^1.0.2:
   resolved "https://registry.yarnpkg.com/app-root-dir/-/app-root-dir-1.0.2.tgz#38187ec2dea7577fff033ffcb12172692ff6e118"
   integrity sha1-OBh+wt6nV3//Az/8sSFyaS/24Rg=
 
+appbase-js@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/appbase-js/-/appbase-js-4.0.2.tgz#a2de2ff8ca0f6e3dc14df357533a7b5c452c3e6e"
+  integrity sha512-rLcdjPSHTP42y3NTIlBRyJAFjT3oT516J/loQ/eTojvVUcvSm+40GYD/bPpVgOmGWSXpWMnLxiw82yu5m+nl3Q==
+  dependencies:
+    cross-fetch "^2.2.2"
+    json-stable-stringify "^1.0.1"
+    querystring "^0.2.0"
+    stream "^0.0.2"
+    url-parser-lite "^0.1.0"
+    ws "^6.1.2"
+
 appbase-js@^4.0.2-beta.11, appbase-js@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/appbase-js/-/appbase-js-4.0.4.tgz#ffd8e3afe563cd5f30601efcc32d54e18c6e7828"
   integrity sha512-h4KScox8gwVbpOA1YA9pbjDsZ9qtx8D7YuRcV5VeoVa9oTOMetPGIbzvaUHuDKFuYDuLvQpFrX7FIBtVK+JObQ==
+  dependencies:
+    cross-fetch "^2.2.2"
+    json-stable-stringify "^1.0.1"
+    querystring "^0.2.0"
+    stream "^0.0.2"
+    url-parser-lite "^0.1.0"
+    ws "^6.1.2"
+
+appbase-js@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/appbase-js/-/appbase-js-4.0.5.tgz#715983cde945b825b294e8cf695f420f9352365f"
+  integrity sha512-dMoqNJvsvO/n6vw2ts2bKfsW5IsXnoBpBxIguEEZSWWY8vuHcUFZZli8a5pozQOByULRp+flH+OWFp8c2eIl6g==
   dependencies:
     cross-fetch "^2.2.2"
     json-stable-stringify "^1.0.1"


### PR DESCRIPTION
## Dependent PR
https://github.com/appbaseio/reactivecore/pull/75

## What this PR does?
- allows empty dataField when enableAppbase=true and checks through custom validator

## Test
https://www.loom.com/share/d5b6f21635434f43b112edcef5924202

### Note
Checkout corresponding `reactivecore` branch and run `yarn` before testing
