### PR TITLE
fix: use body scrollHeight for inifite scroll

### DIFF
--- a/packages/vue/src/components/result/ReactiveList.jsx
+++ b/packages/vue/src/components/result/ReactiveList.jsx
@@ -525,7 +525,7 @@ const ReactiveList = {
 		scrollHandler() {
 			if (
 				!this.isLoading
-				&& window.innerHeight + window.pageYOffset + 300 >= document.body.offsetHeight
+				&& window.innerHeight + window.pageYOffset + 300 >= document.body.scrollHeight
 			) {
 				this.loadMore();
 			}

--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -511,7 +511,7 @@ class ReactiveList extends Component {
 
 	scrollHandler = () => {
 		let renderLoader
-			= window.innerHeight + window.pageYOffset + 300 >= document.body.offsetHeight;
+			= window.innerHeight + window.pageYOffset + 300 >= document.body.scrollHeight;
 		if (this.props.scrollTarget) {
 			renderLoader
 				= this.domNode.clientHeight + this.domNode.scrollTop + 300


### PR DESCRIPTION
## What was the issue?

When a body / HTML height is set to 100% `document.body.offsetHeight` will not change and will be equal to the visible screen height. As a result the value will always be lesser than the `window.innerHeight + window.pageYOffset` as a result new search queries are made even if the user has not scrolled to bottom

Ref: https://stackoverflow.com/questions/53566405/javascript-offsetheight-not-updating-from-initial-rendered-height/53566852

## Fix

* Use `document.body.scrollHeight` to compare with `window.innerHeight + window.pageYOffset`
https://www.loom.com/share/f82aac699a9e43df873d4287942893a1

**Before submitting a pull request,** please make sure the following is done:

- [x] Describe the proposed changes and how it'll improve the library experience.
- [x] Please make sure that there are no linting errors in the code.
- [x] Add a demo video/gif/screenshot to explain how did you test the fix.
- [ ] If it is a global change, try to add any side effects that it could have.
- [ ] Create a PR to add/update the docs (if needed) at [here](https://github.com/appbaseio/Docs).
- [ ] Create a PR to add/update the storybook (if needed) at [here](https://github.com/appbaseio/playground).

**Learn more about contributing:** [Contributing guides](https://github.com/appbaseio/reactivesearch/blob/next/.github/CONTRIBUTING.md)
