### PR TITLE
fix(web): calendarInterval and queryFormat props to optional

### DIFF
--- a/packages/web/src/components/range/DynamicRangeSlider.d.ts
+++ b/packages/web/src/components/range/DynamicRangeSlider.d.ts
@@ -28,8 +28,8 @@ export interface DynamicRangeSliderProps extends CommonProps {
 	renderTooltipData?: (...args: any[]) => any;
 	includeNullValues?: boolean;
 	index?: string;
-	queryFormat: types.queryFormatDate;
-	calendarInterval: types.calendarInterval;
+	queryFormat?: types.queryFormatDate;
+	calendarInterval?: types.calendarInterval;
 }
 
 declare const DynamicRange: React.ComponentClass<DynamicRangeSliderProps>;

--- a/packages/web/src/components/range/RangeInput.d.ts
+++ b/packages/web/src/components/range/RangeInput.d.ts
@@ -18,8 +18,8 @@ export interface RangeInputProps extends CommonProps {
 	selectedValue?: types.selectedValue;
 	includeNullValues?: boolean;
 	index?: string;
-	queryFormat: types.queryFormatDate;
-	calendarInterval: types.calendarInterval;
+	queryFormat?: types.queryFormatDate;
+	calendarInterval?: types.calendarInterval;
 }
 
 declare const RangeInput: React.ComponentClass<RangeInputProps>;

--- a/packages/web/src/components/range/RangeSlider.d.ts
+++ b/packages/web/src/components/range/RangeSlider.d.ts
@@ -30,8 +30,8 @@ export interface RangeSliderProps extends CommonProps {
 	renderTooltipData?: (...args: any[]) => any;
 	includeNullValues?: boolean;
 	index?: string;
-	queryFormat: types.queryFormatDate;
-	calendarInterval: types.calendarInterval;
+	queryFormat?: types.queryFormatDate;
+	calendarInterval?: types.calendarInterval;
 }
 
 declare const RangeSlider: React.ComponentClass<RangeSliderProps>;


### PR DESCRIPTION
**PR Type** 🐞 `Fix`

**Description** The PR removes the mandatory restriction on `calendarInterval` and `queryFormat` props for typescript environment.

**Related Issue** https://github.com/appbaseio/reactivesearch/issues/1845

Testing
https://www.loom.com/share/56931a9f6fb443e69db8eb05737b7ee9