### PR TITLE
fix(vue): currentPage in resultStats slot of reactive-list

### DIFF
--- a/packages/vue/examples/reactive-list-custom-pagination/src/App.vue
+++ b/packages/vue/examples/reactive-list-custom-pagination/src/App.vue
@@ -52,6 +52,7 @@
 					</div>
 					<div class="pagination-wrapper">
 						<paginate
+							:value="resultStats.currentPage + 1"
 							:page-count="resultStats.numberOfPages"
 							:click-handler="(page) => setPage(page-1)"
 							:prev-text="'Prev'"

--- a/packages/vue/src/components/result/ReactiveList.jsx
+++ b/packages/vue/src/components/result/ReactiveList.jsx
@@ -136,11 +136,10 @@ const ReactiveList = {
 			return this.$listeners && this.$listeners.resultStats;
 		},
 		stats() {
-			const { currentPage } = this;
 			const { filteredResults } = this.getAllData();
 			return {
 				...getResultStats(this),
-				currentPage,
+				currentPage: this.$currentPage,
 				displayedResults: filteredResults.length,
 			};
 		},


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

- [ ] Describe the proposed changes and how it'll improve the library experience.
Currently `resultStats.currentPage` in render slot was always returning `0`. This PR helps in fixing this issue and returns the actual page number that is rendered via ReactiveList component

- [ ] Please make sure that there are no linting errors in the code.
- [ ] Add a demo video/gif/screenshot to explain how did you test the fix.
- [ ] If it is a global change, try to add any side effects that it could have.
- [ ] Create a PR to add/update the docs (if needed) at [here](https://github.com/appbaseio/Docs).
- [ ] Create a PR to add/update the storybook (if needed) at [here](https://github.com/appbaseio/playground).

**Learn more about contributing:** [Contributing guides](https://github.com/appbaseio/reactivesearch/blob/next/.github/CONTRIBUTING.md)
