### PR TITLE
feat(web): add setPage prop in render props

### DIFF
--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -2,7 +2,6 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 
-
 import React, { Component } from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { withTheme } from 'emotion-theming';
@@ -812,6 +811,7 @@ class ReactiveList extends Component {
 			settings: this.props.settings,
 			triggerExportCSV: this.triggerExportCSV,
 			triggerExportJSON: this.triggerExportJSON,
+			setPage: this.setPage,
 		};
 	};
 


### PR DESCRIPTION
**PR Type** `feat`

**Description** The PR adds the `setPage` method in the render prop of the `ReactiveList` component to allow custom pagination. Addresses https://github.com/appbaseio/reactivesearch/issues/2121.

https://github.com/appbaseio/Docs/pull/364

