### PR TITLE
fix: render only when props change

### DIFF
--- a/packages/web/src/components/basic/ComponentWrapper.js
+++ b/packages/web/src/components/basic/ComponentWrapper.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import types from '@appbaseio/reactivecore/lib/utils/types';
 import { getInternalComponentID } from '@appbaseio/reactivecore/lib/utils/transform';
 
@@ -33,7 +33,7 @@ import PureComponentWrapper from './PureComponentWrapper';
  * 5. Update component props in redux store
  * 6. Unregister the component on un-mount
  */
-class ComponentWrapper extends PureComponent {
+class ComponentWrapper extends Component {
 	static contextType = ReactReduxContext;
 
 	constructor(props, context) {

--- a/packages/web/src/components/basic/ComponentWrapper.js
+++ b/packages/web/src/components/basic/ComponentWrapper.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import types from '@appbaseio/reactivecore/lib/utils/types';
 import { getInternalComponentID } from '@appbaseio/reactivecore/lib/utils/transform';
 
@@ -7,7 +7,6 @@ import {
 	checkPropChange,
 	checkSomePropChange,
 	hasCustomRenderer,
-	getComponent,
 } from '@appbaseio/reactivecore/lib/utils/helper';
 import { string } from 'prop-types';
 import {
@@ -22,6 +21,7 @@ import {
 } from '@appbaseio/reactivecore/lib/actions';
 
 import { connect, ReactReduxContext, getValidPropsKeys } from '../../utils';
+import PureComponentWrapper from './PureComponentWrapper';
 
 /**
  * ComponentWrapper component is a wrapper component for each ReactiveSearch component
@@ -33,7 +33,7 @@ import { connect, ReactReduxContext, getValidPropsKeys } from '../../utils';
  * 5. Update component props in redux store
  * 6. Unregister the component on un-mount
  */
-class ComponentWrapper extends React.Component {
+class ComponentWrapper extends PureComponent {
 	static contextType = ReactReduxContext;
 
 	constructor(props, context) {
@@ -122,7 +122,7 @@ class ComponentWrapper extends React.Component {
 
 	render() {
 		if (this.hasCustomRenderer) {
-			return getComponent({}, this.props);
+			return <PureComponentWrapper {...this.props} />;
 		}
 		return null;
 	}

--- a/packages/web/src/components/basic/PureComponentWrapper.js
+++ b/packages/web/src/components/basic/PureComponentWrapper.js
@@ -1,0 +1,12 @@
+import { getComponent } from '@appbaseio/reactivecore/lib/utils/helper';
+import { PureComponent } from 'react';
+
+/**
+ * Avoids the re-rendering due to context in ComponentWrapper to propogate
+ * to child components. Usage should be restricted to ComponentWrapper.
+*/
+export default class PureComponentWrapper extends PureComponent {
+	render() {
+		return getComponent({}, this.props);
+	}
+}


### PR DESCRIPTION
# Description
This change makes a wrapper around all the components in `reactivesearch/web` which use `ComponentWrapper` to add a check to shallow compare **props** before rendering. This avoids unnecessary re-renders forced on components due to changing **context** in `ComponentWrapper`

[Loom explanation and preview of solution](https://www.loom.com/share/5bff6697a2a94ad3a88daf1fc1f2bf7b)

[Loom testing all the storybook examples](https://www.loom.com/share/c05dbc29d4544052babd73d4384ec5a2)

Closes #1974 
Related to #1704 