### PR TITLE
fix(web): trigger query on enter key press

### DIFF
--- a/packages/web/src/components/search/SearchBox.js
+++ b/packages/web/src/components/search/SearchBox.js
@@ -484,6 +484,7 @@ const SearchBox = (props) => {
 						props.value === undefined
 						|| cause === causes.SUGGESTION_SELECT
 						|| cause === causes.CLEAR_VALUE
+						|| cause === causes.ENTER_PRESS
 					) {
 						triggerCustomQuery(
 							queryHandlerValue,
@@ -649,7 +650,7 @@ const SearchBox = (props) => {
 					event.target.value,
 					true,
 					props,
-					isTagsMode.current ? causes.SUGGESTION_SELECT : undefined,
+					isTagsMode.current ? causes.SUGGESTION_SELECT : causes.ENTER_PRESS,
 				);
 				onValueSelected(event.target.value, causes.ENTER_PRESS);
 			}

--- a/packages/web/src/components/search/SearchBox.js
+++ b/packages/web/src/components/search/SearchBox.js
@@ -485,6 +485,7 @@ const SearchBox = (props) => {
 						|| cause === causes.SUGGESTION_SELECT
 						|| cause === causes.CLEAR_VALUE
 						|| cause === causes.ENTER_PRESS
+						|| cause === causes.SEARCH_ICON_CLICK
 					) {
 						triggerCustomQuery(
 							queryHandlerValue,
@@ -702,7 +703,7 @@ const SearchBox = (props) => {
 
 	const handleSearchIconClick = () => {
 		if (currentValue.trim()) {
-			setValue(currentValue, true);
+			setValue(currentValue, true, props, causes.SEARCH_ICON_CLICK);
 			onValueSelected(currentValue, causes.SEARCH_ICON_CLICK);
 		}
 	};


### PR DESCRIPTION
**PR Type** `fix`

**Description** The PR fixes a bug with SearchBox component, where the result query wasn't triggered on ENTER key press.

https://www.loom.com/share/cbe0117cae314698b98d20edc76035db

