### PR TITLE
fix(web): add type prop to datasearch input

### DIFF
--- a/packages/web/src/components/search/DataSearch.d.ts
+++ b/packages/web/src/components/search/DataSearch.d.ts
@@ -54,6 +54,7 @@ export interface DataSearchProps extends CommonProps {
 	showIcon?: boolean;
 	title?: types.title;
 	theme?: types.style;
+	type?: string;
 	loader?: types.title;
 	themePreset?: types.themePreset;
 	clearIcon?: types.children;

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -852,6 +852,7 @@ class DataSearch extends Component {
 										onKeyUp: this.withTriggerQuery(this.props.onKeyUp),
 									})}
 									themePreset={themePreset}
+									type={this.props.type}
 								/>
 								{this.renderIcons()}
 								{this.hasCustomRenderer
@@ -1031,6 +1032,7 @@ DataSearch.propTypes = {
 	title: types.title,
 	theme: types.style,
 	themePreset: types.themePreset,
+	type: types.string,
 	URLParams: types.bool,
 	strictSelection: types.bool,
 	searchOperators: types.bool,


### PR DESCRIPTION
My proposition is a little change to add the `type` prop to the `Datasearch` component, so we can set the corresponding input attribute.
The value may be set to `type="text"` by default, I can add it if needed, just tell me what you think.

Motivation: I've received a css file which was using the css selector `input[type=text]` but couldn't set it on the `Datasearch` input field.

This is a quick fix for my use case, maybe we should be able to pass a custom input component in a render function, like we can do for items in `Reactivelist`. I find `Datasearch` a bit difficult to customize compared to other components.

- [x] Create a PR to add/update the docs
    - See: https://github.com/appbaseio/Docs/pull/147