### PR TITLE
Fix Vue renderNoResults check

### DIFF
--- a/packages/vue/src/components/list/MultiList.jsx
+++ b/packages/vue/src/components/list/MultiList.jsx
@@ -172,7 +172,7 @@ const MultiList = {
 		}
 
 		if (!this.hasCustomRenderer && this.modifiedOptions.length === 0 && !this.isLoading) {
-			if (this.renderNoResult) {
+			if (this.renderNoResults) {
 				this.renderNoResult();
 			} else {
 				return null;

--- a/packages/vue/src/components/list/SingleList.jsx
+++ b/packages/vue/src/components/list/SingleList.jsx
@@ -154,7 +154,7 @@ const SingleList = {
 		}
 
 		if (!this.hasCustomRenderer && this.modifiedOptions.length === 0 && !this.isLoading) {
-			if (this.renderNoResult) {
+			if (this.renderNoResults) {
 				this.renderNoResult();
 			} else {
 				return null;


### PR DESCRIPTION
The renderNoResults check was not checking the prop but the internal function instead. Therefor a title was always rendered even if you don't want to display a no results text. By fixing the check it makes it possible to hide titles if there are no results as was the case in the past.

It could have a side effect for new users that titles are no longer displayed for empty filters if they don't set a renderNoResults prop. However this is the case for the React version as well so it's probably expected.

