### PR TITLE
Fix/searchbox autosuggest bug

### DIFF
--- a/packages/web/src/components/search/SearchBox.js
+++ b/packages/web/src/components/search/SearchBox.js
@@ -829,9 +829,7 @@ const SearchBox = (props) => {
 		listenForFocusShortcuts();
 	}, []);
 
-	const hasSuggestions = () =>
-		(Array.isArray(props.defaultSuggestions) && props.defaultSuggestions.length)
-		|| (Array.isArray(parsedSuggestions()) && parsedSuggestions().length);
+	const hasSuggestions = () => (Array.isArray(parsedSuggestions()) && parsedSuggestions().length);
 
 	return (
 		<Container style={props.style} className={props.className}>
@@ -840,7 +838,7 @@ const SearchBox = (props) => {
 					{props.title}
 				</Title>
 			)}
-			{hasSuggestions() || props.autosuggest ? (
+			{hasSuggestions() && props.autosuggest ? (
 				<Downshift
 					id={`${props.componentId}-downshift`}
 					onChange={onSuggestionSelected}

--- a/packages/web/src/components/search/__snapshots__/SearchBox.test.js.snap
+++ b/packages/web/src/components/search/__snapshots__/SearchBox.test.js.snap
@@ -164,24 +164,16 @@ exports[`should display/ hide (search/ clear )icon when (showIcon/ showClear )pr
           className="emotion-7 emotion-8"
         >
           <input
-            aria-activedescendant={null}
-            aria-autocomplete="list"
-            aria-expanded={false}
             aria-label="MockSearchBox"
-            autoComplete="off"
             autoFocus={undefined}
-            className=" emotion-9 emotion-10"
-            id="MockSearchBox-downshift-input"
-            onBlur={[Function]}
+            className="emotion-9 emotion-10"
+            onBlur={undefined}
             onChange={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            onFocus={undefined}
+            onKeyDown={undefined}
             onKeyPress={undefined}
             onKeyUp={undefined}
             placeholder="Search"
-            role="combobox"
-            type={undefined}
             value="test"
           />
           <div>
@@ -1206,24 +1198,16 @@ exports[`should render (prefixed/ suffixed) UI nodes with searchbox when (addonB
           className="emotion-9 emotion-10"
         >
           <input
-            aria-activedescendant={null}
-            aria-autocomplete="list"
-            aria-expanded={false}
             aria-label="MockSearchBox"
-            autoComplete="off"
             autoFocus={undefined}
-            className=" emotion-11 emotion-12"
-            id="MockSearchBox-downshift-input"
-            onBlur={[Function]}
+            className="emotion-11 emotion-12"
+            onBlur={undefined}
             onChange={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            onFocus={undefined}
+            onKeyDown={undefined}
             onKeyPress={undefined}
             onKeyUp={undefined}
             placeholder="Search"
-            role="combobox"
-            type={undefined}
             value=""
           />
           <div>
@@ -1440,24 +1424,16 @@ exports[`should render SearchBox 1`] = `
           className="emotion-7 emotion-8"
         >
           <input
-            aria-activedescendant={null}
-            aria-autocomplete="list"
-            aria-expanded={false}
             aria-label="MockSearchBox"
-            autoComplete="off"
             autoFocus={undefined}
-            className=" emotion-9 emotion-10"
-            id="MockSearchBox-downshift-input"
-            onBlur={[Function]}
+            className="emotion-9 emotion-10"
+            onBlur={undefined}
             onChange={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            onFocus={undefined}
+            onKeyDown={undefined}
             onKeyPress={undefined}
             onKeyUp={undefined}
             placeholder="Search"
-            role="combobox"
-            type={undefined}
             value=""
           />
           <div>
@@ -1678,24 +1654,16 @@ exports[`should render SearchBox with title 1`] = `
           className="emotion-9 emotion-10"
         >
           <input
-            aria-activedescendant={null}
-            aria-autocomplete="list"
-            aria-expanded={false}
             aria-label="MockSearchBox"
-            autoComplete="off"
             autoFocus={undefined}
-            className=" emotion-11 emotion-12"
-            id="MockSearchBox-downshift-input"
-            onBlur={[Function]}
+            className="emotion-11 emotion-12"
+            onBlur={undefined}
             onChange={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            onFocus={undefined}
+            onKeyDown={undefined}
             onKeyPress={undefined}
             onKeyUp={undefined}
             placeholder="Search"
-            role="combobox"
-            type={undefined}
             value=""
           />
           <div>
@@ -3379,24 +3347,16 @@ exports[`should render search icon on the right 1`] = `
           className="emotion-7 emotion-8"
         >
           <input
-            aria-activedescendant={null}
-            aria-autocomplete="list"
-            aria-expanded={true}
             aria-label="MockSearchBox"
-            autoComplete="off"
             autoFocus={undefined}
-            className=" emotion-9 emotion-10"
-            id="MockSearchBox-downshift-input"
-            onBlur={[Function]}
+            className="emotion-9 emotion-10"
+            onBlur={undefined}
             onChange={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            onFocus={undefined}
+            onKeyDown={undefined}
             onKeyPress={undefined}
             onKeyUp={undefined}
             placeholder="Search"
-            role="combobox"
-            type={undefined}
             value=""
           />
           <div>
@@ -3605,24 +3565,16 @@ exports[`should render with a default value when defaultValue prop is set 1`] = 
           className="emotion-7 emotion-8"
         >
           <input
-            aria-activedescendant={null}
-            aria-autocomplete="list"
-            aria-expanded={false}
             aria-label="MockSearchBox"
-            autoComplete="off"
             autoFocus={undefined}
-            className=" emotion-9 emotion-10"
-            id="MockSearchBox-downshift-input"
-            onBlur={[Function]}
+            className="emotion-9 emotion-10"
+            onBlur={undefined}
             onChange={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            onFocus={undefined}
+            onKeyDown={undefined}
             onKeyPress={undefined}
             onKeyUp={undefined}
             placeholder="Search"
-            role="combobox"
-            type={undefined}
             value="test"
           />
           <div>
@@ -3830,24 +3782,16 @@ exports[`should show voice search when showVoiceSearch prop is set 1`] = `
           className="emotion-7 emotion-8"
         >
           <input
-            aria-activedescendant={null}
-            aria-autocomplete="list"
-            aria-expanded={false}
             aria-label="MockSearchBox"
-            autoComplete="off"
             autoFocus={undefined}
-            className=" emotion-9 emotion-10"
-            id="MockSearchBox-downshift-input"
-            onBlur={[Function]}
+            className="emotion-9 emotion-10"
+            onBlur={undefined}
             onChange={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
+            onFocus={undefined}
+            onKeyDown={undefined}
             onKeyPress={undefined}
             onKeyUp={undefined}
             placeholder="Search"
-            role="combobox"
-            type={undefined}
             value=""
           />
           <div>


### PR DESCRIPTION
**PR Type** `BugFix`

**Description** fixes a bug with `autosuggest` prop in the SearchBox component.

Detailed Description@ https://www.loom.com/share/51b5ebc8514b4fc3ad131ada06d08fdf
> When autosuggest is false,
> - suggestions appear in the dropdown (shouldn't appear)
> - esc key doesn't close suggestions (it should close suggestions and defocus)
> - on keystroke changes, the results change (expected) but suggestions from before remain until the text is completely cleared

🧇  Also updates the failing snapshots for SearchBox.
https://www.loom.com/share/0001a77ca8eb4a0ead4a6be5ec468b60