### PR TITLE
feat(web-vue): toggle showing default suggestions through enableDefaultSuggestions prop

### DIFF
--- a/packages/vue/src/components/search/DataSearch.jsx
+++ b/packages/vue/src/components/search/DataSearch.jsx
@@ -115,10 +115,14 @@ const DataSearch = {
 			);
 		}
 
-		this.loadPopularSuggestions(this.$props.componentId);
 		this.currentValue = this.selectedValue || '';
-		if (enableRecentSearches) {
-			this.getRecentSearches();
+		const shouldFetchInitialSuggestions
+			= this.$props.enableDefaultSuggestions || this.currentValue;
+		if (shouldFetchInitialSuggestions) {
+			this.loadPopularSuggestions(this.$props.componentId);
+			if (enableRecentSearches) {
+				this.getRecentSearches();
+			}
 		}
 		this.handleTextChange = debounce(this.handleText, this.$props.debounce);
 		// Set custom and default queries in store
@@ -161,7 +165,7 @@ const DataSearch = {
 		defaultSearchSuggestions() {
 			const isPopularSuggestionsEnabled
 				= this.enableQuerySuggestions || this.enablePopularSuggestions;
-			if (this.currentValue) {
+			if (this.currentValue || !this.enableDefaultSuggestions) {
 				return [];
 			}
 			const customDefaultPopularSuggestions = (this.defaultPopularSuggestions || []).map(
@@ -268,6 +272,7 @@ const DataSearch = {
 		addonAfter: VueTypes.any,
 		expandSuggestionsContainer: VueTypes.bool.def(true),
 		index: VueTypes.string,
+		enableDefaultSuggestions: VueTypes.bool.def(true),
 	},
 	beforeMount() {
 		if (this.$props.highlight) {

--- a/packages/vue/src/components/search/DataSearch.jsx
+++ b/packages/vue/src/components/search/DataSearch.jsx
@@ -850,11 +850,14 @@ const DataSearch = {
 		},
 	},
 	render() {
-		const { theme, size, expandSuggestionsContainer } = this.$props;
+		const { theme, size, expandSuggestionsContainer, enableDefaultSuggestions } = this.$props;
 		const { recentSearchesIcon, popularSearchesIcon } = this.$scopedSlots;
-		const hasSuggestions = this.currentValue
+		let hasSuggestions = this.currentValue
 			? this.suggestionsList.length || this.topSuggestions.length
 			: this.defaultSearchSuggestions.length;
+		if (enableDefaultSuggestions === false && !this.currentValue) {
+			hasSuggestions = false;
+		}
 		return (
 			<Container class={this.$props.className}>
 				{this.$props.title && (

--- a/packages/web/src/components/search/DataSearch.d.ts
+++ b/packages/web/src/components/search/DataSearch.d.ts
@@ -80,6 +80,7 @@ export interface DataSearchProps extends CommonProps {
 	addonAfter?: types.children;
 	expandSuggestionsContainer?: boolean;
 	index?: string;
+	enableDefaultSuggestions?: boolean;
 }
 declare const DataSearch: React.ComponentClass<DataSearchProps>;
 

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -124,6 +124,7 @@ class DataSearch extends Component {
 			distinctFieldConfig,
 			index,
 			enableAppbase,
+			enableDefaultSuggestions,
 		} = this.props;
 
 		// TODO: Remove in 4.0
@@ -153,9 +154,11 @@ class DataSearch extends Component {
 				'Warning(ReactiveSearch): In order to use the `index` prop, the `enableAppbase` prop must be set to true in `ReactiveBase`.',
 			);
 		}
-		fetchPopularSuggestions(componentId);
-		if (enableRecentSearches) {
-			fetchRecentSearches();
+		if (enableDefaultSuggestions) {
+			fetchPopularSuggestions(componentId);
+			if (enableRecentSearches) {
+				fetchRecentSearches();
+			}
 		}
 	}
 
@@ -953,10 +956,11 @@ class DataSearch extends Component {
 			showDistinctSuggestions,
 			defaultPopularSuggestions,
 			defaultSuggestions,
+			enableDefaultSuggestions,
 		} = this.props;
 		const isPopularSuggestionsEnabled = enableQuerySuggestions || enablePopularSuggestions;
 		const { currentValue } = this.state;
-		if (currentValue) {
+		if (currentValue || !enableDefaultSuggestions) {
 			return [];
 		}
 		const customDefaultPopularSuggestions = defaultPopularSuggestions.map(suggestion => ({
@@ -1448,6 +1452,7 @@ DataSearch.propTypes = {
 	addonBefore: types.children,
 	addonAfter: types.children,
 	expandSuggestionsContainer: types.bool,
+	enableDefaultSuggestions: types.bool,
 };
 
 DataSearch.defaultProps = {
@@ -1480,6 +1485,7 @@ DataSearch.defaultProps = {
 	addonBefore: undefined,
 	addonAfter: undefined,
 	expandSuggestionsContainer: true,
+	enableDefaultSuggestions: true,
 };
 
 // Add componentType for SSR

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -1062,11 +1062,19 @@ class DataSearch extends Component {
 		const { currentValue } = this.state;
 		const suggestionsList = this.parsedSuggestions;
 		const {
-			theme, themePreset, size, recentSearchesIcon, popularSearchesIcon,
+			theme,
+			themePreset,
+			size,
+			recentSearchesIcon,
+			popularSearchesIcon,
+			enableDefaultSuggestions,
 		} = this.props;
-		const hasSuggestions = currentValue
+		let hasSuggestions = currentValue
 			? suggestionsList.length || this.topSuggestions.length
 			: this.defaultSuggestions.length;
+		if (enableDefaultSuggestions === false && !currentValue) {
+			hasSuggestions = false;
+		}
 		return (
 			<Container style={this.props.style} className={this.props.className}>
 				{this.props.title && (

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -154,7 +154,8 @@ class DataSearch extends Component {
 				'Warning(ReactiveSearch): In order to use the `index` prop, the `enableAppbase` prop must be set to true in `ReactiveBase`.',
 			);
 		}
-		if (enableDefaultSuggestions) {
+		const shouldFetchInitialSuggestions = enableDefaultSuggestions || this.state.currentValue;
+		if (shouldFetchInitialSuggestions) {
 			fetchPopularSuggestions(componentId);
 			if (enableRecentSearches) {
 				fetchRecentSearches();
@@ -960,7 +961,7 @@ class DataSearch extends Component {
 		} = this.props;
 		const isPopularSuggestionsEnabled = enableQuerySuggestions || enablePopularSuggestions;
 		const { currentValue } = this.state;
-		if (currentValue || !enableDefaultSuggestions) {
+		if (currentValue || enableDefaultSuggestions === false) {
 			return [];
 		}
 		const customDefaultPopularSuggestions = defaultPopularSuggestions.map(suggestion => ({


### PR DESCRIPTION
**PR Type** `Enhancement` 🏗️ 

**Description** The PR adds a prop, `enableDefaultSuggestions` to `<DataSearch/ >` component, to let the user control whether or to not show any initial suggestions, including recent, popular, index, or default suggestions(provided through `defaultSuggestions` prop).

**Affected Libraries**
- [x] React 
- [x] Vue

[📔  Notion](https://www.notion.so/appbase/defaultSuggestions-behavior-for-DataSearch-fc5dcb3dd55a42d184d8815b0594bb44)

https://www.loom.com/share/bb7506371e1f427dbe5f926d6d77e0d7
https://www.loom.com/share/1cb8acf240f147d1bf717b4b2bf25c1a

--- 
**Docs** https://github.com/appbaseio/Docs/pull/313
