### PR TITLE
Prevent showLoadMore from causing setState error

### DIFF
--- a/packages/web/src/components/list/MultiList.js
+++ b/packages/web/src/components/list/MultiList.js
@@ -73,9 +73,9 @@ class MultiList extends Component {
 		updateCustomQuery(props.componentId, props, currentValueArray);
 		updateDefaultQuery(props.componentId, props, currentValueArray);
 
-		this.updateQueryOptions(props);
-
 		const hasMounted = false;
+
+		this.updateQueryOptions(props, false, hasMounted);
 
 		if (currentValueArray.length) {
 			this.setValue(currentValueArray, true, props, hasMounted);
@@ -389,12 +389,19 @@ class MultiList extends Component {
 			: getAggsQuery(valueArray, queryOptions, props);
 	}
 
-	updateQueryOptions = (props, addAfterKey = false) => {
+	updateQueryOptions = (props, addAfterKey = false, hasMounted = true) => {
 		// when using composite aggs flush the current options for a fresh query
 		if (props.showLoadMore && !addAfterKey) {
-			this.setState({
-				options: [],
-			});
+			if (hasMounted) {
+				this.setState({
+					options: [],
+				});
+			} else {
+				this.state = { 
+					...this.state || {},
+					options: [],
+				};
+			}
 		}
 		// for a new query due to other changes don't append after to get fresh results
 		const queryOptions = MultiList.generateQueryOptions(


### PR DESCRIPTION
- Mimic the setValue signature by adding a `hasMounted = true` as a parameter at the end of updateQueryOptions
- When checking `props.showLoadMore`, respond to whether or not the component has mounted by re-assigning state
- Update the constructor to use the new parameter for updateQueryOptions

Result: using `showLoadMore` on MultiList should no longer throw `setState` errors.

This shouldn't have linting errors, as I have mimicked all of the code style to match the file, but I can't get the lint script to run without errors flooding my console that do not pertain to the code I have changed.