### PR TITLE
fix(web): use label instead of value

### DIFF
--- a/packages/web/src/components/list/TabDataList.js
+++ b/packages/web/src/components/list/TabDataList.js
@@ -22,13 +22,13 @@ const TabDataList = (props) => {
 				<TabContainer vertical={props.displayAsVertical}>
 					{data.map(item => (
 						<TabLink
-							onClick={() => handleChange(item.value)}
-							selected={item.value === value}
+							onClick={() => handleChange(item.label)}
+							selected={item.label === value}
 							vertical={props.displayAsVertical}
-							key={item.value}
+							key={item.label}
 						>
 							{renderItem
-								? renderItem(item.label, item.count, item.value === value)
+								? renderItem(item.label, item.count, item.label === value)
 								: defaultItem(item)}
 						</TabLink>
 					))}

--- a/packages/web/src/components/list/TabDataList.js
+++ b/packages/web/src/components/list/TabDataList.js
@@ -6,6 +6,15 @@ import { TabLink, TabContainer } from '../../styles/Tabs';
 
 import SingleDataList from './SingleDataList';
 
+/**
+ * Data property has two properties: label and value.
+ * `label` is unique and is used for comparison.
+ * `value` may not be unique and is used for querying the index.
+ *
+ * Data List componenents use label as value.
+ * This is also added to the `isComponentUsesLabelAsValue` in reactivecore.
+ */
+
 const TabDataList = (props) => {
 	const { renderItem } = props;
 	const defaultItem = item =>


### PR DESCRIPTION
Use label instead of value for `TabDataList` component
- [Issue](https://www.loom.com/share/7f3e1c080c18466dac381da74970b54c)
- [Solution](https://www.loom.com/share/7dba5356e4594cc0a1de8f982900ad17)

[Reactive core](https://github.com/appbaseio/reactivecore/pull/134)