### PR TITLE
fix(vue): querySuggestions value from redux state

### DIFF
--- a/packages/vue/src/components/search/DataSearch.jsx
+++ b/packages/vue/src/components/search/DataSearch.jsx
@@ -108,13 +108,13 @@ const DataSearch = {
 			return withClickIds(suggestionsList);
 		},
 		topSuggestions() {
-			const {
-				enableQuerySuggestions,
-				querySuggestions,
-				showDistinctSuggestions,
-			} = this.$props;
+			const { enableQuerySuggestions, showDistinctSuggestions } = this.$props;
 			return enableQuerySuggestions
-				? getTopSuggestions(querySuggestions, this.currentValue, showDistinctSuggestions)
+				? getTopSuggestions(
+					this.querySuggestions,
+					this.currentValue,
+					showDistinctSuggestions,
+				  )
 				: [];
 		},
 		hasCustomRenderer() {


### PR DESCRIPTION
## What this PR does?
get querySuggestions from redux state instead of props

## Test
https://www.loom.com/share/eb29df47625f484f9ad7d192035338e2