### PR TITLE
feat(vue): add renderNoResults support for List components

### DIFF
--- a/packages/vue/src/components/list/MultiDropdownList.jsx
+++ b/packages/vue/src/components/list/MultiDropdownList.jsx
@@ -66,6 +66,7 @@ const MultiDropdownList = {
 		render: types.func,
 		renderItem: types.func,
 		renderError: types.title,
+		renderNoResults: VueTypes.any,
 		transformData: types.func,
 		selectAllLabel: types.string,
 		showCount: VueTypes.bool.def(true),
@@ -220,6 +221,7 @@ const MultiDropdownList = {
 					showCount={this.$props.showCount}
 					themePreset={this.themePreset}
 					renderItem={renderItemCalc}
+					renderNoResults={this.$scopedSlots.renderNoResults || this.$props.renderNoResults}
 					showSearch={this.$props.showSearch}
 					transformData={this.$props.transformData}
 					footer={

--- a/packages/vue/src/components/list/MultiList.jsx
+++ b/packages/vue/src/components/list/MultiList.jsx
@@ -48,6 +48,7 @@ const MultiList = {
 		render: types.func,
 		renderItem: types.func,
 		renderError: types.title,
+		renderNoResults: VueTypes.any,
 		transformData: types.func,
 		selectAllLabel: types.string,
 		showCount: VueTypes.bool.def(true),
@@ -160,6 +161,19 @@ const MultiList = {
 		if (this.$props.transformData) {
 			itemsToRender = this.$props.transformData(itemsToRender);
 		}
+
+		var filteredItemsToRender = itemsToRender.filter(item => {
+			if (String(item.key).length) {
+				if (this.$props.showSearch && this.$data.searchTerm) {
+					return String(item.key)
+						.toLowerCase()
+						.includes(this.$data.searchTerm.toLowerCase());
+					}
+					return true;
+				}
+				return false;
+			});
+
 		return (
 			<Container class={this.$props.className}>
 				{this.$props.title && (
@@ -199,21 +213,9 @@ const MultiList = {
 								</label>
 							</li>
 						) : null}
-						{itemsToRender
-							.filter(item => {
-								if (String(item.key).length) {
-									if (this.$props.showSearch && this.$data.searchTerm) {
-										return String(item.key)
-											.toLowerCase()
-											.includes(this.$data.searchTerm.toLowerCase());
-									}
-
-									return true;
-								}
-
-								return false;
-							})
-							.map(item => (
+						{(!this.hasCustomRenderer && filteredItemsToRender.length === 0
+						&& !this.isLoading ) ? this.renderNoResult() :
+						filteredItemsToRender.map(item => (
 								<li
 									key={item.key}
 									class={`${this.$data.currentValue[item.key] ? 'active' : ''}`}
@@ -450,6 +452,16 @@ const MultiList = {
 				handleChange: this.handleClick,
 			};
 			return getComponent(data, this);
+		},
+
+		renderNoResult() {
+			const renderNoResults
+				= this.$scopedSlots.renderNoResults || this.$props.renderNoResults;
+			return (
+				<p class={getClassName(this.$props.innerClass, 'noResults') || null}>
+					{isFunction(renderNoResults) ? renderNoResults() : renderNoResults}
+				</p>
+			);
 		},
 	},
 	computed: {

--- a/packages/vue/src/components/list/SingleDropdownList.jsx
+++ b/packages/vue/src/components/list/SingleDropdownList.jsx
@@ -64,6 +64,7 @@ const SingleDropdownList = {
 		render: types.func,
 		renderItem: types.func,
 		renderError: types.title,
+		renderNoResults: VueTypes.any,
 		transformData: types.func,
 		selectAllLabel: types.string,
 		showCount: VueTypes.bool.def(true),
@@ -209,6 +210,7 @@ const SingleDropdownList = {
 					hasCustomRenderer={this.hasCustomRenderer}
 					customRenderer={this.getComponent}
 					renderItem={renderItemCalc}
+					renderNoResults={this.$scopedSlots.renderNoResults || this.$props.renderNoResults}
 					themePreset={this.themePreset}
 					showSearch={this.$props.showSearch}
 					transformData={this.$props.transformData}

--- a/packages/vue/src/components/list/SingleList.jsx
+++ b/packages/vue/src/components/list/SingleList.jsx
@@ -39,6 +39,7 @@ const SingleList = {
 		react: types.react,
 		render: types.func,
 		renderItem: types.func,
+		renderNoResults: VueTypes.any,
 		transformData: types.func,
 		selectAllLabel: types.string,
 		showCount: VueTypes.bool.def(true),
@@ -123,7 +124,7 @@ const SingleList = {
 		},
 	},
 	render() {
-		const { selectAllLabel, renderItem, renderError } = this.$props;
+		const { selectAllLabel, renderItem, renderError, renderNoResults } = this.$props;
 		const renderItemCalc = this.$scopedSlots.renderItem || renderItem;
 		const renderErrorCalc = this.$scopedSlots.renderError || renderError;
 
@@ -139,6 +140,18 @@ const SingleList = {
 		if (this.$props.transformData) {
 			itemsToRender = this.$props.transformData(itemsToRender);
 		}
+
+		var filteredItemsToRender = itemsToRender.filter(item => {
+			if (String(item.key).length) {
+				if (this.$props.showSearch && this.$data.searchTerm) {
+					return String(item.key)
+						.toLowerCase()
+						.includes(this.$data.searchTerm.toLowerCase());
+					}
+					return true;
+				}
+				return false;
+			});
 
 		return (
 			<Container class={this.$props.className}>
@@ -181,20 +194,9 @@ const SingleList = {
 								</label>
 							</li>
 						) : null}
-						{itemsToRender
-							.filter(item => {
-								if (String(item.key).length) {
-									if (this.$props.showSearch && this.$data.searchTerm) {
-										return String(item.key)
-											.toLowerCase()
-											.includes(this.$data.searchTerm.toLowerCase());
-									}
-
-									return true;
-								}
-
-								return false;
-							})
+						{(!this.hasCustomRenderer && filteredItemsToRender.length === 0
+						&& !this.isLoading ) ? this.renderNoResult() :
+						filteredItemsToRender
 							.map(item => (
 								<li
 									key={item.key}
@@ -387,6 +389,16 @@ const SingleList = {
 			} else {
 				this.$emit('change', currentValue);
 			}
+		},
+
+		renderNoResult() {
+			const renderNoResults
+				= this.$scopedSlots.renderNoResults || this.$props.renderNoResults;
+			return (
+				<p class={getClassName(this.$props.innerClass, 'noResults') || null}>
+					{isFunction(renderNoResults) ? renderNoResults() : renderNoResults}
+				</p>
+			);
 		},
 	},
 	computed: {


### PR DESCRIPTION
#1592 
Issue Type:

- Enhancement

Platform:

- Vue

Description:

renderNoResults slot added in List components for displaying customs message when the list is empty. We can either pass an HTML element in the renderNoResults slot or pass a function that returns the custom message as the renderNoResults prop in the List components - 

1. SingleList
2. SingleDropdownList
3. MultiList
4. MultiDropdownList



https://www.loom.com/share/6c4d9a90c095412caea897306bd72e45