### PR TITLE
fix: web #1555 RangeSlider - inappropriate role for element

### DIFF
--- a/packages/web/src/components/range/addons/SliderHandle.js
+++ b/packages/web/src/components/range/addons/SliderHandle.js
@@ -1,8 +1,13 @@
 import React from 'react';
 
 const SliderHandle = ({
-	// eslint-disable-next-line react/prop-types
-	className, style, tooltipTrigger, renderTooltipData, ...passProps
+	/* eslint-disable react/prop-types */
+	className,
+	style,
+	tooltipTrigger,
+	renderTooltipData,
+	...passProps
+	/* eslint-enable react/prop-types */
 }) => {
 	if (tooltipTrigger) {
 		let tooltipClassname = '';
@@ -19,7 +24,7 @@ const SliderHandle = ({
 			case 'none':
 			default:
 				return (
-					<button
+					<div
 						style={style}
 						aria-label="slider-button"
 						className={className}
@@ -29,14 +34,14 @@ const SliderHandle = ({
 		}
 		const tooltipContent = passProps['aria-valuenow'];
 		return (
-			<button style={style} className={className} aria-label="slider-button" {...passProps}>
+			<div style={style} className={className} aria-label="slider-button" {...passProps}>
 				<span className={tooltipClassname}>
 					{renderTooltipData ? renderTooltipData(tooltipContent) : tooltipContent}
 				</span>
-			</button>
+			</div>
 		);
 	}
-	return <button style={style} className={className} {...passProps} />;
+	return <div style={style} className={className} {...passProps} />;
 };
 
 export default SliderHandle;


### PR DESCRIPTION
Issue Type - Bug (#1555)
Platform - Web
Description - The SliderHandle component used by rheostat returns a button component ARIA role slider which was not allowed, so changed it to div instead.
![Axe Analysis](https://user-images.githubusercontent.com/59804102/104196922-6395b200-544a-11eb-890e-2a5df6e66444.png)
 