### PR TITLE
fix: proposed fix for customQuery issue

### DIFF
--- a/packages/vue/src/server/index.js
+++ b/packages/vue/src/server/index.js
@@ -38,19 +38,19 @@ function getValue(state, id, defaultValue) {
 			const parsedValue = JSON.parse(state[id]);
 			return {
 				value: parsedValue,
-				reference: 'URL'
+				reference: 'URL',
 			};
 		} catch (error) {
 			// using react-dom-server for ssr
 			return {
 				value: state[id],
-				reference: 'URL'
+				reference: 'URL',
 			};
 		}
 	}
 	return {
 		value: defaultValue,
-		reference: 'DEFAULT'
+		reference: 'DEFAULT',
 	};
 }
 
@@ -139,19 +139,7 @@ export default function initReactivesearch(componentCollection, searchState, set
 				}
 			});
 			let isInternalComponentPresent = false;
-			// Set custom and default queries
-			if (component.customQuery && typeof component.customQuery === 'function') {
-				customQueries[component.componentId] = component.customQuery(
-					component.value,
-					compProps,
-				);
-			}
-			if (component.defaultQuery && typeof component.defaultQuery === 'function') {
-				defaultQueries[component.componentId] = component.defaultQuery(
-					component.value,
-					compProps,
-				);
-			}
+
 			const isResultComponent = resultComponents.includes(componentType);
 			const internalComponent = `${component.componentId}__internal`;
 			const label = component.filterLabel || component.componentId;
@@ -176,6 +164,19 @@ export default function initReactivesearch(componentCollection, searchState, set
 				showFilter,
 				URLParams: component.URLParams || false,
 			});
+			// Set custom and default queries
+			if (component.customQuery && typeof component.customQuery === 'function') {
+				customQueries[component.componentId] = component.customQuery(
+					component.value || selectedValues[component.componentId].value,
+					compProps,
+				);
+			}
+			if (component.defaultQuery && typeof component.defaultQuery === 'function') {
+				defaultQueries[component.componentId] = component.defaultQuery(
+					component.value,
+					compProps,
+				);
+			}
 
 			// [2] set query options - main component query (valid for result components)
 			if (componentsWithOptions.includes(componentType)) {
@@ -281,7 +282,6 @@ export default function initReactivesearch(componentCollection, searchState, set
 			componentProps[component.componentId] = compProps;
 		});
 
-
 		state = {
 			components,
 			dependencyTree,
@@ -293,7 +293,6 @@ export default function initReactivesearch(componentCollection, searchState, set
 			customQueries,
 			defaultQueries,
 		};
-
 		// [5] Generate finalQuery for search
 		componentCollection.forEach((component) => {
 			// eslint-disable-next-line
@@ -303,7 +302,6 @@ export default function initReactivesearch(componentCollection, searchState, set
 				queryList,
 				queryOptions,
 			);
-
 			const validOptions = ['aggs', 'from', 'sort'];
 			// check if query or options are valid - non-empty
 			if (
@@ -347,8 +345,10 @@ export default function initReactivesearch(componentCollection, searchState, set
 						};
 					}
 				} else {
-					const preference = config && config.analyticsConfig && config.analyticsConfig.userId
-						? `${config.analyticsConfig.userId}_${component}` : component;
+					const preference
+						= config && config.analyticsConfig && config.analyticsConfig.userId
+							? `${config.analyticsConfig.userId}_${component}`
+							: component;
 					finalQuery = [
 						...finalQuery,
 						{
@@ -516,6 +516,7 @@ export default function initReactivesearch(componentCollection, searchState, set
 					? config.analyticsConfig.customEvents
 					: undefined;
 			}
+			console.log('finalQuery', finalQuery);
 			appbaseRef
 				.reactiveSearchv3(finalQuery, rsAPISettings)
 				.then((res) => {

--- a/packages/vue/src/server/index.js
+++ b/packages/vue/src/server/index.js
@@ -167,7 +167,7 @@ export default function initReactivesearch(componentCollection, searchState, set
 			// Set custom and default queries
 			if (component.customQuery && typeof component.customQuery === 'function') {
 				customQueries[component.componentId] = component.customQuery(
-					component.value || selectedValues[component.componentId].value,
+					selectedValues[component.componentId].value,
 					compProps,
 				);
 			}
@@ -516,7 +516,6 @@ export default function initReactivesearch(componentCollection, searchState, set
 					? config.analyticsConfig.customEvents
 					: undefined;
 			}
-			console.log('finalQuery', finalQuery);
 			appbaseRef
 				.reactiveSearchv3(finalQuery, rsAPISettings)
 				.then((res) => {


### PR DESCRIPTION
**PR Type** `BugFix`

**Description** 
- `CustomQuery` and `DefaultQuery` props have a function signature where we provide the component `value` as the first argument. It helps user to change the query based on the current value. For e.g

```jsx
customQuery = (value, props) {
			return {
					query: {
							match: {title: ${value}}
					}
			}
}
```

-  The above functionality is not working with `ReactiveComponent` when `URLParams` is enabled.

[📔 Notion](https://www.notion.so/appbase/Custom-Query-issue-in-ReactiveSearch-96c8bfad62444d1c9bfe367df471874a)

[Loom Demo](https://www.loom.com/share/cf03f0c93bd540c9a828dc5f0d33dc4d)