### PR TITLE
fix(web): add aria-label to sort options in reactiveList

### DIFF
--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -661,6 +661,7 @@ class ReactiveList extends Component {
 			css={sortOptions}
 			className={getClassName(this.props.innerClass, 'sortOptions')}
 			name="sort-options"
+			aria-label="Sort options"
 			onChange={this.handleSortChange}
 			value={this.sortOptionIndex}
 		>


### PR DESCRIPTION
Issue Type - Bug (#1554)
Platform - Web
Description - The select element by the sortOptions of ReactiveList does not pass Axe accessibility check. It does not have a label.

![Screenshot 2021-01-20 at 5 06 48 PM](https://user-images.githubusercontent.com/59804102/105174936-45fed180-5b49-11eb-9456-9c2d7da02664.png)

Please Note - The contrast issue for the select element from Axe is shown because it can't determine the contrast ratio for the element, this might be an issue with Axe.

https://www.loom.com/share/32ed93ae04ec48e7a2d47168e678acf0
