### PR TITLE
fix(web): name attribute changed to displayName for functional components

### DIFF
--- a/packages/web/src/components/basic/NumberBox.js
+++ b/packages/web/src/components/basic/NumberBox.js
@@ -270,5 +270,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 
 hoistNonReactStatics(ForwardRefComponent, NumberBox);
 
-ForwardRefComponent.name = 'NumberBox';
+ForwardRefComponent.displayName = 'NumberBox';
 export default ForwardRefComponent;

--- a/packages/web/src/components/basic/ReactiveComponent.js
+++ b/packages/web/src/components/basic/ReactiveComponent.js
@@ -362,5 +362,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 	<ConnectedComponent {...props} myForwardedRef={ref} />
 ));
 
-ForwardRefComponent.name = 'ReactiveComponent';
+ForwardRefComponent.displayName = 'ReactiveComponent';
 export default ForwardRefComponent;

--- a/packages/web/src/components/date/DatePicker.js
+++ b/packages/web/src/components/date/DatePicker.js
@@ -314,5 +314,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, DatePicker);
 
-ForwardRefComponent.name = 'DatePicker';
+ForwardRefComponent.displayName = 'DatePicker';
 export default ForwardRefComponent;

--- a/packages/web/src/components/date/DateRange.js
+++ b/packages/web/src/components/date/DateRange.js
@@ -571,5 +571,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, DateRange);
 
-ForwardRefComponent.name = 'DateRange';
+ForwardRefComponent.displayName = 'DateRange';
 export default ForwardRefComponent;

--- a/packages/web/src/components/list/MultiDataList.js
+++ b/packages/web/src/components/list/MultiDataList.js
@@ -618,5 +618,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, MultiDataList);
 
-ForwardRefComponent.name = 'MultiDataList';
+ForwardRefComponent.displayName = 'MultiDataList';
 export default ForwardRefComponent;

--- a/packages/web/src/components/list/MultiDropdownList.js
+++ b/packages/web/src/components/list/MultiDropdownList.js
@@ -608,5 +608,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, MultiDropdownList);
 
-ForwardRefComponent.name = 'MultiDropdownList';
+ForwardRefComponent.displayName = 'MultiDropdownList';
 export default ForwardRefComponent;

--- a/packages/web/src/components/list/MultiList.js
+++ b/packages/web/src/components/list/MultiList.js
@@ -397,7 +397,7 @@ class MultiList extends Component {
 					options: [],
 				});
 			} else {
-				this.state = { 
+				this.state = {
 					...this.state || {},
 					options: [],
 				};
@@ -757,5 +757,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, MultiList);
 
-ForwardRefComponent.name = 'MultiList';
+ForwardRefComponent.displayName = 'MultiList';
 export default ForwardRefComponent;

--- a/packages/web/src/components/list/SingleDataList.js
+++ b/packages/web/src/components/list/SingleDataList.js
@@ -529,5 +529,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, SingleDataList);
 
-ForwardRefComponent.name = 'SingleDataList';
+ForwardRefComponent.displayName = 'SingleDataList';
 export default ForwardRefComponent;

--- a/packages/web/src/components/list/SingleDropdownList.js
+++ b/packages/web/src/components/list/SingleDropdownList.js
@@ -494,5 +494,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, SingleDropdownList);
 
-ForwardRefComponent.name = 'SingleDropdownList';
+ForwardRefComponent.displayName = 'SingleDropdownList';
 export default ForwardRefComponent;

--- a/packages/web/src/components/list/SingleList.js
+++ b/packages/web/src/components/list/SingleList.js
@@ -624,5 +624,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, SingleList);
 
-ForwardRefComponent.name = 'SingleList';
+ForwardRefComponent.displayName = 'SingleList';
 export default ForwardRefComponent;

--- a/packages/web/src/components/list/TagCloud.js
+++ b/packages/web/src/components/list/TagCloud.js
@@ -394,5 +394,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 
 hoistNonReactStatics(ForwardRefComponent, TagCloud);
 
-ForwardRefComponent.name = 'TagCloud';
+ForwardRefComponent.displayName = 'TagCloud';
 export default ForwardRefComponent;

--- a/packages/web/src/components/list/ToggleButton.js
+++ b/packages/web/src/components/list/ToggleButton.js
@@ -315,5 +315,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, ToggleButton);
 
-ForwardRefComponent.name = 'ToggleButton';
+ForwardRefComponent.displayName = 'ToggleButton';
 export default ForwardRefComponent;

--- a/packages/web/src/components/range/DynamicRangeSlider.js
+++ b/packages/web/src/components/range/DynamicRangeSlider.js
@@ -677,5 +677,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, DynamicRangeSlider);
 
-ForwardRefComponent.name = 'DynamicRangeSlider';
+ForwardRefComponent.displayName = 'DynamicRangeSlider';
 export default ForwardRefComponent;

--- a/packages/web/src/components/range/MultiDropdownRange.js
+++ b/packages/web/src/components/range/MultiDropdownRange.js
@@ -298,5 +298,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, MultiDropdownRange);
 
-ForwardRefComponent.name = 'MultiDropdownRange';
+ForwardRefComponent.displayName = 'MultiDropdownRange';
 export default ForwardRefComponent;

--- a/packages/web/src/components/range/MultiRange.js
+++ b/packages/web/src/components/range/MultiRange.js
@@ -329,5 +329,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, MultiRange);
 
-ForwardRefComponent.name = 'MultiRange';
+ForwardRefComponent.displayName = 'MultiRange';
 export default ForwardRefComponent;

--- a/packages/web/src/components/range/RangeInput.js
+++ b/packages/web/src/components/range/RangeInput.js
@@ -234,5 +234,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, RangeInput);
 
-ForwardRefComponent.name = 'RangeInput';
+ForwardRefComponent.displayName = 'RangeInput';
 export default ForwardRefComponent;

--- a/packages/web/src/components/range/RangeSlider.js
+++ b/packages/web/src/components/range/RangeSlider.js
@@ -472,5 +472,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, RangeSlider);
 
-ForwardRefComponent.name = 'RangeSlider';
+ForwardRefComponent.displayName = 'RangeSlider';
 export default ForwardRefComponent;

--- a/packages/web/src/components/range/RatingsFilter.js
+++ b/packages/web/src/components/range/RatingsFilter.js
@@ -279,5 +279,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, RatingsFilter);
 
-ForwardRefComponent.name = 'RatingsFilter';
+ForwardRefComponent.displayName = 'RatingsFilter';
 export default ForwardRefComponent;

--- a/packages/web/src/components/range/SingleDropdownRange.js
+++ b/packages/web/src/components/range/SingleDropdownRange.js
@@ -244,5 +244,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, SingleDropdownRange);
 
-ForwardRefComponent.name = 'SingleDropdownRange';
+ForwardRefComponent.displayName = 'SingleDropdownRange';
 export default ForwardRefComponent;

--- a/packages/web/src/components/range/SingleRange.js
+++ b/packages/web/src/components/range/SingleRange.js
@@ -258,5 +258,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, SingleRange);
 
-ForwardRefComponent.name = 'SingleRange';
+ForwardRefComponent.displayName = 'SingleRange';
 export default ForwardRefComponent;

--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -999,5 +999,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, ReactiveList);
 
-ForwardRefComponent.name = 'ReactiveList';
+ForwardRefComponent.displayName = 'ReactiveList';
 export default ForwardRefComponent;

--- a/packages/web/src/components/search/CategorySearch.js
+++ b/packages/web/src/components/search/CategorySearch.js
@@ -1520,5 +1520,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, CategorySearch);
 
-ForwardRefComponent.name = 'CategorySearch';
+ForwardRefComponent.displayName = 'CategorySearch';
 export default ForwardRefComponent;

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -1385,5 +1385,5 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 ));
 hoistNonReactStatics(ForwardRefComponent, DataSearch);
 
-ForwardRefComponent.name = 'DataSearch';
+ForwardRefComponent.displayName = 'DataSearch';
 export default ForwardRefComponent;


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

- [x] Describe the proposed changes and how it'll improve the library experience.

Changed the `name` attribute to `displayName` for the following functional components, while assigning it to the ForwardRefComponents - `NumberBox`, `ReactiveComponent`, `DatePicker`, `DateRange`, `MultiDataList`, `MultiDropdownList`, `MultiList`, `SingleDataList`, `SingleDropdownList`, `SingleList`, `TagCloud`, `ToggleButton`,`DynamicRangeSlider`, `MultiDropdownRange`, `MultiRange`, `Range Input`, `RangeSlider`,
`RatingsFilter`, `SingleDropdownRange`, `SingleRange`, `ReactiveList`, `CategorySearch` & `DataSearch`.

Look into this issue for further reference - https://github.com/appbaseio/reactivesearch/issues/1614

- [x] Please make sure that there are no linting errors in the code.
- [x] Add a demo video/gif/screenshot to explain how did you test the fix.
https://www.loom.com/share/b47f9643b5e14dbd8b122e11108824c6

- [ ] If it is a global change, try to add any side effects that it could have.
- [ ] Create a PR to add/update the docs (if needed) at [here](https://github.com/appbaseio/Docs).
- [ ] Create a PR to add/update the storybook (if needed) at [here](https://github.com/appbaseio/playground).

**Learn more about contributing:** [Contributing guides](https://github.com/appbaseio/reactivesearch/blob/next/.github/CONTRIBUTING.md)
