### PR TITLE
fix(web): Handle dataField array queries for TreeList

### DIFF
--- a/packages/web/src/components/list/TreeList.d.ts
+++ b/packages/web/src/components/list/TreeList.d.ts
@@ -37,6 +37,10 @@ export interface TreeListProps extends CommonProps {
 	sortBy?: types.sortByWithCount;
 	size?: number;
 	nestedField?: string;
+	URLParams?: boolean;
+	innerClass?: types.style;
+	placeholder?: string;
+	react?: types.react;
 }
 
 declare const TreeList: React.ComponentClass<TreeListProps>;

--- a/packages/web/src/components/list/TreeList.d.ts
+++ b/packages/web/src/components/list/TreeList.d.ts
@@ -33,6 +33,10 @@ export interface TreeListProps extends CommonProps {
 	defaultQuery?: (...args: any[]) => any;
 	endpoint?: types.endpointConfig;
 	title?: types.title;
+	queryFormat?: types.queryFormatSearch;
+	sortBy?: types.sortByWithCount;
+	size?: number;
+	nestedField?: string;
 }
 
 declare const TreeList: React.ComponentClass<TreeListProps>;


### PR DESCRIPTION
Pre-requisite: https://github.com/appbaseio/reactivecore/pull/142

This change ensures that the queries generated by the TreeList are correct and adhere to the fact that `dataField` is an array of strings not a single string.
I have also added some fixes for:

* nested queries
* size not being set
* sortBy not being set
* choice of `and` or `or` for selection (defaults to `or` as in MultiList)

