### PR TITLE
fix: multidatalist - bug with renderItem callback always receiving isSelected as false

### DIFF
--- a/packages/web/examples/MultiDataList/src/index.js
+++ b/packages/web/examples/MultiDataList/src/index.js
@@ -16,6 +16,9 @@ const Main = () => (
 		app="meetup_app"
 		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
 		enableAppbase
+		appbaseConfig={{
+			enableQueryRules: false,
+		}}
 	>
 		<div className="row">
 			<div className="col">

--- a/packages/web/examples/MultiDataList/src/index.js
+++ b/packages/web/examples/MultiDataList/src/index.js
@@ -16,9 +16,6 @@ const Main = () => (
 		app="meetup_app"
 		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
 		enableAppbase
-		appbaseConfig={{
-			enableQueryRules: false,
-		}}
 	>
 		<div className="row">
 			<div className="col">

--- a/packages/web/src/components/list/MultiDataList.js
+++ b/packages/web/src/components/list/MultiDataList.js
@@ -483,16 +483,15 @@ class MultiDataList extends Component {
 								return (
 									<li
 										key={item.label}
-										className={`${
-											isChecked ? 'active' : ''
-										}`}
+										className={`${isChecked ? 'active' : ''}`}
 										role="option"
 										aria-checked={isChecked}
 										aria-selected={isChecked}
 									>
 										<Checkbox
 											className={
-												getClassName(this.props.innerClass, 'checkbox') || null
+												getClassName(this.props.innerClass, 'checkbox')
+												|| null
 											}
 											id={`${this.props.componentId}-${item.label}`}
 											name={`${this.props.componentId}-${item.label}`}
@@ -508,7 +507,7 @@ class MultiDataList extends Component {
 											htmlFor={`${this.props.componentId}-${item.label}`}
 										>
 											{renderItem ? (
-												renderItem(item.label, item.count, this.state.currentValue === item.label)
+												renderItem(item.label, item.count, isChecked)
 											) : (
 												<span>
 													<span>{item.label}</span>


### PR DESCRIPTION
**PR Type** `BugFix`

**Description** 
- https://github.com/appbaseio/reactivesearch/issues/1821
   - fixed the issue of passing the isChecked value to `renderItem` callback.
   - fixed live example breaking due to promoted result.
   - **Demo** 👉 https://www.loom.com/share/9bdcd25ffccc4365bcaf1e805345c16a


[📔  Notion](https://www.notion.so/appbase/ReactiveSearch-issues-86750916b182477793caefc4d89b377f)
