### PR TITLE
Add customQuery to the DateRangeProps

### DIFF
--- a/packages/web/src/components/date/DateRange.d.ts
+++ b/packages/web/src/components/date/DateRange.d.ts
@@ -5,6 +5,7 @@ import * as types from '../../types';
 export interface DateRangeProps extends CommonProps {
 	autoFocusEnd?: boolean;
 	dataField: string;
+	customQuery?: (...args: any[]) => any;
 	dayPickerInputProps?: types.props;
 	defaultValue?: types.dateObject;
 	value?: types.dateObject;


### PR DESCRIPTION
The `customQuery` appears to be present in the DateRange component, as seen in the link below, but it is not in the props. This means anyone using Typescript will have errors about using `customQuery` when also using DateRange.

https://github.com/appbaseio/reactivesearch/blob/next/packages/web/src/components/date/DateRange.js#L344

The fix was a copy-paste from the existing DataSearch .d.ts file, and pasting it in the DateRange.d.ts file.