### PR TITLE
feat(vue): add scrollOnChange option to prevent scrolling to top

### DIFF
--- a/packages/vue/src/components/result/ReactiveList.jsx
+++ b/packages/vue/src/components/result/ReactiveList.jsx
@@ -114,7 +114,7 @@ const ReactiveList = {
 		pagination: VueTypes.bool.def(false),
 		paginationAt: types.paginationAt.def('bottom'),
 		react: types.react,
-		scrollOnChange: VueTypes.bool.def(false),
+		scrollOnChange: VueTypes.bool.def(true),
 		showResultStats: VueTypes.bool.def(true),
 		showEndPage: VueTypes.bool.def(false),
 		size: VueTypes.number.def(10),

--- a/packages/vue/src/components/result/ReactiveList.jsx
+++ b/packages/vue/src/components/result/ReactiveList.jsx
@@ -114,6 +114,7 @@ const ReactiveList = {
 		pagination: VueTypes.bool.def(false),
 		paginationAt: types.paginationAt.def('bottom'),
 		react: types.react,
+		scrollOnChange: VueTypes.bool.def(false),
 		showResultStats: VueTypes.bool.def(true),
 		showEndPage: VueTypes.bool.def(false),
 		size: VueTypes.number.def(10),
@@ -275,7 +276,9 @@ const ReactiveList = {
 
 					if (newVal.length < oldVal.length) {
 						// query has changed
-						window.scrollTo(0, 0);
+						if (this.scrollOnChange) {
+							window.scrollTo(0, 0);
+						}
 						this.from = 0;
 					}
 				}

--- a/packages/vue/src/components/result/ReactiveList.jsx
+++ b/packages/vue/src/components/result/ReactiveList.jsx
@@ -266,7 +266,9 @@ const ReactiveList = {
 					if (this.hasPageChangeListener) {
 						this.$emit('pageChange', this.currentPageState + 1, this.totalPages);
 					} else {
-						window.scrollTo(0, 0);
+						if (this.scrollOnChange) {
+							window.scrollTo(0, 0);
+						}
 					}
 					this.isLoading = false;
 				}


### PR DESCRIPTION
When users change the filter options and fewer hits are found than before changing the filter, the page jumps to the top. It should be possible to disable this automatic scrolling behavior. This has been implemented in the React version of the library some time ago (see https://github.com/appbaseio/reactivesearch/issues/528).
