### PR TITLE
fix(web): Set jest rootDir = src

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -25,6 +25,9 @@
 		"test": "jest --watch",
 		"typescript": "tsc -p tsconfig.json"
 	},
+	"jest": {
+		"testURL": "http://localhost/"
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/appbaseio/reactivesearch.git"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -26,6 +26,7 @@
 		"typescript": "tsc -p tsconfig.json"
 	},
 	"jest": {
+		"rootDir": "src",
 		"testURL": "http://localhost/"
 	},
 	"repository": {


### PR DESCRIPTION
so we don't run tests on files in both `src` and `lib`. For example, I
created a new file, `SingleDataList.spec.js` in `src` and it got copied
to `lib` with the build and then Jest wanted to run on both copies of
the file, which seems redundant:

```
 PASS  src/components/list/SingleDataList.spec.js
 PASS  lib/components/list/SingleDataList.spec.js
 PASS  src/utils/__tests__/composeThemeObject.js

Test Suites: 3 passed, 3 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        0.123s, estimated 1s
Ran all test suites.
```