### PR TITLE
fix(vue): datasearch component tags mode for autosuggest off

### DIFF
--- a/packages/vue/src/components/search/DataSearch.jsx
+++ b/packages/vue/src/components/search/DataSearch.jsx
@@ -718,11 +718,10 @@ const DataSearch = {
 
 		handleKeyDown(event, highlightedIndex) {
 			const { value: targetValue } = event.target;
-			const { value, strictSelection, size } = this.$props;
+			const { value, strictSelection, size, autosuggest } = this.$props;
 			if (value !== undefined) {
 				this.isPending = true;
 			}
-
 			// if a suggestion was selected, delegate the handling to suggestion handler
 			if (
 				event.key === 'Enter'
@@ -737,7 +736,7 @@ const DataSearch = {
 			) {
 				this.isPending = false;
 				this.setValue(
-					this.$options.isTagsMode && strictSelection ? '' : targetValue,
+					this.$options.isTagsMode && autosuggest && strictSelection ? '' : targetValue,
 					true,
 					this.$props,
 					undefined,
@@ -1393,8 +1392,7 @@ const DataSearch = {
 												this.$emit('focus', e, this.triggerQuery);
 											},
 											keydown: (e) => {
-												this.$emit('keyDown', e, this.triggerQuery);
-												this.$emit('key-down', e, this.triggerQuery);
+												this.handleKeyDown(e, null);
 											},
 											keyup: (e) => {
 												this.$emit('keyUp', e, this.triggerQuery);


### PR DESCRIPTION
**PR Type** `fix` 🐞 

**Description** The PR fixes working with tags mode when the `autosuggest` prop is set to `false`.

[📔  Notion](https://www.notion.so/reactivesearch/Funda-DataSearch-renderSelectedTags-slot-not-working-autosuggest-set-false-bce2d15d9330436bbb3812311420d3ff)

https://www.loom.com/share/0ecfbe3d40a740ac895dfa0d73644d8c
