### PR TITLE
fix(vue): array values from URL parameters

### DIFF
--- a/packages/vue/src/components/list/MultiList.jsx
+++ b/packages/vue/src/components/list/MultiList.jsx
@@ -309,9 +309,15 @@ const MultiList = {
 					currentValue = {
 						...rest,
 					};
+
 				} else {
-					currentValue[value] = true;
+					if (Array.isArray(value)) {
+						value.forEach( val => currentValue[val] = true );
+					} else {
+						currentValue[value] = true;
+					}
 				}
+
 				if (selectAllLabel && selectAllLabel in currentValue) {
 					const { [selectAllLabel]: del, ...obj } = currentValue;
 					currentValue = {


### PR DESCRIPTION
When using a MultiList, URLParams and an array in the URL it will convert the array to a string
For example:
["Jacket", "Hooded"] will be converted to ["Jacket,Hooded"]