### PR TITLE
fix(vue): - DataSearch - enter key press behavior for tag mode

### DIFF
--- a/packages/vue/src/components/search/DataSearch.jsx
+++ b/packages/vue/src/components/search/DataSearch.jsx
@@ -639,7 +639,6 @@ const DataSearch = {
 		},
 		updateQueryHandler(componentId, value, props) {
 			const { customQuery, filterLabel, showFilter, URLParams } = props;
-
 			let customQueryOptions;
 			const defaultQueryTobeSet = DataSearch.defaultQuery(value, props);
 			let query = defaultQueryTobeSet;
@@ -719,13 +718,24 @@ const DataSearch = {
 
 		handleKeyDown(event, highlightedIndex) {
 			const { value: targetValue } = event.target;
-			const { value, strictSelection } = this.$props;
+			const { value, strictSelection, size } = this.$props;
 			if (value !== undefined) {
 				this.isPending = true;
 			}
 
 			// if a suggestion was selected, delegate the handling to suggestion handler
-			if (event.key === 'Enter' && (highlightedIndex === null || highlightedIndex < 0)) {
+			if (
+				event.key === 'Enter'
+				&& (highlightedIndex === null
+					|| highlightedIndex < 0
+					|| highlightedIndex
+						=== [
+							...[...this.suggestionsList].slice(0, size || 10),
+							...this.defaultSearchSuggestions,
+							...this.topSuggestions,
+						].length)
+			) {
+				this.isPending = false;
 				this.setValue(
 					this.$options.isTagsMode && strictSelection ? '' : targetValue,
 					true,

--- a/packages/vue/src/components/search/DataSearch.jsx
+++ b/packages/vue/src/components/search/DataSearch.jsx
@@ -572,15 +572,10 @@ const DataSearch = {
 					// to set the query otherwise the value should reset
 
 					if (props.strictSelection) {
-						if (
-							cause === causes.SUGGESTION_SELECT
-							|| (this.$options.isTagsMode
-								? this.selectedTags.length === 0
-								: value === '')
-						) {
+						if (cause === causes.SUGGESTION_SELECT) {
 							this.updateQueryHandler(props.componentId, queryHandlerValue, props);
 						} else {
-							this.setValue('', true);
+							this.setValue('', true, props, undefined, true, false);
 						}
 					} else {
 						this.updateQueryHandler(props.componentId, queryHandlerValue, props);
@@ -730,13 +725,8 @@ const DataSearch = {
 			}
 
 			// if a suggestion was selected, delegate the handling to suggestion handler
-			if (event.key === 'Enter' && highlightedIndex === null) {
-				this.setValue(
-					event.target.value,
-					true,
-					this.$props,
-					this.$options.isTagsMode ? causes.SUGGESTION_SELECT : undefined, // to handle tags
-				);
+			if (event.key === 'Enter' && (highlightedIndex === null || highlightedIndex < 0)) {
+				this.setValue(event.target.value, true, this.$props, undefined, false, false);
 				this.onValueSelectedHandler(event.target.value, causes.ENTER_PRESS);
 			}
 			// Need to review

--- a/packages/vue/src/components/search/DataSearch.jsx
+++ b/packages/vue/src/components/search/DataSearch.jsx
@@ -125,6 +125,7 @@ const DataSearch = {
 			this.updateDefaultQueryHandler,
 			this.$props.debounce,
 		);
+		this.updateQueryHandlerDebounced = debounce(this.updateQueryHandler, this.$props.debounce);
 		// Set custom and default queries in store
 		updateCustomQuery(this.componentId, this.setCustomQuery, this.$props, this.currentValue);
 		updateDefaultQuery(this.componentId, this.setDefaultQuery, this.$props, this.currentValue);
@@ -364,7 +365,7 @@ const DataSearch = {
 					newVal,
 					true,
 					this.$props,
-					undefined,
+					newVal === '' ? causes.CLEAR_VALUE : undefined,
 					false,
 					typeof newVal !== 'string' && this.$options.isTagsMode,
 				);
@@ -420,11 +421,7 @@ const DataSearch = {
 			if (this.$props.autosuggest) {
 				this.updateDefaultQueryHandlerDebounced(value, this.$props);
 			} else {
-				this.updateDefaultQueryHandlerDebounced(
-					this.$props.componentId,
-					value,
-					this.$props,
-				);
+				this.updateQueryHandlerDebounced(this.$props.componentId, value, this.$props);
 			}
 		},
 		validateDataField() {

--- a/packages/vue/src/components/search/DataSearch.jsx
+++ b/packages/vue/src/components/search/DataSearch.jsx
@@ -571,10 +571,10 @@ const DataSearch = {
 					// to set the query otherwise the value should reset
 
 					if (props.strictSelection && props.autosuggest) {
-						if (cause === causes.SUGGESTION_SELECT) {
+						if (cause === causes.SUGGESTION_SELECT || props.value !== undefined) {
 							this.updateQueryHandler(props.componentId, queryHandlerValue, props);
-						} else {
-							this.setValue('', true, props, undefined, true, false);
+						} else if (this.currentValue !== '') {
+							this.setValue('', true);
 						}
 					} else {
 						this.updateQueryHandler(props.componentId, queryHandlerValue, props);
@@ -719,14 +719,20 @@ const DataSearch = {
 
 		handleKeyDown(event, highlightedIndex) {
 			const { value: targetValue } = event.target;
-			const { value } = this.$props;
+			const { value, strictSelection } = this.$props;
 			if (value !== undefined) {
 				this.isPending = true;
 			}
 
 			// if a suggestion was selected, delegate the handling to suggestion handler
 			if (event.key === 'Enter' && (highlightedIndex === null || highlightedIndex < 0)) {
-				this.setValue(targetValue, true, this.$props, undefined, false, false);
+				this.setValue(
+					this.$options.isTagsMode && strictSelection ? '' : targetValue,
+					true,
+					this.$props,
+					undefined,
+					false,
+				);
 				this.onValueSelectedHandler(targetValue, causes.ENTER_PRESS);
 			}
 			// Need to review
@@ -746,13 +752,12 @@ const DataSearch = {
 				this.setValue(inputValue, false, this.$props, undefined, true, false);
 			} else {
 				this.isPending = true;
-
+				this.currentValue = inputValue;
 				this.$emit(
 					'change',
 					inputValue,
 					({ isOpen = false } = {}) => {
 						if (this.$options.isTagsMode && autosuggest) {
-							this.currentValue = value;
 							this.isOpen = isOpen;
 							this.updateDefaultQueryHandlerDebounced(this.currentValue, this.$props);
 							return;
@@ -1334,6 +1339,8 @@ const DataSearch = {
 														domProps: getInputProps({
 															value:
 																this.$data.currentValue === null
+																|| typeof this.$data.currentValue
+																	!== 'string'
 																	? ''
 																	: this.$data.currentValue,
 														}),
@@ -1376,27 +1383,6 @@ const DataSearch = {
 												this.$emit('focus', e, this.triggerQuery);
 											},
 											keydown: (e) => {
-												const { value } = this.$props;
-												if (value !== undefined) {
-													this.isPending = true;
-												}
-
-												// if a suggestion was selected, delegate the handling to suggestion handler
-												if (e.key === 'Enter' && this.$options.isTagsMode) {
-													const { value: targetValue } = e.target;
-													this.setValue(
-														targetValue,
-														true,
-														this.$props,
-														undefined,
-														false,
-														true,
-													);
-													this.onValueSelectedHandler(
-														targetValue,
-														causes.ENTER_PRESS,
-													);
-												}
 												this.$emit('keyDown', e, this.triggerQuery);
 												this.$emit('key-down', e, this.triggerQuery);
 											},

--- a/packages/vue/src/components/search/SearchBox.jsx
+++ b/packages/vue/src/components/search/SearchBox.jsx
@@ -297,7 +297,7 @@ const SearchBox = {
 					// selected value is cleared, call onValueSelected
 					this.onValueSelectedHandler('', causes.CLEAR_VALUE);
 				}
-				// if (this.$props.value === undefined) {
+
 				if (this.$options.isTagsMode) {
 					// handling reset of tags through SelectedFilters or URL
 					this.selectedTags = [];
@@ -307,7 +307,6 @@ const SearchBox = {
 					cause = causes.SUGGESTION_SELECT;
 				}
 				this.setValue(newVal || '', true, this.$props, cause);
-				// }
 			}
 		},
 		focusShortcuts() {
@@ -448,10 +447,7 @@ const SearchBox = {
 						if (typeof value === 'string' && !!value) {
 							this.selectedTags.push(value);
 						} else if (Array.isArray(value) && !isEqual(this.selectedTags, value)) {
-							const mergedArray = Array.from(
-								new Set([...this.selectedTags, ...value]),
-							);
-							this.selectedTags = mergedArray;
+							this.selectedTags = value;
 						}
 					} else if (value) {
 						this.selectedTags = typeof value !== 'string' ? value : [...value];


### PR DESCRIPTION
**PR Type** `fix`

**Description** The PR intends to fix the enter key press behavior for the DataSeach component when the mode prop is set to `tag`.

[📔  Notion](https://www.notion.so/reactivesearch/Funda-Disable-enter-event-on-DataSearch-b20736d2037346cbae0a8b12d6f35ecf)

https://www.loom.com/share/1b85041a890940b2a8dc5747eaa01acd

https://github.com/appbaseio/Docs/pull/367