### PR TITLE
feat(web-vue): add support for searchboxId prop

### DIFF
--- a/packages/vue/src/components/search/SearchBox.jsx
+++ b/packages/vue/src/components/search/SearchBox.jsx
@@ -203,6 +203,7 @@ const SearchBox = {
 		renderEnterButton: VueTypes.any,
 		mode: VueTypes.oneOf(['select', 'tag']).def('select'),
 		renderSelectedTags: VueTypes.any,
+		searchboxId: VueTypes.string,
 	},
 	beforeMount() {
 		if (this.selectedValue) {

--- a/packages/web/src/components/search/SearchBox.d.ts
+++ b/packages/web/src/components/search/SearchBox.d.ts
@@ -85,6 +85,7 @@ export interface SearchBoxProps extends CommonProps {
 	customStopwords?: string[];
 	enterButton?: boolean;
 	renderEnterButton?: (onClick: any) => types.children;
+	searchboxId?: string;
 }
 
 declare const SearchBox: React.ComponentClass<SearchBoxProps>;

--- a/packages/web/src/components/search/SearchBox.js
+++ b/packages/web/src/components/search/SearchBox.js
@@ -1436,6 +1436,7 @@ SearchBox.propTypes = {
 	enterButton: types.bool,
 	renderEnterButton: types.func,
 	customEvents: types.componentObject,
+	searchboxId: types.string,
 };
 
 SearchBox.defaultProps = {


### PR DESCRIPTION
**PR Type**  `Feat`

**Description** The PR adds support for **searchboxId** prop to `SearchBox` component.

https://github.com/appbaseio/reactivecore/pull/133

https://www.loom.com/share/7fae76d7fb02456ebca1ab9be7981c79