### PR TITLE
fix(web): Set jest testURL to fix opaque origin

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -25,6 +25,9 @@
 		"test": "jest --watch",
 		"typescript": "tsc -p tsconfig.json"
 	},
+	"jest": {
+		"testURL": "http://localhost/"
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/appbaseio/reactivesearch.git"


### PR DESCRIPTION
This fixes the following error that I get when running `npm run test`:

```
 FAIL  src/utils/__tests__/composeThemeObject.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)
```