### PR TITLE
fix(vue): updated reactive-component-with-custom-query example

### DIFF
--- a/packages/vue/examples/reactive-component-with-custom-query/src/App.vue
+++ b/packages/vue/examples/reactive-component-with-custom-query/src/App.vue
@@ -15,12 +15,6 @@
 						<CustomComponent :aggregations="aggregations" :setQuery="setQuery" />
 					</div>
 				</ReactiveComponent>
-				<DynamicRangeSlider
-					componentId="Pricing"
-					dataField="price"
-					tooltipTrigger="hover"
-					:react="{ and: 'CarSensor' }"
-				/>
 			</div>
 
 			<div class="col">
@@ -32,7 +26,7 @@
 					:size="20"
 					:pagination="true"
 					:react="{
-						and: ['CarSensor', 'Pricing'],
+						and: ['CarSensor'],
 					}"
 				>
 					<div slot="renderItem" slot-scope="{ item }">


### PR DESCRIPTION
Removed DynamicRangeSlider component from vue reactive-component-with-custom-query example