### PR TITLE
fix(web): range-input component resetting bug

### DIFF
--- a/packages/web/src/components/range/RangeSlider.js
+++ b/packages/web/src/components/range/RangeSlider.js
@@ -146,14 +146,24 @@ class RangeSlider extends Component {
 				getNumericRangeArray(prevProps.value, this.props.queryFormat),
 			)
 		) {
-			const value = RangeSlider.parseValue(this.props.value, this.props);
-			this.handleChange(
-				getValueArrayWithinLimits(
+			let value = getValueArrayWithinLimits(
+				RangeSlider.parseValue(this.props.value, this.props),
+				getNumericRangeArray(this.props.range, this.props.queryFormat),
+			);
+
+			// when the current value is equal to the range,
+			// this implies the component is reset to initial values
+			// thus we pass null to handleChange that would fire query
+			// to update the dependent result components as well
+
+			value = !isEqual(value, getNumericRangeArray(this.props.range, this.props.queryFormat))
+				? getValueArrayWithinLimits(
 					value,
 					getNumericRangeArray(this.props.range, this.props.queryFormat),
-				),
-				this.props,
-			);
+				  )
+				: null;
+
+			this.handleChange(value, this.props);
 		} else if (
 			// cautionary conversion of state and selectedValues from state to numerics
 			// in order to make comparison meaningful


### PR DESCRIPTION
**PR Type** 🐞 `Fix`

**Description** The PR addresses a bug with the `RangeInput` component, wherein the component didn't update the dependent component on reset via the `SelectedFilters` component. 

**originally reported @https://github.com/appbaseio/reactivesearch/issues/1937**

https://www.loom.com/share/f4e28210a4424e4aa2c1f6f84a44d43a