### PR TITLE
fix(web-vue): enableDefaultSuggestions bugs

### DIFF
--- a/packages/vue/src/components/search/DataSearch.jsx
+++ b/packages/vue/src/components/search/DataSearch.jsx
@@ -44,7 +44,7 @@ const {
 	recordSuggestionClick,
 	loadPopularSuggestions,
 	getRecentSearches,
-	updateHits,
+	resetStoreForComponent,
 } = Actions;
 const {
 	debounce,
@@ -458,7 +458,7 @@ const DataSearch = {
 			const performUpdate = () => {
 				// Refresh recent searches when value becomes empty
 				if (!value && props.enableDefaultSuggestions === false) {
-					this.updateHits(props.componentId, { hits: [], total: 0 });
+					this.resetStoreForComponent(props.componentId);
 				} else if (!value && this.currentValue && this.enableRecentSearches) {
 					this.getRecentSearches();
 				}
@@ -504,6 +504,11 @@ const DataSearch = {
 			checkValueChange(props.componentId, value, props.beforeValueChange, performUpdate);
 		},
 		updateDefaultQueryHandler(value, props) {
+			if (!value && props.enableDefaultSuggestions === false) {
+				// clear Component data from store
+				this.resetStoreForComponent(props.componentId);
+				return;
+			}
 			let defaultQueryOptions;
 			let query = DataSearch.defaultQuery(value, props);
 			if (this.defaultQuery) {
@@ -1396,7 +1401,7 @@ const mapDispatchToProps = {
 	recordSuggestionClick,
 	loadPopularSuggestions,
 	getRecentSearches,
-	updateHits,
+	resetStoreForComponent,
 };
 const DSConnected = ComponentWrapper(connect(mapStateToProps, mapDispatchToProps)(DataSearch), {
 	componentType: componentTypes.dataSearch,

--- a/packages/vue/src/components/search/DataSearch.jsx
+++ b/packages/vue/src/components/search/DataSearch.jsx
@@ -44,6 +44,7 @@ const {
 	recordSuggestionClick,
 	loadPopularSuggestions,
 	getRecentSearches,
+	updateHits,
 } = Actions;
 const {
 	debounce,
@@ -456,7 +457,9 @@ const DataSearch = {
 		setValue(value, isDefaultValue = false, props = this.$props, cause, toggleIsOpen = true) {
 			const performUpdate = () => {
 				// Refresh recent searches when value becomes empty
-				if (!value && this.currentValue && this.enableRecentSearches) {
+				if (!value && props.enableDefaultSuggestions === false) {
+					this.updateHits(props.componentId, { hits: [], total: 0 });
+				} else if (!value && this.currentValue && this.enableRecentSearches) {
 					this.getRecentSearches();
 				}
 				this.currentValue = value;
@@ -1393,6 +1396,7 @@ const mapDispatchToProps = {
 	recordSuggestionClick,
 	loadPopularSuggestions,
 	getRecentSearches,
+	updateHits,
 };
 const DSConnected = ComponentWrapper(connect(mapStateToProps, mapDispatchToProps)(DataSearch), {
 	componentType: componentTypes.dataSearch,

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -14,7 +14,7 @@ import {
 	setCustomHighlightOptions,
 	loadPopularSuggestions,
 	getRecentSearches,
-	updateHits,
+	resetStoreForComponent,
 } from '@appbaseio/reactivecore/lib/actions';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import {
@@ -448,13 +448,13 @@ class DataSearch extends Component {
 					enableRecentSearches,
 					fetchRecentSearches,
 					enableDefaultSuggestions,
-					updateStoreHits,
+					resetStore,
 					componentId,
 				} = this.props;
 				// Refresh recent searches when value becomes empty,
 				// only when enableDefaultSuggestions is true
 				if (!value && enableDefaultSuggestions === false) {
-					updateStoreHits(componentId, { hits: [], total: 0 });
+					resetStore(componentId);
 				} else if (!value && this.state.currentValue && enableRecentSearches) {
 					fetchRecentSearches();
 				}
@@ -533,7 +533,13 @@ class DataSearch extends Component {
 	}, this.props.debounce);
 
 	updateDefaultQuery = (value, props) => {
-		const { defaultQuery } = props;
+		const { defaultQuery, resetStore, enableDefaultSuggestions } = props;
+		if (!value && enableDefaultSuggestions === false) {
+			// clear Component data from store
+			resetStore(props.componentId);
+			return;
+		}
+
 		let defaultQueryOptions;
 		let query = DataSearch.defaultQuery(value, props);
 		if (defaultQuery) {
@@ -1377,7 +1383,7 @@ DataSearch.propTypes = {
 	setCustomHighlightOptions: types.funcRequired,
 	setSuggestionsSearchValue: types.funcRequired,
 	triggerAnalytics: types.funcRequired,
-	updateStoreHits: types.funcRequired,
+	resetStore: types.funcRequired,
 	error: types.title,
 	isLoading: types.bool,
 	lastUsedQuery: types.string,
@@ -1546,7 +1552,7 @@ const mapDispatchtoProps = dispatch => ({
 		dispatch(recordSuggestionClick(searchPosition, documentId)),
 	fetchRecentSearches: queryOptions => dispatch(getRecentSearches(queryOptions)),
 	fetchPopularSuggestions: component => dispatch(loadPopularSuggestions(component)),
-	updateStoreHits: (componentId, hits) => dispatch(updateHits(componentId, hits)),
+	resetStore: componentId => dispatch(resetStoreForComponent(componentId)),
 });
 
 const ConnectedComponent = connect(

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -14,6 +14,7 @@ import {
 	setCustomHighlightOptions,
 	loadPopularSuggestions,
 	getRecentSearches,
+	updateHits,
 } from '@appbaseio/reactivecore/lib/actions';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import {
@@ -443,9 +444,18 @@ class DataSearch extends Component {
 	) => {
 		const performUpdate = () => {
 			if (hasMounted) {
-				const { enableRecentSearches, fetchRecentSearches } = this.props;
-				// Refresh recent searches when value becomes empty
-				if (!value && this.state.currentValue && enableRecentSearches) {
+				const {
+					enableRecentSearches,
+					fetchRecentSearches,
+					enableDefaultSuggestions,
+					updateStoreHits,
+					componentId,
+				} = this.props;
+				// Refresh recent searches when value becomes empty,
+				// only when enableDefaultSuggestions is true
+				if (!value && enableDefaultSuggestions === false) {
+					updateStoreHits(componentId, { hits: [], total: 0 });
+				} else if (!value && this.state.currentValue && enableRecentSearches) {
 					fetchRecentSearches();
 				}
 				this.setState(
@@ -1367,6 +1377,7 @@ DataSearch.propTypes = {
 	setCustomHighlightOptions: types.funcRequired,
 	setSuggestionsSearchValue: types.funcRequired,
 	triggerAnalytics: types.funcRequired,
+	updateStoreHits: types.funcRequired,
 	error: types.title,
 	isLoading: types.bool,
 	lastUsedQuery: types.string,
@@ -1535,6 +1546,7 @@ const mapDispatchtoProps = dispatch => ({
 		dispatch(recordSuggestionClick(searchPosition, documentId)),
 	fetchRecentSearches: queryOptions => dispatch(getRecentSearches(queryOptions)),
 	fetchPopularSuggestions: component => dispatch(loadPopularSuggestions(component)),
+	updateStoreHits: (componentId, hits) => dispatch(updateHits(componentId, hits)),
 });
 
 const ConnectedComponent = connect(


### PR DESCRIPTION
**PR Type** 🪛 `BugFix`

**Description** The PR fixes bugs with `enableDefaultSuggestions`, basically when search input is empty, the fix avoids redundant API calls and updates the redux-store to have zero hits.

https://www.loom.com/share/0dde597a38a74eac967181b23f7ad91a

https://github.com/appbaseio/reactivecore/pull/126