### PR TITLE
fix(web): inavlid placeholder in date_range

### DIFF
--- a/packages/web/src/components/date/DateRange.js
+++ b/packages/web/src/components/date/DateRange.js
@@ -332,8 +332,8 @@ class DateRange extends Component {
 		let modCurrentDate = currentDate;
 		if (typeof currentDate.start === 'string' || typeof currentDate.end === 'string') {
 			modCurrentDate = {
-				start: new XDate(currentDate.start)[0],
-				end: new XDate(currentDate.end)[0],
+				start: currentDate.start ? new XDate(currentDate.start)[0] : '',
+				end: currentDate.end ? new XDate(currentDate.end)[0] : '',
 			};
 		}
 		if (modCurrentDate && !(modCurrentDate.start === '' && modCurrentDate.end === '')) {


### PR DESCRIPTION
**Issue Type:** `BUG`

Description: Onclearing the DateRange component's value the placeholder would get set to `invalid date`.

[Loom Demo](https://www.loom.com/share/23015ef4df514d31825c5bef0a226ff9)