### PR TITLE
fix(web): call onChange when clear icon is clicked

### DIFF
--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -499,7 +499,11 @@ class DataSearch extends Component {
 
 	clearValue = () => {
 		this.isPending = false;
+		const { onChange } = this.props;
 		this.setValue('', true);
+		if (onChange) {
+			onChange('', this.triggerQuery);
+		}
 		this.onValueSelected(null, causes.CLEAR_VALUE);
 	};
 


### PR DESCRIPTION
## What this PR do:
If the DataSearch component is controlled with prop showClear and if we click on the clear icon, onChange never gets called.

## Testing:
https://www.loom.com/share/d12c06c079e24940bdfb6304a15d1f9e