### PR TITLE
Change prev & next with an arrow

### DIFF
--- a/packages/vue/src/components/result/addons/Pagination.jsx
+++ b/packages/vue/src/components/result/addons/Pagination.jsx
@@ -108,7 +108,7 @@ const Pagination = {
 					onClick={onPrevPage}
 					tabIndex="0"
 				>
-					Prev
+					<
 				</Button>
 				{
 					<Button
@@ -139,7 +139,7 @@ const Pagination = {
 					onClick={onNextPage}
 					tabIndex="0"
 				>
-					Next
+					>
 				</Button>
 			</div>
 		);


### PR DESCRIPTION
Because of the text not being translatable there is an issue with translations. This will eliminate the need to translate the text and makes the buttons internationally known.
