### PR TITLE
fix(web): render element as tag

### DIFF
--- a/packages/web/src/components/result/ResultList.js
+++ b/packages/web/src/components/result/ResultList.js
@@ -39,12 +39,13 @@ class ResultList extends Component {
 
 	render() {
 		const {
-			children, id, href, target, ...props
+			children, id, href, target, as, ...props
 		} = this.props;
 		const { hasImage, isSmall } = this.state;
 		return (
 			<ListItem
 				id={id}
+				as={as}
 				href={href}
 				image={hasImage}
 				small={isSmall}
@@ -62,11 +63,13 @@ ResultList.propTypes = {
 	children: types.children,
 	target: types.stringRequired,
 	href: types.string,
+	as: types.string,
 	id: oneOfType([types.string, types.number]),
 };
 
 ResultList.defaultProps = {
 	target: '_blank',
+	as: 'a',
 };
 
 export default ResultList;

--- a/packages/web/src/styles/Base.js
+++ b/packages/web/src/styles/Base.js
@@ -1,7 +1,14 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import { string } from 'prop-types';
 
-const Base = styled(({ as: T = 'div', ...props }) => <T {...props} />)`
+export const RenderAsTagComponent = ({ as: Tag = 'div', ...props }) => <Tag {...props} />;
+
+RenderAsTagComponent.propTypes = {
+	as: string,
+};
+
+const Base = styled(RenderAsTagComponent)`
 	font-family: ${({ theme }) => theme.typography.fontFamily};
 	font-size: ${({ theme }) => theme.typography.fontSize};
 	color: ${({ theme }) => theme.colors.textColor};

--- a/packages/web/src/styles/ListItem.js
+++ b/packages/web/src/styles/ListItem.js
@@ -1,6 +1,7 @@
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { lighten } from 'polished';
+import { RenderAsTagComponent } from './Base';
 
 import Title from './Title';
 
@@ -28,32 +29,32 @@ const Image = styled('div')`
 	background-image: ${props => `url(${props.src})`};
 `;
 
-const ListItem = styled('a')`
+const ListItem = styled(RenderAsTagComponent)`
 	width: 100%;
 	height: auto;
 	outline: none;
 	text-decoration: none;
 	border-radius: 0;
 	background-color: ${({ theme }) =>
-		(theme.colors.backgroundColor
-			? lighten(0.1, theme.colors.backgroundColor)
-			: '#fff')};
+	(theme.colors.backgroundColor
+		? lighten(0.1, theme.colors.backgroundColor)
+		: '#fff')};
 	display: flex;
 	flex-direction: row;
 	margin: 0;
 	padding: 10px;
 	border-bottom: 1px solid ${({ theme }) =>
-		(theme.colors.backgroundColor
-			? lighten(0.3, theme.colors.backgroundColor)
-			: lighten(0.68, theme.colors.textColor))};
+			(theme.colors.backgroundColor
+				? lighten(0.3, theme.colors.backgroundColor)
+				: lighten(0.68, theme.colors.textColor))};
 	color: ${({ theme }) => theme.colors.textColor};
 	${props => (props.href ? 'cursor: pointer' : null)}; all 0.3s ease;
 
 	&:hover, &:focus {
 		background-color: ${({ theme }) =>
-		(theme.colors.backgroundColor
-			? lighten(0.2, theme.colors.backgroundColor)
-			: '#fdfefd')};
+					(theme.colors.backgroundColor
+						? lighten(0.2, theme.colors.backgroundColor)
+						: '#fdfefd')};
 	}
 
 	&:last-of-type {
@@ -76,11 +77,11 @@ const ListItem = styled('a')`
 
 	article {
 		width: ${(props) => {
-		if (props.image) {
-			return props.small ? 'calc(100% - 100px)' : 'calc(100% - 160px)';
-		}
-		return '100%';
-	}};
+							if (props.image) {
+								return props.small ? 'calc(100% - 100px)' : 'calc(100% - 160px)';
+							}
+							return '100%';
+						}};
 		padding-left: ${props => (props.image ? '10px' : 0)};
 		font-size: 0.9rem;
 	}


### PR DESCRIPTION
- Using `ResultList` causes a HTML semantic issue. `ResultList` renders as `a` tag. Therefore, users can't nest `a` inside `ResultList`. This doesn't break UI however.
- [Loom preview](https://www.loom.com/share/dc196e731fe9415a836cb8bac3ecce11)

Closes #2053 