### PR TITLE
fix(web): mic behavior with autosuggest

### DIFF
--- a/packages/web/src/components/search/CategorySearch.js
+++ b/packages/web/src/components/search/CategorySearch.js
@@ -698,6 +698,7 @@ class CategorySearch extends Component {
 	};
 
 	handleVoiceResults = ({ results }) => {
+		const { autosuggest } = this.props;
 		if (
 			results
 			&& results[0]
@@ -707,8 +708,8 @@ class CategorySearch extends Component {
 			&& results[0][0].transcript.trim()
 		) {
 			this.isPending = false;
-			this.setValue(results[0][0].transcript.trim(), true);
-			if (this.props.autosuggest) {
+			this.setValue(results[0][0].transcript.trim(), !autosuggest);
+			if (autosuggest) {
 				this._inputRef.focus();
 				this.setState({
 					isOpen: true,

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -596,6 +596,7 @@ class DataSearch extends Component {
 	};
 
 	handleVoiceResults = ({ results }) => {
+		const { autosuggest } = this.props;
 		if (
 			results
 			&& results[0]
@@ -605,8 +606,8 @@ class DataSearch extends Component {
 			&& results[0][0].transcript.trim()
 		) {
 			this.isPending = false;
-			this.setValue(results[0][0].transcript.trim(), true);
-			if (this.props.autosuggest) {
+			this.setValue(results[0][0].transcript.trim(), !autosuggest);
+			if (autosuggest) {
 				this._inputRef.focus();
 				this.setState({
 					isOpen: true,


### PR DESCRIPTION
## What this PR does: 

When we have autoSuggest  on and after speech is recognized it triggers the query instead of just updating the input value. Ref: https://www.loom.com/share/8bd61aa247ca4456a6d240b1d2652d52

## Testing:

### DataSearch with autosuggest: 
https://www.loom.com/share/8fee2a52ebf54fef90a4ccfbb830b51b

### DataSearch with autosuggest=false
https://www.loom.com/share/81f8ee79ad8f49d8926a2d1f4019b038

### CategorySearch with autosuggest: 
https://www.loom.com/share/c07f29c62a5948f1abd5035d15dbe1c3

### CategorySearch with autosuggest=false
https://www.loom.com/share/dcadd2e160da45bfb50eef37a264e4a3