### PR TITLE
perf(vue): avoid redundant queries on mount

### DIFF
--- a/packages/vue/src/components/basic/ReactiveComponent.jsx
+++ b/packages/vue/src/components/basic/ReactiveComponent.jsx
@@ -110,6 +110,7 @@ const ReactiveComponent = {
 		}
 	},
 	mounted() {
+		this.setReact(this.$props); // set query for internal component
 		const propsKeys = getValidPropsKeys(this.$props);
 		this.$watch(propsKeys.join('.'), (newVal, oldVal) => {
 			checkSomePropChange(newVal, oldVal, propsKeys, () => {
@@ -136,8 +137,6 @@ const ReactiveComponent = {
 			this.addComponent(this.internalComponent);
 			this.setComponentProps(this.internalComponent, this.$props, componentTypes.reactiveComponent);
 		}
-
-		this.setReact(this.$props); // set query for internal component
 
 		if (this.internalComponent && this.$props.defaultQuery) {
 			updateDefaultQuery(this.componentId, this.setDefaultQuery, this.$props, undefined);

--- a/packages/vue/src/components/list/MultiDropdownList.jsx
+++ b/packages/vue/src/components/list/MultiDropdownList.jsx
@@ -102,6 +102,7 @@ const MultiDropdownList = {
 		updateDefaultQuery(this.componentId, this.setDefaultQuery, this.$props, this.currentValue);
 	},
 	mounted() {
+		this.setReact(this.$props);
 		const propsKeys = getValidPropsKeys(this.$props);
 		this.$watch(propsKeys.join('.'), (newVal, oldVal) => {
 			checkSomePropChange(newVal, oldVal, propsKeys, () => {
@@ -122,7 +123,6 @@ const MultiDropdownList = {
 		this.addComponent(this.internalComponent);
 		this.addComponent(this.$props.componentId);
 		this.updateQueryOptions(this.$props);
-		this.setReact(this.$props);
 
 		if (this.selectedValue) {
 			this.setValue(this.selectedValue, true);

--- a/packages/vue/src/components/list/MultiList.jsx
+++ b/packages/vue/src/components/list/MultiList.jsx
@@ -102,6 +102,7 @@ const MultiList = {
 		updateDefaultQuery(this.componentId, this.setDefaultQuery, this.$props, this.currentValue);
 	},
 	mounted() {
+		this.setReact(this.$props);
 		const propsKeys = getValidPropsKeys(this.$props);
 		this.$watch(propsKeys.join('.'), (newVal, oldVal) => {
 			checkSomePropChange(newVal, oldVal, propsKeys, () => {
@@ -122,7 +123,6 @@ const MultiList = {
 		this.addComponent(this.internalComponent);
 		this.addComponent(this.$props.componentId);
 		this.updateQueryHandlerOptions(this.$props);
-		this.setReact(this.$props);
 
 		if (this.selectedValue) {
 			this.setValue(this.selectedValue);

--- a/packages/vue/src/components/list/SingleDropdownList.jsx
+++ b/packages/vue/src/components/list/SingleDropdownList.jsx
@@ -100,6 +100,7 @@ const SingleDropdownList = {
 		updateDefaultQuery(this.componentId, this.setDefaultQuery, this.$props, this.currentValue);
 	},
 	mounted() {
+		this.setReact(this.$props);
 		const propsKeys = getValidPropsKeys(this.$props);
 		this.$watch(propsKeys.join('.'), (newVal, oldVal) => {
 			checkSomePropChange(newVal, oldVal, propsKeys, () => {
@@ -120,7 +121,6 @@ const SingleDropdownList = {
 		this.addComponent(this.internalComponent);
 		this.addComponent(this.$props.componentId);
 		this.updateQueryOptions(this.$props);
-		this.setReact(this.$props);
 
 		if (this.selectedValue) {
 			this.setValue(this.selectedValue);

--- a/packages/vue/src/components/list/SingleList.jsx
+++ b/packages/vue/src/components/list/SingleList.jsx
@@ -99,6 +99,7 @@ const SingleList = {
 		updateDefaultQuery(this.componentId, this.setDefaultQuery, this.$props, this.currentValue);
 	},
 	mounted() {
+		this.setReact(this.$props);
 		const propsKeys = getValidPropsKeys(this.$props);
 		this.$watch(propsKeys.join('.'), (newVal, oldVal) => {
 			checkSomePropChange(newVal, oldVal, propsKeys, () => {
@@ -119,7 +120,6 @@ const SingleList = {
 		this.addComponent(this.internalComponent);
 		this.addComponent(this.$props.componentId);
 		this.updateQueryHandlerOptions(this.$props);
-		this.setReact(this.$props);
 
 		if (this.selectedValue) {
 			this.setValue(this.selectedValue);

--- a/packages/vue/src/components/list/ToggleButton.jsx
+++ b/packages/vue/src/components/list/ToggleButton.jsx
@@ -61,7 +61,6 @@ const ToggleButton = {
 			this.handleToggle(this.$data.currentValue, true, props, hasMounted);
 		}
 		this.addComponent(props.componentId);
-		this.setReact(props);
 	},
 	created() {
 		const onQueryChange = (...args) => {
@@ -76,6 +75,7 @@ const ToggleButton = {
 		updateCustomQuery(this.componentId, this.setCustomQuery, this.$props, this.currentValue);
 	},
 	mounted() {
+		this.setReact(this.$props);
 		const propsKeys = getValidPropsKeys(this.$props);
 		this.$watch(propsKeys.join('.'), (newVal, oldVal) => {
 			checkSomePropChange(newVal, oldVal, propsKeys, () => {

--- a/packages/vue/src/components/range/DynamicRangeSlider.jsx
+++ b/packages/vue/src/components/range/DynamicRangeSlider.jsx
@@ -80,10 +80,11 @@ const DynamicRangeSlider = {
 			this.componentId,
 			this.setCustomQuery,
 			this.$props,
-			this.state.currentValue,
+			this.currentValue,
 		);
 	},
 	mounted() {
+		this.setReact();
 		const propsKeys = getValidPropsKeys(this.$props);
 		this.$watch(propsKeys.join('.'), (newVal, oldVal) => {
 			checkSomePropChange(newVal, oldVal, propsKeys, () => {
@@ -111,7 +112,6 @@ const DynamicRangeSlider = {
 
 		// get range before executing other queries
 		this.updateRangeQueryOptions();
-		this.setReact();
 	},
 
 	beforeUpdate() {

--- a/packages/vue/src/components/range/MultiRange.jsx
+++ b/packages/vue/src/components/range/MultiRange.jsx
@@ -175,6 +175,7 @@ const MultiRange = {
 		updateCustomQuery(this.componentId, this.setCustomQuery, this.$props, this.currentValue);
 	},
 	mounted() {
+		this.setReact(this.$props);
 		const propsKeys = getValidPropsKeys(this.$props);
 		this.$watch(propsKeys.join('.'), (newVal, oldVal) => {
 			checkSomePropChange(newVal, oldVal, propsKeys, () => {
@@ -184,7 +185,6 @@ const MultiRange = {
 	},
 	beforeMount() {
 		this.addComponent(this.$props.componentId);
-		this.setReact(this.$props);
 		if (this.selectedValue) {
 			this.selectItem(this.selectedValue, true);
 		} else if (this.$props.value) {

--- a/packages/vue/src/components/range/RangeSlider.jsx
+++ b/packages/vue/src/components/range/RangeSlider.jsx
@@ -180,6 +180,7 @@ const RangeSlider = {
 		updateCustomQuery(this.componentId, this.setCustomQuery, this.$props, this.currentValue);
 	},
 	mounted() {
+		this.setReact(this.$props);
 		const propsKeys = getValidPropsKeys(this.$props);
 		this.$watch(propsKeys.join('.'), (newVal, oldVal) => {
 			checkSomePropChange(newVal, oldVal, propsKeys, () => {
@@ -193,7 +194,6 @@ const RangeSlider = {
 	},
 	beforeMount() {
 		this.addComponent(this.$props.componentId);
-		this.setReact(this.$props);
 
 		const { value, defaultValue } = this.$props;
 		const { selectedValue } = this;

--- a/packages/vue/src/components/range/SingleRange.jsx
+++ b/packages/vue/src/components/range/SingleRange.jsx
@@ -64,6 +64,7 @@ const SingleRange = {
 		updateCustomQuery(this.componentId, this.setCustomQuery, this.$props, this.currentValue);
 	},
 	mounted() {
+		this.setReact(this.$props);
 		const propsKeys = getValidPropsKeys(this.$props);
 		this.$watch(propsKeys.join('.'), (newVal, oldVal) => {
 			checkSomePropChange(newVal, oldVal, propsKeys, () => {
@@ -77,7 +78,6 @@ const SingleRange = {
 	},
 	beforeMount() {
 		this.addComponent(this.$props.componentId);
-		this.setReact(this.$props);
 
 		if (this.selectedValue) {
 			this.setValue(this.selectedValue);

--- a/packages/vue/src/components/search/DataSearch.jsx
+++ b/packages/vue/src/components/search/DataSearch.jsx
@@ -175,8 +175,6 @@ const DataSearch = {
 			this.setQueryOptions(this.$props.componentId, this.queryOptions);
 		}
 
-		this.setReact(this.$props);
-
 		if (this.selectedValue) {
 			this.setValue(this.selectedValue, true);
 		} else if (this.$props.value) {
@@ -186,6 +184,7 @@ const DataSearch = {
 		}
 	},
 	mounted() {
+		this.setReact(this.$props);
 		const propsKeys = getValidPropsKeys(this.$props);
 		this.$watch(propsKeys.join('.'), (newVal, oldVal) => {
 			checkSomePropChange(newVal, oldVal, propsKeys, () => {


### PR DESCRIPTION
## What this PR does?
when there is some default value provided to the component and that component is part of a `react` dependency of some other component, there were two api calls made
1. at the time of load
2. with `value` as `defaultValue`

This PR fixes the same avoiding redundant API calls.

## Test
### Part 1
https://www.loom.com/share/dd1fdb1376ae48fca9adf2b0ba3cb5e1
### Part 2
https://www.loom.com/share/e4b928574a7b4dbd8f0ad984dfc40ac8
