### PR TITLE
Round dynamic range slider values

### DIFF
--- a/packages/vue/src/components/range/DynamicRangeSlider.jsx
+++ b/packages/vue/src/components/range/DynamicRangeSlider.jsx
@@ -326,11 +326,11 @@ const DynamicRangeSlider = {
 						<vue-slider-component
 							ref="slider"
 							value={[
-								Math.max(start, this.currentValue[0]),
-								Math.min(end, this.currentValue[1]),
+								Math.floor(Math.max(start, this.currentValue[0])),
+								Math.ceil(Math.min(end, this.currentValue[1])),
 							]}
-							min={Math.min(start, this.currentValue[0])}
-							max={Math.max(end, this.currentValue[1])}
+							min={Math.floor(Math.min(start, this.currentValue[0]))}
+							max={Math.ceil(Math.max(end, this.currentValue[1]))}
 							onDrag-end={this.handleSlider}
 							dotSize={20}
 							height={4}


### PR DESCRIPTION
The slider was updated recently: https://github.com/appbaseio/reactivesearch/pull/1853 and [by default the interval is 1](https://nightcatsama.github.io/vue-slider-component/#/api/props?hash=interval) which doesn't work with decimals. You'll get a console error:
```
The prop "interval" is invalid, "(max - min)" must be divisible by "interval"
```
And the slider doesn't work as it should. This rounds the values to fix this issue.

> Internal reference: RAP-255