### PR TITLE
feat(web): selectAllLabel with showCount

### DIFF
--- a/packages/web/src/components/list/MultiDataList.js
+++ b/packages/web/src/components/list/MultiDataList.js
@@ -419,7 +419,9 @@ class MultiDataList extends Component {
 	}
 
 	render() {
-		const { selectAllLabel, showCount, renderItem } = this.props;
+		const {
+			selectAllLabel, showCount, renderItem, total,
+		} = this.props;
 		const { options } = this.state;
 
 		if (!this.hasCustomRenderer && options.length === 0) {
@@ -469,7 +471,19 @@ class MultiDataList extends Component {
 									className={getClassName(this.props.innerClass, 'label') || null}
 									htmlFor={`${this.props.componentId}-${selectAllLabel}`}
 								>
-									{selectAllLabel}
+									<span>
+										<span>{selectAllLabel}</span>
+										{showCount && total && (
+											<span
+												className={
+													getClassName(this.props.innerClass, 'count')
+													|| null
+												}
+											>
+												{total}
+											</span>
+										)}
+									</span>
 								</label>
 							</li>
 						) : null}
@@ -540,7 +554,7 @@ MultiDataList.propTypes = {
 	rawData: types.rawData,
 	options: types.options,
 	enableAppbase: types.bool,
-
+	total: types.number,
 	setCustomQuery: types.funcRequired,
 	// component props
 	beforeValueChange: types.func,
@@ -604,6 +618,7 @@ const mapStateToProps = (state, props) => ({
 		props.nestedField && state.aggregations[props.componentId]
 			? state.aggregations[props.componentId].reactivesearch_nested
 			: state.aggregations[props.componentId],
+	total: state.hits[props.componentId] && state.hits[props.componentId].total,
 	enableAppbase: state.config.enableAppbase,
 });
 

--- a/packages/web/src/components/list/MultiDropdownList.js
+++ b/packages/web/src/components/list/MultiDropdownList.js
@@ -458,6 +458,7 @@ class MultiDropdownList extends Component {
 			selectAll = [
 				{
 					key: this.props.selectAllLabel,
+					doc_count: this.props.showCount && this.props.total,
 				},
 			];
 		}
@@ -519,6 +520,7 @@ MultiDropdownList.propTypes = {
 	isLoading: types.bool,
 	error: types.title,
 	enableAppbase: types.bool,
+	total: types.number,
 	// component props
 	beforeValueChange: types.func,
 	children: types.func,
@@ -599,6 +601,7 @@ const mapStateToProps = (state, props) => ({
 		(state.selectedValues[props.componentId]
 			&& state.selectedValues[props.componentId].value)
 		|| null,
+	total: state.hits[props.componentId] && state.hits[props.componentId].total,
 	isLoading: state.isLoading[props.componentId],
 	themePreset: state.config.themePreset,
 	error: state.error[props.componentId],

--- a/packages/web/src/components/list/MultiList.js
+++ b/packages/web/src/components/list/MultiList.js
@@ -543,6 +543,8 @@ class MultiList extends Component {
 			renderError,
 			error,
 			isLoading,
+			showCount,
+			total,
 		} = this.props;
 		const { isLastBucket } = this.state;
 
@@ -600,7 +602,17 @@ class MultiList extends Component {
 									className={getClassName(this.props.innerClass, 'label') || null}
 									htmlFor={`${this.props.componentId}-${selectAllLabel}`}
 								>
-									{selectAllLabel}
+									<span>
+
+										<span>
+											{selectAllLabel}
+										</span>
+										{showCount ? (
+											<span>
+												{total}
+											</span>)
+											: null}
+									</span>
 								</label>
 							</li>
 						) : null}
@@ -688,6 +700,7 @@ MultiList.propTypes = {
 	isLoading: types.bool,
 	error: types.title,
 	enableAppbase: types.bool,
+	total: types.number,
 	// component props
 	beforeValueChange: types.func,
 	children: types.func,
@@ -762,6 +775,7 @@ const mapStateToProps = (state, props) => ({
 		(state.selectedValues[props.componentId]
 			&& state.selectedValues[props.componentId].value)
 		|| null,
+	total: state.hits[props.componentId] && state.hits[props.componentId].total,
 	isLoading: state.isLoading[props.componentId],
 	themePreset: state.config.themePreset,
 	error: state.error[props.componentId],

--- a/packages/web/src/components/list/SingleDataList.js
+++ b/packages/web/src/components/list/SingleDataList.js
@@ -402,7 +402,7 @@ class SingleDataList extends Component {
 									id={`${this.props.componentId}-${selectAllLabel}`}
 									value={selectAllLabel}
 									tabIndex={isAllChecked ? '-1' : '0'}
-									onClick={this.handleClick}
+									onChange={this.handleClick}
 									checked={isAllChecked}
 									show={this.props.showRadio}
 								/>

--- a/packages/web/src/components/list/SingleDataList.js
+++ b/packages/web/src/components/list/SingleDataList.js
@@ -361,7 +361,9 @@ class SingleDataList extends Component {
 	}
 
 	render() {
-		const { selectAllLabel, showCount, renderItem } = this.props;
+		const {
+			selectAllLabel, showCount, renderItem, total,
+		} = this.props;
 		const { options } = this.state;
 
 		if (!this.hasCustomRenderer && options.length === 0) {
@@ -408,7 +410,19 @@ class SingleDataList extends Component {
 									className={getClassName(this.props.innerClass, 'label') || null}
 									htmlFor={`${this.props.componentId}-${selectAllLabel}`}
 								>
-									{selectAllLabel}
+									<Span>
+										{selectAllLabel}
+										{showCount && total && (
+											<span
+												className={
+													getClassName(this.props.innerClass, 'count')
+													|| null
+												}
+											>
+												&nbsp;({total})
+											</span>
+										)}
+									</Span>
 								</Label>
 							</li>
 						)}
@@ -474,7 +488,7 @@ class SingleDataList extends Component {
 SingleDataList.propTypes = {
 	setQueryOptions: types.funcRequired,
 	updateQuery: types.funcRequired,
-
+	total: types.number,
 	selectedValue: types.selectedValue,
 	options: types.options,
 	rawData: types.rawData,
@@ -539,6 +553,7 @@ const mapStateToProps = (state, props) => ({
 			&& state.selectedValues[props.componentId].value)
 		|| null,
 	themePreset: state.config.themePreset,
+	total: state.hits[props.componentId] && state.hits[props.componentId].total,
 	options:
 		props.nestedField && state.aggregations[props.componentId]
 			? state.aggregations[props.componentId].reactivesearch_nested

--- a/packages/web/src/components/list/SingleDataList.js
+++ b/packages/web/src/components/list/SingleDataList.js
@@ -338,6 +338,7 @@ class SingleDataList extends Component {
 			data: this.listItems,
 			handleChange: this.handleClick,
 			rawData: this.props.rawData,
+			total: this.props.total,
 		};
 		return getComponent(data, this.props);
 	}

--- a/packages/web/src/components/list/SingleDataList.js
+++ b/packages/web/src/components/list/SingleDataList.js
@@ -215,6 +215,8 @@ class SingleDataList extends Component {
 		if (value !== props.selectAllLabel) {
 			currentValue = props.data.find(item => item.label === value);
 			currentValue = currentValue ? currentValue.value : null;
+		} else {
+			currentValue = props.selectAllLabel;
 		}
 		let query = SingleDataList.defaultQuery(currentValue, props);
 		if (customQuery) {
@@ -398,7 +400,7 @@ class SingleDataList extends Component {
 									id={`${this.props.componentId}-${selectAllLabel}`}
 									value={selectAllLabel}
 									tabIndex={isAllChecked ? '-1' : '0'}
-									onChange={this.handleClick}
+									onClick={this.handleClick}
 									checked={isAllChecked}
 									show={this.props.showRadio}
 								/>

--- a/packages/web/src/components/list/SingleDropdownList.js
+++ b/packages/web/src/components/list/SingleDropdownList.js
@@ -334,6 +334,7 @@ class SingleDropdownList extends Component {
 			selectAll = [
 				{
 					key: this.props.selectAllLabel,
+					doc_count: this.props.showCount && this.props.total,
 				},
 			];
 		}
@@ -395,6 +396,7 @@ SingleDropdownList.propTypes = {
 	error: types.title,
 	isLoading: types.bool,
 	enableAppbase: types.bool,
+	total: types.number,
 	// component props
 	beforeValueChange: types.func,
 	children: types.func,
@@ -474,6 +476,7 @@ const mapStateToProps = (state, props) => ({
 			&& state.selectedValues[props.componentId].value)
 		|| '',
 	isLoading: state.isLoading[props.componentId],
+	total: state.hits[props.componentId] && state.hits[props.componentId].total,
 	themePreset: state.config.themePreset,
 	error: state.error[props.componentId],
 	enableAppbase: state.config.enableAppbase,

--- a/packages/web/src/components/list/SingleList.js
+++ b/packages/web/src/components/list/SingleList.js
@@ -624,7 +624,6 @@ const mapStateToProps = (state, props) => ({
 			&& state.selectedValues[props.componentId].value)
 		|| '',
 	total: state.hits[props.componentId] && state.hits[props.componentId].total,
-
 	themePreset: state.config.themePreset,
 	isLoading: state.isLoading[props.componentId],
 	error: state.error[props.componentId],

--- a/packages/web/src/components/list/SingleList.js
+++ b/packages/web/src/components/list/SingleList.js
@@ -401,6 +401,7 @@ class SingleList extends Component {
 			renderError,
 			error,
 			isLoading,
+			total,
 		} = this.props;
 		const { isLastBucket } = this.state;
 
@@ -459,7 +460,19 @@ class SingleList extends Component {
 									className={getClassName(this.props.innerClass, 'label') || null}
 									htmlFor={`${this.props.componentId}-${selectAllLabel}`}
 								>
-									{selectAllLabel}
+									<span>
+										<span>{selectAllLabel}</span>
+										{this.props.showCount && (
+											<span
+												className={
+													getClassName(this.props.innerClass, 'count')
+													|| null
+												}
+											>
+												{total}
+											</span>
+										)}
+									</span>
 								</label>
 							</li>
 						) : null}
@@ -533,6 +546,7 @@ SingleList.propTypes = {
 	isLoading: types.bool,
 	error: types.title,
 	enableAppbase: types.bool,
+	total: types.number,
 	// component props
 	beforeValueChange: types.func,
 	children: types.func,
@@ -609,6 +623,8 @@ const mapStateToProps = (state, props) => ({
 		(state.selectedValues[props.componentId]
 			&& state.selectedValues[props.componentId].value)
 		|| '',
+	total: state.hits[props.componentId] && state.hits[props.componentId].total,
+
 	themePreset: state.config.themePreset,
 	isLoading: state.isLoading[props.componentId],
 	error: state.error[props.componentId],

--- a/packages/web/src/components/list/TabDataList.d.ts
+++ b/packages/web/src/components/list/TabDataList.d.ts
@@ -10,6 +10,7 @@ export interface TabDataList extends CommonProps {
 	placeholder?: string;
 	react?: types.react;
 	title?: types.title;
+	selectAllLabel: string;
 	showCount?: boolean;
 	render?: (...args: any[]) => any;
 	renderItem?: (...args: any[]) => any;

--- a/packages/web/src/components/list/TabDataList.js
+++ b/packages/web/src/components/list/TabDataList.js
@@ -3,6 +3,7 @@ import types from '@appbaseio/reactivecore/lib/utils/types';
 import { bool } from 'prop-types';
 import React from 'react';
 import { TabLink, TabContainer } from '../../styles/Tabs';
+import { getNestedProperty } from '../../utils';
 
 import SingleDataList from './SingleDataList';
 
@@ -27,7 +28,9 @@ const TabDataList = (props) => {
 		<SingleDataList
 			{...props}
 			showSearch={props.showSearch}
-			render={({ data, value, handleChange }) => (
+			render={({
+				data, value, handleChange, rawData,
+			}) => (
 				<TabContainer vertical={props.displayAsVertical}>
 					{props.selectAllLabel ? (
 						<TabLink
@@ -36,7 +39,11 @@ const TabDataList = (props) => {
 							vertical={props.displayAsVertical}
 							key={props.selectAllLabel}
 						>
-							{props.selectAllLabel}
+							{defaultItem({
+								label: props.selectAllLabel,
+								value: props.selectAllLabel,
+								count: props.showCount && getNestedProperty(rawData, 'hits.total.value'),
+							})}
 						</TabLink>
 					) : null}
 					{data.map(item => (

--- a/packages/web/src/components/list/TabDataList.js
+++ b/packages/web/src/components/list/TabDataList.js
@@ -1,9 +1,9 @@
 import { hasCustomRenderer } from '@appbaseio/reactivecore/lib/utils/helper';
 import types from '@appbaseio/reactivecore/lib/utils/types';
-import { bool } from 'prop-types';
+import { bool, number } from 'prop-types';
 import React from 'react';
 import { TabLink, TabContainer } from '../../styles/Tabs';
-import { getNestedProperty } from '../../utils';
+import { connect } from '../../utils';
 
 import SingleDataList from './SingleDataList';
 
@@ -17,7 +17,7 @@ import SingleDataList from './SingleDataList';
  */
 
 const TabDataList = (props) => {
-	const { renderItem } = props;
+	const { renderItem, totalDocs } = props;
 	const defaultItem = item =>
 		`${item.label} ${props.showCount && item.count ? `(${item.count})` : ''}`;
 
@@ -29,7 +29,7 @@ const TabDataList = (props) => {
 			{...props}
 			showSearch={props.showSearch}
 			render={({
-				data, value, handleChange, rawData,
+				data, value, handleChange,
 			}) => (
 				<TabContainer vertical={props.displayAsVertical}>
 					{props.selectAllLabel ? (
@@ -42,7 +42,7 @@ const TabDataList = (props) => {
 							{defaultItem({
 								label: props.selectAllLabel,
 								value: props.selectAllLabel,
-								count: props.showCount && getNestedProperty(rawData, 'hits.total.value'),
+								count: totalDocs,
 							})}
 						</TabLink>
 					) : null}
@@ -71,6 +71,8 @@ TabDataList.defaultProps = {
 };
 
 TabDataList.propTypes = {
+	totalDocs: number,
+	// componentProps
 	displayAsVertical: bool,
 	children: types.func,
 	componentId: types.stringRequired,
@@ -89,4 +91,11 @@ TabDataList.propTypes = {
 	endpoint: types.endpoint,
 	selectAllLabel: types.string,
 };
-export default TabDataList;
+
+const mapStateToProps = (state, props) => ({
+	totalDocs: state.hits[props.componentId] && state.hits[props.componentId].total,
+});
+
+const ConnectedComponent = connect(mapStateToProps, null)(props => <TabDataList {...props} />);
+
+export default ConnectedComponent;

--- a/packages/web/src/components/list/TabDataList.js
+++ b/packages/web/src/components/list/TabDataList.js
@@ -1,9 +1,8 @@
 import { hasCustomRenderer } from '@appbaseio/reactivecore/lib/utils/helper';
 import types from '@appbaseio/reactivecore/lib/utils/types';
-import { bool, number } from 'prop-types';
+import { bool } from 'prop-types';
 import React from 'react';
 import { TabLink, TabContainer } from '../../styles/Tabs';
-import { connect } from '../../utils';
 
 import SingleDataList from './SingleDataList';
 
@@ -17,19 +16,20 @@ import SingleDataList from './SingleDataList';
  */
 
 const TabDataList = (props) => {
-	const { renderItem, totalDocs } = props;
+	const { renderItem } = props;
 	const defaultItem = item =>
 		`${item.label} ${props.showCount && item.count ? `(${item.count})` : ''}`;
 
 	if (hasCustomRenderer(props) || props.showRadio) {
 		return <SingleDataList {...props} />;
 	}
+
 	return (
 		<SingleDataList
 			{...props}
 			showSearch={props.showSearch}
 			render={({
-				data, value, handleChange,
+				data, value, handleChange, total,
 			}) => (
 				<TabContainer vertical={props.displayAsVertical}>
 					{props.selectAllLabel ? (
@@ -42,7 +42,7 @@ const TabDataList = (props) => {
 							{defaultItem({
 								label: props.selectAllLabel,
 								value: props.selectAllLabel,
-								count: totalDocs,
+								count: total,
 							})}
 						</TabLink>
 					) : null}
@@ -71,8 +71,6 @@ TabDataList.defaultProps = {
 };
 
 TabDataList.propTypes = {
-	totalDocs: number,
-	// componentProps
 	displayAsVertical: bool,
 	children: types.func,
 	componentId: types.stringRequired,
@@ -92,10 +90,4 @@ TabDataList.propTypes = {
 	selectAllLabel: types.string,
 };
 
-const mapStateToProps = (state, props) => ({
-	totalDocs: state.hits[props.componentId] && state.hits[props.componentId].total,
-});
-
-const ConnectedComponent = connect(mapStateToProps, null)(props => <TabDataList {...props} />);
-
-export default ConnectedComponent;
+export default TabDataList;

--- a/packages/web/src/utils/index.js
+++ b/packages/web/src/utils/index.js
@@ -282,3 +282,16 @@ export function decodeHtml(str) {
 		return String.fromCharCode(num);
 	});
 }
+
+// Similar to lodash.get eg. a[0].b.c
+export function getNestedProperty(object, keys, defaultVal = null): any {
+	if (!object) {
+		return object;
+	}
+	const clonedKeys = Array.isArray(keys) ? keys : keys.replace(/(\[(\d)\])/g, '.$2').split('.');
+	const clonedObj = object[clonedKeys[0]];
+	if (clonedObj && clonedKeys.length > 1) {
+		return getNestedProperty(clonedObj, clonedKeys.slice(1), defaultVal);
+	}
+	return clonedObj === undefined ? defaultVal : clonedObj;
+}

--- a/packages/web/src/utils/index.js
+++ b/packages/web/src/utils/index.js
@@ -14,6 +14,10 @@ export const SearchPreferencesContext = React.createContext(null);
 
 export const ReduxGetStateContext = React.createContext(null);
 
+/**
+ * This exported connect expects two args (mapStateToProps, mapStateToDispatch).
+ * If we don't want to pass any of them, then we need to explicityly pass as null.
+*/
 export const connect = (...args) => connectToStore(...args, null, { context: ReactReduxContext });
 
 export const X_SEARCH_CLIENT = 'ReactiveSearch React';
@@ -281,17 +285,4 @@ export function decodeHtml(str) {
 		const num = parseInt(numStr, 10); // read num as normal number
 		return String.fromCharCode(num);
 	});
-}
-
-// Similar to lodash.get eg. a[0].b.c
-export function getNestedProperty(object, keys, defaultVal = null): any {
-	if (!object) {
-		return object;
-	}
-	const clonedKeys = Array.isArray(keys) ? keys : keys.replace(/(\[(\d)\])/g, '.$2').split('.');
-	const clonedObj = object[clonedKeys[0]];
-	if (clonedObj && clonedKeys.length > 1) {
-		return getNestedProperty(clonedObj, clonedKeys.slice(1), defaultVal);
-	}
-	return clonedObj === undefined ? defaultVal : clonedObj;
 }


### PR DESCRIPTION
`selectAllLabel` label should show count as total number of documents when `showCount` is true.

- [Loom preview](https://www.loom.com/share/0a83a7e15fa54473995d7dc60a256904)
- [Notion card](https://www.notion.so/appbase/selectAllLabel-support-for-Elasticsearch-0afc7e0e88f84f998dbee01b6839bc0a)

- [Reactivecore PR](https://github.com/appbaseio/reactivecore)