### PR TITLE
fix(web): TreeList TypeScript types

### DIFF
--- a/packages/web/src/components/list/TreeList.d.ts
+++ b/packages/web/src/components/list/TreeList.d.ts
@@ -13,13 +13,13 @@ export interface TreeListProps extends CommonProps {
 	showCount?: boolean;
 	showSearch?: boolean;
 	showIcon?: boolean;
-	icon: types.children;
+	icon?: types.children;
 	showLeafIcon?: boolean;
-	leafIcon: types.children;
+	leafIcon?: types.children;
 	showLine?: boolean;
-	switcherIcon: (expanded: boolean) => types.children;
+	switcherIcon?: (expanded: boolean) => types.children;
 	render?: (data: any) => any;
-	renderItem: (item: any, count?: number, isSelected?: boolean) => any;
+	renderItem?: (item: any, count?: number, isSelected?: boolean) => any;
 	dataField: types.stringArray;
 	showFilter?: boolean;
 	index?: string;
@@ -32,6 +32,7 @@ export interface TreeListProps extends CommonProps {
 	customQuery?: (...args: any[]) => any;
 	defaultQuery?: (...args: any[]) => any;
 	endpoint?: types.endpointConfig;
+	title?: types.title;
 }
 
 declare const TreeList: React.ComponentClass<TreeListProps>;


### PR DESCRIPTION
The typings for TreeList were incorrect resulting in the need for overrides. The title attribute was missing and icon, leafIcon, switcherIcon and renderItem were mandatory (although they are optional). The TreeList example here https://github.com/appbaseio/reactivesearch/blob/next/packages/web/examples/TreeList/src/index.js#L18-L25 confirms this.
