### PR TITLE
fix(web & vue): url-params-provider removes all params from the url

### DIFF
--- a/packages/vue/src/components/URLParamsProvider.jsx
+++ b/packages/vue/src/components/URLParamsProvider.jsx
@@ -106,7 +106,9 @@ const URLParamsProvider = {
 
 				if (!currentComponents.length) {
 					Array.from(this.params.keys()).forEach(item => {
-						this.params.delete(item);
+						if(this.searchComponents.includes(item)) {
+							this.params.delete(item);
+						}
 					});
 					this.pushToHistory();
 				}
@@ -211,6 +213,7 @@ const URLParamsProvider = {
 
 const mapStateToProps = state => ({
 	selectedValues: state.selectedValues,
+	searchComponents: state.components,
 });
 
 const mapDispatchtoProps = {

--- a/packages/vue/src/components/URLParamsProvider.jsx
+++ b/packages/vue/src/components/URLParamsProvider.jsx
@@ -106,7 +106,7 @@ const URLParamsProvider = {
 
 				if (!currentComponents.length) {
 					Array.from(this.params.keys()).forEach(item => {
-						if(this.searchComponents.includes(item)) {
+						if(this.searchComponents && this.searchComponents.includes(item)) {
 							this.params.delete(item);
 						}
 					});

--- a/packages/web/src/components/basic/URLParamsProvider.js
+++ b/packages/web/src/components/basic/URLParamsProvider.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { setHeaders, setValue } from '@appbaseio/reactivecore/lib/actions';
 import types from '@appbaseio/reactivecore/lib/utils/types';
 import { isEqual } from '@appbaseio/reactivecore/lib/utils/helper';
@@ -108,7 +109,9 @@ class URLParamsProvider extends Component {
 
 			if (!currentComponents.length) {
 				Array.from(this.params.keys()).forEach((item) => {
-					this.params.delete(item);
+					if (this.props.searchComponents.includes(item)) {
+						this.params.delete(item);
+					}
 				});
 				this.pushToHistory();
 			}
@@ -216,6 +219,7 @@ URLParamsProvider.propTypes = {
 	setHeaders: types.func,
 	setValue: types.func,
 	selectedValues: types.selectedValues,
+	searchComponents: PropTypes.arrayOf(String),
 	// component props
 	children: types.children,
 	as: types.string,
@@ -234,6 +238,7 @@ URLParamsProvider.defaultProps = {
 
 const mapStateToProps = state => ({
 	selectedValues: state.selectedValues,
+	searchComponents: state.components,
 });
 
 const mapDispatchtoProps = dispatch => ({

--- a/packages/web/src/components/basic/URLParamsProvider.js
+++ b/packages/web/src/components/basic/URLParamsProvider.js
@@ -108,8 +108,9 @@ class URLParamsProvider extends Component {
 				});
 
 			if (!currentComponents.length) {
+				const { searchComponents } = this.props;
 				Array.from(this.params.keys()).forEach((item) => {
-					if (this.props.searchComponents.includes(item)) {
+					if (searchComponents && searchComponents.includes(item)) {
 						this.params.delete(item);
 					}
 				});


### PR DESCRIPTION
- Issue Type - Bug (#1615)

- Description - Currently the URLParamsProvider component removes all query parameters from the URL by clicking the Clear All button in the SelectedFilters irrespective of whether the query was set by a ReactiveSearch component or not. The fix was to add a check whether the query key matches any ReactiveSearch components Id before deleting it from the params in the URLParamsProvider component inside web and vue.

https://www.loom.com/share/9f60d3103a014c18920718ed5fb7f790