### PR TITLE
Patch 3

### DIFF
--- a/packages/web/src/components/search/CategorySearch.js
+++ b/packages/web/src/components/search/CategorySearch.js
@@ -568,13 +568,14 @@ class CategorySearch extends Component {
 			updateCustomQuery(props.componentId, props, value);
 		}
 
-		// query options should be applied to the source component,
-		// not on internal component, hence using `this.props.componentId` here
-		props.setQueryOptions(props.componentId, {
-			...this.queryOptions,
-			...customQueryOptions,
-		});
 		if (!this.isPending) {
+			// execute the query on an uncontrolled component
+      // query options should be applied to the source component,
+      // not on internal component, hence using `this.props.componentId` here
+      props.setQueryOptions(props.componentId, {
+        ...this.queryOptions,
+        ...customQueryOptions,
+      });
 			props.updateQuery({
 				componentId: props.componentId,
 				query,

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -510,10 +510,20 @@ class DataSearch extends Component {
 
 		// query options should be applied to the source component,
 		// not on internal component, hence using `this.props.componentId` here
-		props.setQueryOptions(props.componentId, {
-			...this.queryOptions,
-			...customQueryOptions,
-		});
+		if ('value' in props) {
+			// do NOT execute a query if the component is controlled. That's the user's responsibility.
+			props.setQueryOptionsNoExecute(props.componentId, {
+				...this.queryOptions,
+				...customQueryOptions,
+			});
+		} else {
+			// execute the query on an uncontrolled component
+			props.setQueryOptions(props.componentId, {
+				...this.queryOptions,
+				...customQueryOptions,
+			});
+		}
+
 		if (!this.isPending) {
 			props.updateQuery({
 				componentId: props.componentId,
@@ -1217,6 +1227,7 @@ const mapDispatchtoProps = dispatch => ({
 	setDefaultQuery: (component, query) => dispatch(setDefaultQuery(component, query)),
 	setSuggestionsSearchValue: value => dispatch(setSuggestionsSearchValue(value)),
 	setQueryOptions: (component, props) => dispatch(setQueryOptions(component, props)),
+	setQueryOptionsNoExecute: (component, props) => dispatch(setQueryOptions(component, props)),
 	updateQuery: updateQueryObject => dispatch(updateQuery(updateQueryObject)),
 	triggerAnalytics: (searchPosition, documentId) =>
 		dispatch(recordSuggestionClick(searchPosition, documentId)),

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -1218,7 +1218,6 @@ const mapDispatchtoProps = dispatch => ({
 	setDefaultQuery: (component, query) => dispatch(setDefaultQuery(component, query)),
 	setSuggestionsSearchValue: value => dispatch(setSuggestionsSearchValue(value)),
 	setQueryOptions: (component, props) => dispatch(setQueryOptions(component, props)),
-	setQueryOptionsNoExecute: (component, props) => dispatch(setQueryOptions(component, props, false)),
 	updateQuery: updateQueryObject => dispatch(updateQuery(updateQueryObject)),
 	triggerAnalytics: (searchPosition, documentId) =>
 		dispatch(recordSuggestionClick(searchPosition, documentId)),

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -1227,7 +1227,7 @@ const mapDispatchtoProps = dispatch => ({
 	setDefaultQuery: (component, query) => dispatch(setDefaultQuery(component, query)),
 	setSuggestionsSearchValue: value => dispatch(setSuggestionsSearchValue(value)),
 	setQueryOptions: (component, props) => dispatch(setQueryOptions(component, props)),
-	setQueryOptionsNoExecute: (component, props) => dispatch(setQueryOptions(component, props)),
+	setQueryOptionsNoExecute: (component, props) => dispatch(setQueryOptions(component, props, false)),
 	updateQuery: updateQueryObject => dispatch(updateQuery(updateQueryObject)),
 	triggerAnalytics: (searchPosition, documentId) =>
 		dispatch(recordSuggestionClick(searchPosition, documentId)),

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -508,23 +508,14 @@ class DataSearch extends Component {
 			updateCustomQuery(props.componentId, props, value);
 		}
 
-		// query options should be applied to the source component,
-		// not on internal component, hence using `this.props.componentId` here
-		if ('value' in props) {
-			// do NOT execute a query if the component is controlled. That's the user's responsibility.
-			props.setQueryOptionsNoExecute(props.componentId, {
-				...this.queryOptions,
-				...customQueryOptions,
-			});
-		} else {
+		if (!this.isPending) {
 			// execute the query on an uncontrolled component
+      // query options should be applied to the source component,
+      // not on internal component, hence using `this.props.componentId` here
 			props.setQueryOptions(props.componentId, {
 				...this.queryOptions,
 				...customQueryOptions,
 			});
-		}
-
-		if (!this.isPending) {
 			props.updateQuery({
 				componentId: props.componentId,
 				query,


### PR DESCRIPTION
Okay, so I found a really edge-case bug that was causing an extremely frustrating user experience in our app (OnTopical).

If `componentDidUpdate` gets called, and `value` is set, the call to the store to execute the search query is called regardless of it being the user's responsibility. In our experience, this only happens the first time that the DataSearch component is loaded, and never again.

Call stack issues are:
`this.setValue` leads to line 423, where `this.updateQuery` is called
`this.updateQuery` erroneously dispatches a `props.setQueryOptions` without passing the `execute = false` argument (third argument, [see this](https://github.com/appbaseio/reactivecore/blob/master/src/actions/query.js#L510)).

I am not certain there are no linting errors, but I have done what I can to ensure code-style consistency. To test the fix, I had to manually change the code in my node_modules, slowly following along to find what happened. I noticed that every single time the `setQueryOptions` connection to the props gets called, it _also_ executed the query when the expected behavior is not to.

The storybook / docs are unnecessary, as this amendment simply guarantees what the docs assert.
