### PR TITLE
fix(vue): fix initial hydration of query options in DataSearch component

### DIFF
--- a/packages/vue/src/components/basic/ComponentWrapper.jsx
+++ b/packages/vue/src/components/basic/ComponentWrapper.jsx
@@ -128,18 +128,22 @@ const ComponentWrapper = (
 	},
 	methods: {
 		setReact(props) {
-			const { react } = props;
+			const { react, executeInitialQuery } = props;
 			if (this.internalComponent) {
 				if (react) {
 					const newReact = pushToAndClause(react, this.internalComponent);
-					this.watchComponent(props.componentId, newReact);
+					this.watchComponent(props.componentId, newReact, executeInitialQuery);
 				} else {
-					this.watchComponent(props.componentId, {
-						and: this.internalComponent,
-					});
+					this.watchComponent(
+						props.componentId,
+						{
+							and: this.internalComponent,
+						},
+						executeInitialQuery,
+					);
 				}
 			} else {
-				this.watchComponent(props.componentId, react);
+				this.watchComponent(props.componentId, react, executeInitialQuery);
 			}
 		},
 	},

--- a/packages/vue/src/components/search/DataSearch.jsx
+++ b/packages/vue/src/components/search/DataSearch.jsx
@@ -123,6 +123,8 @@ const DataSearch = {
 		// Set custom and default queries in store
 		updateCustomQuery(this.componentId, this.setCustomQuery, this.$props, this.currentValue);
 		updateDefaultQuery(this.componentId, this.setDefaultQuery, this.$props, this.currentValue);
+
+		this.updateDefaultQueryHandler(this.currentValue, this.$props, false);
 	},
 	computed: {
 		suggestionsList() {
@@ -596,7 +598,7 @@ const DataSearch = {
 
 			checkValueChange(props.componentId, value, props.beforeValueChange, performUpdate);
 		},
-		updateDefaultQueryHandler(value, props) {
+		updateDefaultQueryHandler(value, props, execute) {
 			if (!value && props.enableDefaultSuggestions === false) {
 				// clear Component data from store
 				this.resetStoreForComponent(props.componentId);
@@ -620,14 +622,18 @@ const DataSearch = {
 					...this.queryOptions,
 					...defaultQueryOptions,
 				},
-				false,
+				execute,
 			);
-			this.updateQuery({
-				componentId: this.internalComponent,
-				query,
-				value,
-				componentType: componentTypes.dataSearch,
-			});
+			this.updateQuery(
+				{
+					componentId: this.internalComponent,
+					query,
+					value,
+					componentType: componentTypes.dataSearch,
+				},
+				execute,
+			);
+			window.console.log('execute', execute);
 		},
 		updateQueryHandler(componentId, value, props) {
 			const { customQuery, filterLabel, showFilter, URLParams } = props;

--- a/packages/vue/src/components/search/DataSearch.jsx
+++ b/packages/vue/src/components/search/DataSearch.jsx
@@ -633,7 +633,6 @@ const DataSearch = {
 				},
 				execute,
 			);
-			window.console.log('execute', execute);
 		},
 		updateQueryHandler(componentId, value, props) {
 			const { customQuery, filterLabel, showFilter, URLParams } = props;


### PR DESCRIPTION
**PR Type** `fix` 🐞 

**Description** The PR fixes an issue with setting the query options considering the `deafultQuery` in **DataSearch** component.

https://github.com/appbaseio/reactivecore/pull/145

https://www.loom.com/share/9f2a589e311f41008ea07861be141f2a