### PR TITLE
fix(web): child-selector ssr injection error

### DIFF
--- a/packages/web/src/styles/Button.js
+++ b/packages/web/src/styles/Button.js
@@ -12,7 +12,7 @@ const filters = ({ colors: { borderColor } }) => css`
 		font-size: 0.85rem;
 		position: relative;
 
-		span:first-child {
+		span:first-of-type {
 			max-width: 260px;
 			white-space: nowrap;
 			overflow: hidden;
@@ -20,7 +20,7 @@ const filters = ({ colors: { borderColor } }) => css`
 			margin-right: 26px;
 		}
 
-		span:last-child {
+		span:last-of-type {
 			display: flex;
 			height: 100%;
 			top: 0;
@@ -34,7 +34,7 @@ const filters = ({ colors: { borderColor } }) => css`
 
 		&:hover,
 		&:focus {
-			span:first-child {
+			span:first-of-type {
 				text-decoration: line-through;
 			}
 		}

--- a/packages/web/src/styles/FormControlList.js
+++ b/packages/web/src/styles/FormControlList.js
@@ -89,11 +89,11 @@ const formItem = ({ theme }) => css`
 			justify-content: space-between;
 			line-height: 1.3rem;
 
-			& > span:first-child {
+			& > span:first-of-type {
 				padding-right: 5px;
 			}
 
-			& > span:nth-child(2) {
+			& > span:nth-of-type(2) {
 				color: ${lighten(0.35, theme.colors.textColor)};
 			}
 		}

--- a/packages/web/src/styles/ListItem.js
+++ b/packages/web/src/styles/ListItem.js
@@ -56,7 +56,7 @@ const ListItem = styled('a')`
 			: '#fdfefd')};
 	}
 
-	&:last-child {
+	&:last-of-type {
 		border: 0;
 	}
 


### PR DESCRIPTION
## What does this PR do:

Remove `:nth-child` selectors with `nth-of-type` to suppress emotion ssr error.

## Testing: 
https://www.loom.com/share/6d698bafa60e4cdcb02dc0578c4d53d9