### PR TITLE
feat(vue): support for enable-strict-selection prop added

### DIFF
--- a/packages/vue/src/components/list/SingleDropdownList.jsx
+++ b/packages/vue/src/components/list/SingleDropdownList.jsx
@@ -79,10 +79,6 @@ const SingleDropdownList = {
 		showLoadMore: VueTypes.bool.def(false),
 		loadMoreLabel: VueTypes.oneOfType([VueTypes.string, VueTypes.any]).def('Load More'),
 		nestedField: types.string,
-		enableStrictSelection: {
-			types: types.bool,
-			default: false,
-		},
 	},
 	created() {
 		// Set custom and default queries in store
@@ -234,9 +230,6 @@ const SingleDropdownList = {
 
 	methods: {
 		setValue(value, props = this.$props) {
-			if (props.enableStrictSelection && !value) {
-				return;
-			}
 			const performUpdate = () => {
 				this.currentValue = value;
 				this.updateQueryHandler(value, props);

--- a/packages/vue/src/components/list/SingleDropdownList.jsx
+++ b/packages/vue/src/components/list/SingleDropdownList.jsx
@@ -79,6 +79,10 @@ const SingleDropdownList = {
 		showLoadMore: VueTypes.bool.def(false),
 		loadMoreLabel: VueTypes.oneOfType([VueTypes.string, VueTypes.any]).def('Load More'),
 		nestedField: types.string,
+		enableStrictSelection: {
+			types: types.bool,
+			default: false,
+		},
 	},
 	created() {
 		// Set custom and default queries in store
@@ -230,6 +234,9 @@ const SingleDropdownList = {
 
 	methods: {
 		setValue(value, props = this.$props) {
+			if (props.enableStrictSelection && !value) {
+				return;
+			}
 			const performUpdate = () => {
 				this.currentValue = value;
 				this.updateQueryHandler(value, props);

--- a/packages/vue/src/components/list/SingleList.jsx
+++ b/packages/vue/src/components/list/SingleList.jsx
@@ -266,9 +266,6 @@ const SingleList = {
 		setValue(nextValue, props = this.$props) {
 			let value = nextValue;
 
-			if (!value && props.enableStrictSelection) {
-				return;
-			}
 			if (nextValue === this.$data.currentValue && !props.enableStrictSelection) {
 				value = '';
 			}

--- a/packages/vue/src/components/list/SingleList.jsx
+++ b/packages/vue/src/components/list/SingleList.jsx
@@ -53,6 +53,10 @@ const SingleList = {
 		showMissing: VueTypes.bool.def(false),
 		missingLabel: VueTypes.string.def('N/A'),
 		nestedField: types.string,
+		enableStrictSelection: {
+			types: types.bool,
+			default: false,
+		},
 	},
 	data() {
 		const props = this.$props;
@@ -262,10 +266,12 @@ const SingleList = {
 		setValue(nextValue, props = this.$props) {
 			let value = nextValue;
 
-			if (nextValue === this.$data.currentValue) {
+			if (!value && props.enableStrictSelection) {
+				return;
+			}
+			if (nextValue === this.$data.currentValue && !props.enableStrictSelection) {
 				value = '';
 			}
-
 			const performUpdate = () => {
 				this.currentValue = value;
 				this.updateQueryHandler(value, props);

--- a/packages/vue/src/components/list/SingleList.jsx
+++ b/packages/vue/src/components/list/SingleList.jsx
@@ -53,10 +53,7 @@ const SingleList = {
 		showMissing: VueTypes.bool.def(false),
 		missingLabel: VueTypes.string.def('N/A'),
 		nestedField: types.string,
-		enableStrictSelection: {
-			types: types.bool,
-			default: false,
-		},
+		enableStrictSelection: VueTypes.bool.def(false),
 	},
 	data() {
 		const props = this.$props;
@@ -128,7 +125,7 @@ const SingleList = {
 		},
 	},
 	render() {
-		const { selectAllLabel, renderItem, renderError, renderNoResults } = this.$props;
+		const { selectAllLabel, renderItem, renderError, renderNoResults, enableStrictSelection } = this.$props;
 		const renderItemCalc = this.$scopedSlots.renderItem || renderItem;
 		const renderErrorCalc = this.$scopedSlots.renderError || renderError;
 
@@ -214,7 +211,7 @@ const SingleList = {
 										name={this.$props.componentId}
 										value={item.key}
 										readOnly
-										onClick={this.handleClick}
+										onClick={this.$data.currentValue === String(item.key) && enableStrictSelection ? () => false : this.handleClick}
 										type="radio"
 										show={this.$props.showRadio}
 										{...{
@@ -266,7 +263,7 @@ const SingleList = {
 		setValue(nextValue, props = this.$props) {
 			let value = nextValue;
 
-			if (nextValue === this.$data.currentValue && !props.enableStrictSelection) {
+			if (nextValue === this.$data.currentValue) {
 				value = '';
 			}
 			const performUpdate = () => {

--- a/packages/vue/src/components/list/SingleList.jsx
+++ b/packages/vue/src/components/list/SingleList.jsx
@@ -125,7 +125,13 @@ const SingleList = {
 		},
 	},
 	render() {
-		const { selectAllLabel, renderItem, renderError, renderNoResults, enableStrictSelection } = this.$props;
+		const {
+			selectAllLabel,
+			renderItem,
+			renderError,
+			renderNoResults,
+			enableStrictSelection,
+		} = this.$props;
 		const renderItemCalc = this.$scopedSlots.renderItem || renderItem;
 		const renderErrorCalc = this.$scopedSlots.renderError || renderError;
 
@@ -142,17 +148,17 @@ const SingleList = {
 			itemsToRender = this.$props.transformData(itemsToRender);
 		}
 
-		var filteredItemsToRender = itemsToRender.filter(item => {
+		const filteredItemsToRender = itemsToRender.filter(item => {
 			if (String(item.key).length) {
 				if (this.$props.showSearch && this.$data.searchTerm) {
 					return String(item.key)
 						.toLowerCase()
 						.includes(this.$data.searchTerm.toLowerCase());
-					}
-					return true;
 				}
-				return false;
-			});
+				return true;
+			}
+			return false;
+		});
 
 		return (
 			<Container class={this.$props.className}>
@@ -195,10 +201,11 @@ const SingleList = {
 								</label>
 							</li>
 						) : null}
-						{(!this.hasCustomRenderer && filteredItemsToRender.length === 0
-						&& !this.isLoading ) ? this.renderNoResult() :
-						filteredItemsToRender
-							.map(item => (
+						{!this.hasCustomRenderer
+						&& filteredItemsToRender.length === 0
+						&& !this.isLoading
+							? this.renderNoResult()
+							: filteredItemsToRender.map(item => (
 								<li
 									key={item.key}
 									class={`${
@@ -211,7 +218,12 @@ const SingleList = {
 										name={this.$props.componentId}
 										value={item.key}
 										readOnly
-										onClick={this.$data.currentValue === String(item.key) && enableStrictSelection ? () => false : this.handleClick}
+										onClick={
+											this.$data.currentValue === String(item.key)
+												&& enableStrictSelection
+												? () => false
+												: this.handleClick
+										}
 										type="radio"
 										show={this.$props.showRadio}
 										{...{
@@ -222,7 +234,8 @@ const SingleList = {
 									/>
 									<label
 										class={
-											getClassName(this.$props.innerClass, 'label') || null
+											getClassName(this.$props.innerClass, 'label')
+												|| null
 										}
 										for={`${this.$props.componentId}-${item.key}`}
 									>
@@ -230,7 +243,8 @@ const SingleList = {
 											renderItemCalc({
 												label: item.key,
 												count: item.doc_count,
-												isChecked: this.currentValue === String(item.key),
+												isChecked:
+														this.currentValue === String(item.key),
 											})
 										) : (
 											<span>
@@ -244,7 +258,7 @@ const SingleList = {
 															) || null
 														}
 													>
-														&nbsp;(
+															&nbsp;(
 														{item.doc_count})
 													</span>
 												)}
@@ -252,7 +266,7 @@ const SingleList = {
 										)}
 									</label>
 								</li>
-							))}
+							  ))}
 					</UL>
 				)}
 			</Container>

--- a/packages/vue/src/components/range/SingleRange.jsx
+++ b/packages/vue/src/components/range/SingleRange.jsx
@@ -37,6 +37,10 @@ const SingleRange = {
 		title: types.title,
 		URLParams: VueTypes.bool.def(false),
 		nestedField: types.string,
+		enableStrictSelection: {
+			types: types.bool,
+			default: false,
+		},
 	},
 	created() {
 		// Set custom query in store
@@ -116,8 +120,10 @@ const SingleRange = {
 
 	methods: {
 		setValue(value, props = this.$props) {
+			if (props.enableStrictSelection && !value) {
+				return;
+			}
 			const currentValue = SingleRange.parseValue(value, props);
-
 			const performUpdate = () => {
 				this.currentValue = currentValue;
 				this.updateQueryHandler(currentValue, props);

--- a/packages/vue/src/components/range/SingleRange.jsx
+++ b/packages/vue/src/components/range/SingleRange.jsx
@@ -37,10 +37,6 @@ const SingleRange = {
 		title: types.title,
 		URLParams: VueTypes.bool.def(false),
 		nestedField: types.string,
-		enableStrictSelection: {
-			types: types.bool,
-			default: false,
-		},
 	},
 	created() {
 		// Set custom query in store
@@ -120,9 +116,6 @@ const SingleRange = {
 
 	methods: {
 		setValue(value, props = this.$props) {
-			if (props.enableStrictSelection && !value) {
-				return;
-			}
 			const currentValue = SingleRange.parseValue(value, props);
 			const performUpdate = () => {
 				this.currentValue = currentValue;


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

- [x] Describe the proposed changes and how it'll improve the library experience.

  - support for `enableStrictSelection` prop added to the following components in ReactiveSearch Vue library -
    - `SingleList`
    - `SingleDropdownList`
    - `SingleRange`
    
  - when `enableStrictSelection` prop is set to true it disables the user to deselect an option without selecting another one
  
- [x] Please make sure that there are no linting errors in the code.

- [x] Add a demo video/gif/screenshot to explain how did you test the fix.
  - https://www.loom.com/share/4ec0bd96e90846e6b3dfd78ea8c6e817

- [ ] If it is a global change, try to add any side effects that it could have.

- [x] Create a PR to add/update the docs (if needed) at [here](https://github.com/appbaseio/Docs).
  - https://github.com/appbaseio/Docs/pull/203

- [x] Create a PR to add/update the storybook (if needed) at [here](https://github.com/appbaseio/playground).
  - https://github.com/appbaseio/vue-playground/pull/30

**Learn more about contributing:** [Contributing guides](https://github.com/appbaseio/reactivesearch/blob/next/.github/CONTRIBUTING.md)