### PR TITLE
Fix/toggle button

### DIFF
--- a/packages/vue/src/components/list/ToggleButton.jsx
+++ b/packages/vue/src/components/list/ToggleButton.jsx
@@ -174,7 +174,6 @@ const ToggleButton = {
 		},
 
 		handleClick(item) {
-			console.log('handleClick called ==>> ', item);
 			const { value } = this.$props;
 			if (value === undefined) {
 				this.handleToggle(item);

--- a/packages/vue/src/components/list/ToggleButton.jsx
+++ b/packages/vue/src/components/list/ToggleButton.jsx
@@ -174,6 +174,7 @@ const ToggleButton = {
 		},
 
 		handleClick(item) {
+			console.log('handleClick called ==>> ', item);
 			const { value } = this.$props;
 			if (value === undefined) {
 				this.handleToggle(item);
@@ -186,7 +187,7 @@ const ToggleButton = {
 			const renderItem = this.$scopedSlots.renderItem || this.renderItem;
 			const isSelected = this.$data.currentValue.some(value => value.value === item.value);
 
-			return (
+			return renderItem ? renderItem({ item, isSelected, handleClick: () => this.handleClick(item) }) : (
 				<Button
 					class={`${getClassName(this.$props.innerClass, 'button')} ${
 						isSelected ? 'active' : ''
@@ -198,9 +199,9 @@ const ToggleButton = {
 					tabIndex={isSelected ? '-1' : '0'}
 					onKeypress={e => handleA11yAction(e, () => this.handleClick(item))}
 				>
-					{renderItem ? renderItem({ item, isSelected }) : item.label}
+					{item.label}
 				</Button>
-			);
+			)
 		},
 	},
 


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

- [x] Describe the proposed changes and how it'll improve the library experience.
  - support added for `renderItem` to override the default button in `toggle-button` component for Vue - ReactiveSearch
  - added an additional method `handleClick` to handle the click event in the slot scope properties
  - when `renderItem` is defined just render the content passed through `renderItem` slot
  - please look into this issue for further reference - https://github.com/appbaseio/reactivesearch/issues/1656

- [x] Please make sure that there are no linting errors in the code.

- [x] Add a demo video/gif/screenshot to explain how did you test the fix.
  - https://www.loom.com/share/8a6dc8a59a6442f7a65c8dfba8ba57d0

- [x] If it is a global change, try to add any side effects that it could have.
  - This would be a breaking change for users who were previously using the `toggle-button` with `renderItem` but didn't use the `handleClick` method to listen to the click events.
  
- [x] Create a PR to add/update the docs (if needed) at [here](https://github.com/appbaseio/Docs).
  - docs PR - https://github.com/appbaseio/Docs/pull/196

- [ ] Create a PR to add/update the storybook (if needed) at [here](https://github.com/appbaseio/playground).

**Learn more about contributing:** [Contributing guides](https://github.com/appbaseio/reactivesearch/blob/next/.github/CONTRIBUTING.md)