### PR TITLE
Allow any default value type

### DIFF
--- a/packages/vue/src/components/list/ToggleButton.jsx
+++ b/packages/vue/src/components/list/ToggleButton.jsx
@@ -17,7 +17,7 @@ const ToggleButton = {
 		componentId: types.stringRequired,
 		data: types.data,
 		dataField: types.stringRequired,
-		defaultValue: types.stringOrArray,
+		defaultValue: types.any,
 		value: types.stringOrArray,
 		filterLabel: types.string,
 		nestedField: types.string,


### PR DESCRIPTION
As it could also be a number, boolean, etc. For example:
```
<toggle-button
    component-id="in_stock"
    data-field="in_stock"
    :data="[{'label': 'in_stock', 'value': 1}]"
    :default-value="1"
>
```