### PR TITLE
fix(web): Make showCount work for booleans

### DIFF
--- a/packages/web/src/components/list/SingleDataList.js
+++ b/packages/web/src/components/list/SingleDataList.js
@@ -248,6 +248,7 @@ class SingleDataList extends Component {
 				(obj, item) => ({
 					...obj,
 					[item.key]: item.doc_count,
+					[item.key_as_string]: item.doc_count,
 				}),
 				{},
 			);


### PR DESCRIPTION
Make `showCount` work for `boolean` fields in a `SingleDataList`.

Fixes: GH-1797

### Testing
Tested locally with a local clone of my codesandboxio demo from #1797 - https://codesandbox.io/s/reactivesearch-quickstart-final-app-forked-hpgv2?file=/src/App.js

![Screen Shot 2021-10-10 at 11 02 50 AM](https://user-images.githubusercontent.com/305268/136707866-c4e57acb-a53b-42e2-b70f-5db9e5d8960a.png)