### PR TITLE
refactor(vue index file): remove unused import

### DIFF
--- a/packages/vue/src/index.js
+++ b/packages/vue/src/index.js
@@ -1,7 +1,3 @@
-// Add polyfills to support in IE
-// eslint-disable-next-line
-import { polyfills } from '@appbaseio/reactivecore';
-
 import ReactiveList from './components/result/ReactiveList.jsx';
 import ReactiveBase from './components/ReactiveBase/index.jsx';
 import DataSearch from './components/search/DataSearch.jsx';


### PR DESCRIPTION
**Issue type:** Refactor
**Platform:** Vue
**Description:** Clean up linter warning by removing unused import. That is not only unused, but also commented out using ESLint, to have a cleaner console when running the Vue application.

**Linter warning**
```
[WEB] [build.cjsWatch] (!) Unused external imports
[WEB] [build.cjsWatch] polyfills imported from external module '@appbaseio/reactivecore' but never used
```

**Before console**
![image](https://user-images.githubusercontent.com/8817968/105517834-d23eff00-5cd7-11eb-939e-10f27cea5010.png)

**After console**
![image](https://user-images.githubusercontent.com/8817968/105517808-cb17f100-5cd7-11eb-8d6f-27c3739dcc43.png)

**Loom video**
Video shows you that the console is clean when removing the import. And also shows you that the application is still working when removing that specific line, and no errors are shown.
https://www.loom.com/share/660779d47ad946c986877b4376cfa57a
