### PR TITLE
fix(web): update types for histogram in RangeInput

### DIFF
--- a/packages/web/src/components/range/RangeInput.d.ts
+++ b/packages/web/src/components/range/RangeInput.d.ts
@@ -17,6 +17,7 @@ export interface RangeInputProps extends CommonProps {
 	themePreset?: types.themePreset;
 	selectedValue?: types.selectedValue;
 	includeNullValues?: boolean;
+	showHistogram?: boolean;
 	index?: string;
 	queryFormat?: types.queryFormatDate;
 	calendarInterval?: types.calendarInterval;

--- a/packages/web/src/components/range/RangeInput.d.ts
+++ b/packages/web/src/components/range/RangeInput.d.ts
@@ -12,6 +12,7 @@ export interface RangeInputProps extends CommonProps {
 	validateRange?: (value: Array<number>) => boolean;
 	onChange?: (...args: any[]) => any;
 	range: types.range;
+	rangeLabels: types.rangeLabels,
 	stepValue?: number;
 	style: types.style;
 	themePreset?: types.themePreset;

--- a/packages/web/src/components/range/RangeInput.js
+++ b/packages/web/src/components/range/RangeInput.js
@@ -481,6 +481,7 @@ RangeInput.propTypes = {
 	stepValue: types.number,
 	style: types.style,
 	themePreset: types.themePreset,
+	showHistogram: types.bool,
 	componentId: types.stringRequired,
 	includeNullValues: types.bool,
 	enableAppbase: types.bool,
@@ -496,6 +497,7 @@ RangeInput.defaultProps = {
 	},
 	stepValue: 1,
 	includeNullValues: false,
+	showHistogram: true,
 };
 
 const mapStateToProps = (state, props) => ({

--- a/packages/web/src/components/range/RangeInput.js
+++ b/packages/web/src/components/range/RangeInput.js
@@ -478,6 +478,7 @@ RangeInput.propTypes = {
 	onValueChange: types.func,
 	onChange: types.func,
 	range: types.range,
+	rangeLabels: types.rangeLabels,
 	stepValue: types.number,
 	style: types.style,
 	themePreset: types.themePreset,


### PR DESCRIPTION
It adds missing types and props for showHistogram prop in RangeInput

Shows correct intellisense support after running `yarn build:copy-types` from `packages/web`

Closes #1930