### PR TITLE
fix(vue): logic to build default SingleList filter query #1481

### DIFF
--- a/packages/vue/src/components/list/SingleList.jsx
+++ b/packages/vue/src/components/list/SingleList.jsx
@@ -478,6 +478,11 @@ SingleList.defaultQuery = (value, props) => {
 		};
 	}
 	if (value) {
+		query = {
+			term: {
+				[props.dataField]: value,
+			},
+		};
 		if (props.showMissing && props.missingLabel === value) {
 			query = {
 				bool: {
@@ -487,11 +492,6 @@ SingleList.defaultQuery = (value, props) => {
 				},
 			};
 		}
-		query = {
-			term: {
-				[props.dataField]: value,
-			},
-		};
 	}
 
 	if (query && props.nestedField) {


### PR DESCRIPTION
Fixes https://github.com/appbaseio/reactivesearch/issues/1481
The query that handles the case when the user selects to find items with no value for the filter field gets overwritten by the query that uses the selected term value.

The solution is to create the term query by default, and overwrite it with the missing value query if necessary.