### PR TITLE
fix(web): dataField prop in RangeInput.d.ts

### DIFF
--- a/packages/web/src/components/range/RangeInput.d.ts
+++ b/packages/web/src/components/range/RangeInput.d.ts
@@ -4,6 +4,7 @@ import * as types from '../../types';
 
 export interface RangeInputProps extends CommonProps {
 	className?: string;
+	dataField: string;
 	defaultValue?: types.range;
 	value?: types.range;
 	innerClass?: types.style;


### PR DESCRIPTION
fixes #1452 

## Fixes
https://codesandbox.io/s/ecstatic-mccarthy-q9d02?file=/src/App.tsx (error on L22)

## Change
add `dataField` in RangeInput prop