### PR TITLE
Infinite scroll adding the scroll event properly

### DIFF
--- a/packages/vue/src/components/result/ReactiveList.jsx
+++ b/packages/vue/src/components/result/ReactiveList.jsx
@@ -309,8 +309,18 @@ const ReactiveList = {
 			}
 		},
 		infiniteScroll(newVal, oldVal) {
+			if (newVal !== oldVal)
+			{
+				if (newVal && !this.pagination) {
+					window.addEventListener('scroll', this.scrollHandler);
+				} else {
+					window.removeEventListener('scroll', this.scrollHandler);
+				}
+			}
+		},
+		pagination(newVal, oldVal) {
 			if (newVal !== oldVal) {
-				if (!newVal) {
+				if (!newVal && this.infiniteScroll) {
 					window.addEventListener('scroll', this.scrollHandler);
 				} else {
 					window.removeEventListener('scroll', this.scrollHandler);


### PR DESCRIPTION
Switching from pagination to infinite scroll while the component is already mounted doesn't add the event.

This fixes that.