### PR TITLE
feat(vue): local treeshaking of components

### DIFF
--- a/packages/vue/src/components/basic/ReactiveComponent.jsx
+++ b/packages/vue/src/components/basic/ReactiveComponent.jsx
@@ -17,7 +17,7 @@ import { ListConnected as SingleList } from '../list/SingleList.jsx';
 import { ListConnected as MultiList } from '../list/MultiList.jsx';
 import { ListConnected as SingleDropdownList } from '../list/SingleDropdownList.jsx';
 import { ListConnected as MultiDropdownList } from '../list/MultiDropdownList.jsx';
-import { ListConnected as ToggleButton } from '../list/ToggleButton.jsx';
+import { TBConnected as ToggleButton } from '../list/ToggleButton.jsx';
 import { RangeConnected as DynamicRangeSlider } from '../range/DynamicRangeSlider.jsx';
 import { RangeConnected as SingleRange } from '../range/SingleRange.jsx';
 import { RangeConnected as MultiRange } from '../range/MultiRange.jsx';
@@ -420,12 +420,12 @@ const RcConnected = PreferencesConsumer({
 		});
 	},
 });
-
-ReactiveComponent.install = function (Vue) {
-	Vue.component(ReactiveComponent.name, RcConnected);
+RcConnected.name = ReactiveComponent.name;
+RcConnected.install = function (Vue) {
+	Vue.component(RcConnected.name, RcConnected);
 };
 
 // Add componentType for SSR
-ReactiveComponent.componentType = componentTypes.reactiveComponent;
+RcConnected.componentType = componentTypes.reactiveComponent;
 
-export default ReactiveComponent;
+export default RcConnected;

--- a/packages/vue/src/components/basic/SelectedFilters.jsx
+++ b/packages/vue/src/components/basic/SelectedFilters.jsx
@@ -176,8 +176,9 @@ const mapDispatchtoProps = {
 };
 
 const RcConnected = connect(mapStateToProps, mapDispatchtoProps)(SelectedFilters);
+RcConnected.name = SelectedFilters.name;
 
-SelectedFilters.install = function (Vue) {
-	Vue.component(SelectedFilters.name, RcConnected);
+RcConnected.install = function (Vue) {
+	Vue.component(RcConnected.name, RcConnected);
 };
-export default SelectedFilters;
+export default RcConnected;

--- a/packages/vue/src/components/basic/StateProvider.jsx
+++ b/packages/vue/src/components/basic/StateProvider.jsx
@@ -246,8 +246,8 @@ const mapDispatchtoProps = {
 };
 
 const StateProviderConnected = connect(mapStateToProps, mapDispatchtoProps)(StateProvider);
-
-StateProvider.install = function (Vue) {
-	Vue.component(StateProvider.name, StateProviderConnected);
+StateProviderConnected.name = StateProvider.name;
+StateProviderConnected.install = function (Vue) {
+	Vue.component(StateProviderConnected.name, StateProviderConnected);
 };
-export default StateProvider;
+export default StateProviderConnected;

--- a/packages/vue/src/components/list/MultiDropdownList.jsx
+++ b/packages/vue/src/components/list/MultiDropdownList.jsx
@@ -210,7 +210,7 @@ const MultiDropdownList = {
 			selectAll = [
 				{
 					key: this.$props.selectAllLabel,
-					doc_count: this.totalDocumentCount
+					doc_count: this.totalDocumentCount,
 				},
 			];
 		}
@@ -574,12 +574,13 @@ export const ListConnected = PreferencesConsumer(
 		internalComponent: MultiDropdownList.hasInternalComponent(),
 	}),
 );
+ListConnected.name = MultiDropdownList.name;
 
-MultiDropdownList.install = function (Vue) {
-	Vue.component(MultiDropdownList.name, ListConnected);
+ListConnected.install = function (Vue) {
+	Vue.component(ListConnected.name, ListConnected);
 };
 
 // Add componentType for SSR
-MultiDropdownList.componentType = componentTypes.multiDropdownList;
+ListConnected.componentType = componentTypes.multiDropdownList;
 
-export default MultiDropdownList;
+export default ListConnected;

--- a/packages/vue/src/components/list/MultiList.jsx
+++ b/packages/vue/src/components/list/MultiList.jsx
@@ -641,12 +641,12 @@ export const ListConnected = PreferencesConsumer(
 		internalComponent: MultiList.hasInternalComponent(),
 	}),
 );
-
-MultiList.install = function (Vue) {
-	Vue.component(MultiList.name, ListConnected);
+ListConnected.name = MultiList.name;
+ListConnected.install = function (Vue) {
+	Vue.component(ListConnected.name, ListConnected);
 };
 
 // Add componentType for SSR
-MultiList.componentType = componentTypes.multiList;
+ListConnected.componentType = componentTypes.multiList;
 
-export default MultiList;
+export default ListConnected;

--- a/packages/vue/src/components/list/SingleDropdownList.jsx
+++ b/packages/vue/src/components/list/SingleDropdownList.jsx
@@ -200,7 +200,7 @@ const SingleDropdownList = {
 			selectAll = [
 				{
 					key: this.$props.selectAllLabel,
-					doc_count: this.totalDocumentCount
+					doc_count: this.totalDocumentCount,
 				},
 			];
 		}
@@ -462,12 +462,12 @@ export const ListConnected = PreferencesConsumer(
 		internalComponent: SingleDropdownList.hasInternalComponent(),
 	}),
 );
-
-SingleDropdownList.install = function (Vue) {
-	Vue.component(SingleDropdownList.name, ListConnected);
+ListConnected.name = SingleDropdownList.name;
+ListConnected.install = function (Vue) {
+	Vue.component(ListConnected.name, ListConnected);
 };
 
 // Add componentType for SSR
-SingleDropdownList.componentType = componentTypes.singleDropdownList;
+ListConnected.componentType = componentTypes.singleDropdownList;
 
-export default SingleDropdownList;
+export default ListConnected;

--- a/packages/vue/src/components/list/SingleList.jsx
+++ b/packages/vue/src/components/list/SingleList.jsx
@@ -541,12 +541,13 @@ export const ListConnected = PreferencesConsumer(
 		internalComponent: SingleList.hasInternalComponent(),
 	}),
 );
+ListConnected.name = SingleList.name;
 
-SingleList.install = function (Vue) {
-	Vue.component(SingleList.name, ListConnected);
+ListConnected.install = function (Vue) {
+	Vue.component(ListConnected.name, ListConnected);
 };
 
 // Add componentType for SSR
-SingleList.componentType = componentTypes.singleList;
+ListConnected.componentType = componentTypes.singleList;
 
-export default SingleList;
+export default ListConnected;

--- a/packages/vue/src/components/list/ToggleButton.jsx
+++ b/packages/vue/src/components/list/ToggleButton.jsx
@@ -295,16 +295,17 @@ const mapDispatchtoProps = {
 	setCustomQuery,
 };
 
-export const ListConnected = PreferencesConsumer(
+export const TBConnected = PreferencesConsumer(
 	ComponentWrapper(connect(mapStateToProps, mapDispatchtoProps)(ToggleButton), {
 		componentType: componentTypes.toggleButton,
 	}),
 );
+TBConnected.name = ToggleButton.name;
 
-ToggleButton.install = function (Vue) {
-	Vue.component(ToggleButton.name, ListConnected);
+TBConnected.install = function (Vue) {
+	Vue.component(TBConnected.name, TBConnected);
 };
 // Add componentType for SSR
-ToggleButton.componentType = componentTypes.toggleButton;
+TBConnected.componentType = componentTypes.toggleButton;
 
-export default ToggleButton;
+export default TBConnected;

--- a/packages/vue/src/components/range/DynamicRangeSlider.jsx
+++ b/packages/vue/src/components/range/DynamicRangeSlider.jsx
@@ -473,11 +473,13 @@ export const RangeConnected = PreferencesConsumer(
 	connect(mapStateToProps, mapDispatchtoProps)(DynamicRangeSlider),
 );
 
-DynamicRangeSlider.install = function (Vue) {
-	Vue.component(DynamicRangeSlider.name, RangeConnected);
+RangeConnected.name = DynamicRangeSlider.name;
+
+RangeConnected.install = function (Vue) {
+	Vue.component(RangeConnected.name, RangeConnected);
 };
 
 // Add componentType for SSR
-DynamicRangeSlider.componentType = componentTypes.dynamicRangeSlider;
+RangeConnected.componentType = componentTypes.dynamicRangeSlider;
 
-export default DynamicRangeSlider;
+export default RangeConnected;

--- a/packages/vue/src/components/range/MultiRange.jsx
+++ b/packages/vue/src/components/range/MultiRange.jsx
@@ -287,11 +287,12 @@ export const RangeConnected = PreferencesConsumer(
 		componentType: componentTypes.multiRange,
 	}),
 );
+RangeConnected.name = MultiRange.name;
 
-MultiRange.install = function (Vue) {
-	Vue.component(MultiRange.name, RangeConnected);
+RangeConnected.install = function (Vue) {
+	Vue.component(RangeConnected.name, RangeConnected);
 };
 // Add componentType for SSR
-MultiRange.componentType = componentTypes.multiRange;
+RangeConnected.componentType = componentTypes.multiRange;
 
-export default MultiRange;
+export default RangeConnected;

--- a/packages/vue/src/components/range/RangeInput.jsx
+++ b/packages/vue/src/components/range/RangeInput.jsx
@@ -290,12 +290,13 @@ export const RangeConnected = PreferencesConsumer(
 		componentType: componentTypes.rangeInput,
 	}),
 );
+RangeConnected.name = RangeInput.name;
 
-RangeInput.install = function (Vue) {
-	Vue.component(RangeInput.name, RangeConnected);
+RangeConnected.install = function (Vue) {
+	Vue.component(RangeConnected.name, RangeConnected);
 };
 
 // Add componentType for SSR
-RangeInput.componentType = componentTypes.rangeInput;
+RangeConnected.componentType = componentTypes.rangeInput;
 
-export default RangeInput;
+export default RangeConnected;

--- a/packages/vue/src/components/range/RangeSlider.jsx
+++ b/packages/vue/src/components/range/RangeSlider.jsx
@@ -289,12 +289,13 @@ export const RangeConnected = PreferencesConsumer(
 		componentType: componentTypes.rangeSlider,
 	}),
 );
+RangeConnected.name = RangeSlider.name;
 
-RangeSlider.install = function (Vue) {
-	Vue.component(RangeSlider.name, RangeConnected);
+RangeConnected.install = function (Vue) {
+	Vue.component(RangeConnected.name, RangeConnected);
 };
 
 // Add componentType for SSR
-RangeSlider.componentType = componentTypes.rangeSlider;
+RangeConnected.componentType = componentTypes.rangeSlider;
 
-export default RangeSlider;
+export default RangeConnected;

--- a/packages/vue/src/components/range/SingleRange.jsx
+++ b/packages/vue/src/components/range/SingleRange.jsx
@@ -227,11 +227,12 @@ export const RangeConnected = PreferencesConsumer(
 		componentType: componentTypes.singleRange,
 	}),
 );
+RangeConnected.name = SingleRange.name;
 
-SingleRange.install = function (Vue) {
-	Vue.component(SingleRange.name, RangeConnected);
+RangeConnected.install = function (Vue) {
+	Vue.component(RangeConnected.name, RangeConnected);
 };
 // Add componentType for SSR
-SingleRange.componentType = componentTypes.singleRange;
+RangeConnected.componentType = componentTypes.singleRange;
 
-export default SingleRange;
+export default RangeConnected;

--- a/packages/vue/src/components/result/ReactiveList.jsx
+++ b/packages/vue/src/components/result/ReactiveList.jsx
@@ -872,12 +872,14 @@ export const RLConnected = PreferencesConsumer(
 	}),
 );
 
-ReactiveList.install = function (Vue) {
-	Vue.component(ReactiveList.name, RLConnected);
+RLConnected.name = ReactiveList.name;
+
+RLConnected.install = function (Vue) {
+	Vue.component(RLConnected.name, RLConnected);
 	Vue.component(ResultListWrapper.name, ResultListWrapper);
 	Vue.component(ResultCardsWrapper.name, ResultCardsWrapper);
 };
 // Add componentType for SSR
-ReactiveList.componentType = componentTypes.reactiveList;
+RLConnected.componentType = componentTypes.reactiveList;
 
-export default ReactiveList;
+export default RLConnected;

--- a/packages/vue/src/components/search/DataSearch.jsx
+++ b/packages/vue/src/components/search/DataSearch.jsx
@@ -1612,10 +1612,13 @@ export const DSConnected = PreferencesConsumer(
 	}),
 );
 
-DataSearch.install = function (Vue) {
-	Vue.component(DataSearch.name, DSConnected);
+DSConnected.name = DataSearch.name;
+
+// plugins usage
+DSConnected.install = function (Vue) {
+	Vue.component(DSConnected.name, DSConnected);
 };
 // Add componentType for SSR
-DataSearch.componentType = componentTypes.dataSearch;
+DSConnected.componentType = componentTypes.dataSearch;
 
-export default DataSearch;
+export default DSConnected;

--- a/packages/vue/src/components/search/SearchBox.jsx
+++ b/packages/vue/src/components/search/SearchBox.jsx
@@ -1457,11 +1457,11 @@ export const SBConnected = PreferencesConsumer(
 		internalComponent: true,
 	}),
 );
-
-SearchBox.install = function (Vue) {
-	Vue.component(SearchBox.name, SBConnected);
+SBConnected.name = SearchBox.name;
+SBConnected.install = function (Vue) {
+	Vue.component(SBConnected.name, SBConnected);
 };
 // Add componentType for SSR
-SearchBox.componentType = componentTypes.searchBox;
+SBConnected.componentType = componentTypes.searchBox;
 
-export default SearchBox;
+export default SBConnected;


### PR DESCRIPTION
**PR Type** `feature` ⭐ 

**Description** The PR allows local tree-shaking of Vue components.

[📔 Notion](https://www.notion.so/Funda-Enable-tree-shaking-for-Appbase-components-1fb92b5d01184fda90d331f110710b18)


https://www.loom.com/share/12c23e34be8543e589d65bee838a14b6

Components' list
---
- [x] ReactiveList
- [x] ReactiveBase
- [x] DataSearch
- [x] SearchBox
- [x] SingleList
- [x] MultiList
- [x] SingleDropdownList
- [x] MultiDropdownList
- [x] ToggleButton
- [x] ReactiveComponent
- [x] SelectedFilters
- [x] SingleRange
- [x] MultiRange
- [x] ResultCard
- [x] ResultList
- [x] RangeSlider
- [x] DynamicRangeSlider
- [x] StateProvider
- [ ] ReactiveGoogleMap
- [x] RangeInput
