### PR TITLE
Fix/components not reacting to props

### DIFF
--- a/packages/web/src/components/basic/ComponentWrapper.js
+++ b/packages/web/src/components/basic/ComponentWrapper.js
@@ -9,7 +9,7 @@ import {
 	hasCustomRenderer,
 	getComponent,
 } from '@appbaseio/reactivecore/lib/utils/helper';
-import { string } from 'prop-types';
+import { object, string } from 'prop-types';
 import {
 	addComponent,
 	removeComponent,
@@ -131,7 +131,7 @@ class ComponentWrapper extends React.Component {
 
 	render() {
 		if (this.hasCustomRenderer) {
-			return getComponent({}, this.props);
+			return getComponent(this.props.componentProps, this.props);
 		}
 		return null;
 	}
@@ -156,6 +156,7 @@ ComponentWrapper.propTypes = {
 	react: types.react,
 	render: types.func,
 	setReact: types.bool,
+	componentProps: object, // eslint-disable-line
 	// props to test the components
 	mockData: types.any, // eslint-disable-line
 	mode: string,
@@ -165,6 +166,10 @@ ComponentWrapper.defaultProps = {
 	setReact: true,
 	destroyOnUnmount: true,
 };
+
+const mapStateToProps = (state, ownProps) => ({
+	componentProps: state.props[ownProps.componentId],
+});
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
 	setTestData: (component, data) => dispatch(mockDataForTesting(component, data)),
@@ -180,4 +185,4 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
 		dispatch(setQueryListener(component, onQueryChange, beforeQueryChange)),
 });
 
-export default connect(null, mapDispatchToProps)(ComponentWrapper);
+export default connect(mapStateToProps, mapDispatchToProps)(ComponentWrapper);

--- a/packages/web/src/components/basic/NumberBox.js
+++ b/packages/web/src/components/basic/NumberBox.js
@@ -289,7 +289,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.numberBox}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/basic/NumberBox.js
+++ b/packages/web/src/components/basic/NumberBox.js
@@ -64,7 +64,7 @@ class NumberBox extends Component {
 		checkPropChange(this.props.queryFormat, this.props.queryFormat, () => {
 			this.updateQuery(this.state.currentValue, this.props);
 		});
-		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField'], () => {
+		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField', 'aggregationSize'], () => {
 			this.updateQuery(this.state.currentValue, this.props);
 		});
 	}

--- a/packages/web/src/components/basic/ReactiveComponent.js
+++ b/packages/web/src/components/basic/ReactiveComponent.js
@@ -487,7 +487,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 							internalComponent={!!props.defaultQuery}
 							componentType={componentTypes.reactiveComponent}
 						>
-							{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+							{
+								componentProps =>
+									(<ConnectedComponent
+										{...preferenceProps}
+										{...componentProps}
+										myForwardedRef={ref}
+									/>)
+							}
 						</ComponentWrapper>
 					);
 			}

--- a/packages/web/src/components/chart/ReactiveChart.js
+++ b/packages/web/src/components/chart/ReactiveChart.js
@@ -340,6 +340,7 @@ class ReactiveChart extends React.Component {
 					contextmenu: onContextMenu,
 					datazoom: this.handleRange,
 				}}
+				notMerge
 			/>
 		);
 	}

--- a/packages/web/src/components/chart/ReactiveChart.js
+++ b/packages/web/src/components/chart/ReactiveChart.js
@@ -90,7 +90,7 @@ class ReactiveChart extends React.Component {
 				options: this.transformOptions(this.props.options, this.props),
 			});
 		}
-		checkSomePropChange(this.props, prevProps, ['dataField'], () => {
+		checkSomePropChange(this.props, prevProps, ['dataField', 'aggregationSize'], () => {
 			this.updateDefaultQuery();
 			this.updateQuery(this.state.currentValue, this.props);
 		});

--- a/packages/web/src/components/chart/ReactiveChart.js
+++ b/packages/web/src/components/chart/ReactiveChart.js
@@ -25,6 +25,7 @@ import {
 	isFunction,
 	debounce,
 	parseHits,
+	checkSomePropChange,
 } from '@appbaseio/reactivecore/lib/utils/helper';
 import {
 	connect,
@@ -89,6 +90,10 @@ class ReactiveChart extends React.Component {
 				options: this.transformOptions(this.props.options, this.props),
 			});
 		}
+		checkSomePropChange(this.props, prevProps, ['dataField'], () => {
+			this.updateDefaultQuery();
+			this.updateQuery(this.state.currentValue, this.props);
+		});
 		if (!isQueryIdentical(this.state.currentValue, this.props, prevProps, 'defaultQuery')) {
 			this.updateDefaultQuery();
 			// Clear the component value
@@ -868,7 +873,7 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 					size={size}
 					dataField={dataField}
 				>
-					{() => (
+					{componentProps => (
 						<ConnectedComponent
 							{...preferenceProps}
 							size={size}
@@ -876,6 +881,7 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 							aggregationSize={aggregationSize}
 							dataField={dataField}
 							myForwardedRef={ref}
+							{...componentProps}
 						/>
 					)}
 				</ComponentWrapper>

--- a/packages/web/src/components/date/DatePicker.js
+++ b/packages/web/src/components/date/DatePicker.js
@@ -326,7 +326,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.datePicker}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/date/DatePicker.js
+++ b/packages/web/src/components/date/DatePicker.js
@@ -54,7 +54,7 @@ class DatePicker extends Component {
 	}
 
 	componentDidUpdate(prevProps) {
-		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField'], () =>
+		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField', 'aggregationSize'], () =>
 			this.updateQuery(
 				this.state.currentDate ? this.formatInputDate(this.state.currentDate) : null,
 				this.props,

--- a/packages/web/src/components/date/DateRange.js
+++ b/packages/web/src/components/date/DateRange.js
@@ -114,7 +114,7 @@ class DateRange extends Component {
 			}
 		}
 
-		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField'], () =>
+		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField', 'aggregationSize'], () =>
 			this.updateQuery(
 				this.state.currentDate
 					? {

--- a/packages/web/src/components/date/DateRange.js
+++ b/packages/web/src/components/date/DateRange.js
@@ -601,7 +601,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.dateRange}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/list/MultiDataList.js
+++ b/packages/web/src/components/list/MultiDataList.js
@@ -645,7 +645,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.multiDataList}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/list/MultiDataList.js
+++ b/packages/web/src/components/list/MultiDataList.js
@@ -79,7 +79,7 @@ class MultiDataList extends Component {
 		const valueArray
 			= typeof this.state.currentValue === 'object' ? Object.keys(this.state.currentValue) : [];
 
-		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField'], () => {
+		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField', 'aggregationSize'], () => {
 			this.updateQuery(valueArray, this.props);
 
 			if (this.props.showCount) {

--- a/packages/web/src/components/list/MultiDropdownList.js
+++ b/packages/web/src/components/list/MultiDropdownList.js
@@ -629,7 +629,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.multiDropdownList}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/list/MultiList.js
+++ b/packages/web/src/components/list/MultiList.js
@@ -805,7 +805,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.multiList}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/list/MultiList.js
+++ b/packages/web/src/components/list/MultiList.js
@@ -155,7 +155,7 @@ class MultiList extends Component {
 			this.updateQueryOptions(this.props),
 		);
 
-		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField'], () => {
+		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField', 'aggregationSize'], () => {
 			this.updateQueryOptions(this.props);
 			this.updateQuery(valueArray, this.props);
 		});

--- a/packages/web/src/components/list/SingleDataList.js
+++ b/packages/web/src/components/list/SingleDataList.js
@@ -586,7 +586,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.singleDataList}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/list/SingleDataList.js
+++ b/packages/web/src/components/list/SingleDataList.js
@@ -88,7 +88,7 @@ class SingleDataList extends Component {
 	}
 
 	componentDidUpdate(prevProps) {
-		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField'], () => {
+		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField', 'aggregationSize'], () => {
 			this.updateQuery(this.state.currentValue, this.props);
 
 			if (this.props.showCount) {

--- a/packages/web/src/components/list/SingleDropdownList.js
+++ b/packages/web/src/components/list/SingleDropdownList.js
@@ -503,7 +503,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.singleDropdownList}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/list/SingleList.js
+++ b/packages/web/src/components/list/SingleList.js
@@ -654,7 +654,10 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.singleList}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						<ConnectedComponent {...preferenceProps} {...componentProps} myForwardedRef={ref} />
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/list/SingleList.js
+++ b/packages/web/src/components/list/SingleList.js
@@ -125,7 +125,7 @@ class SingleList extends Component {
 			this.updateQueryOptions(this.props),
 		);
 
-		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField'], () => {
+		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField', 'aggregationSize'], () => {
 			this.updateQueryOptions(this.props);
 			this.updateQuery(this.state.currentValue, this.props);
 		});

--- a/packages/web/src/components/list/TagCloud.js
+++ b/packages/web/src/components/list/TagCloud.js
@@ -81,7 +81,7 @@ class TagCloud extends Component {
 			this.updateQueryOptions(this.props),
 		);
 
-		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField'], () => {
+		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField', 'aggregationSize'], () => {
 			this.updateQueryOptions(this.props);
 			this.updateQuery(Object.keys(this.state.currentValue), this.props);
 		});

--- a/packages/web/src/components/list/TagCloud.js
+++ b/packages/web/src/components/list/TagCloud.js
@@ -408,7 +408,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.tagCloud}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/list/ToggleButton.js
+++ b/packages/web/src/components/list/ToggleButton.js
@@ -56,7 +56,7 @@ class ToggleButton extends Component {
 	}
 
 	componentDidUpdate(prevProps) {
-		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField'], () => {
+		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField', 'aggregationSize'], () => {
 			this.updateQuery(this.state.currentValue, this.props);
 		});
 

--- a/packages/web/src/components/list/ToggleButton.js
+++ b/packages/web/src/components/list/ToggleButton.js
@@ -342,7 +342,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.toggleButton}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/list/TreeList/index.js
+++ b/packages/web/src/components/list/TreeList/index.js
@@ -637,7 +637,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				componentType={componentTypes.treeList}
 				mode={preferenceProps.testMode ? 'test' : ''}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/range/DynamicRangeSlider.js
+++ b/packages/web/src/components/range/DynamicRangeSlider.js
@@ -226,7 +226,7 @@ class DynamicRangeSlider extends Component {
 			this.setReact(this.props);
 		});
 
-		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField'], () => {
+		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField', 'aggregationSize'], () => {
 			this.updateRangeQueryOptions(this.props);
 		});
 

--- a/packages/web/src/components/range/MultiDropdownRange.js
+++ b/packages/web/src/components/range/MultiDropdownRange.js
@@ -331,7 +331,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.multiDropdownRange}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/range/MultiDropdownRange.js
+++ b/packages/web/src/components/range/MultiDropdownRange.js
@@ -63,7 +63,7 @@ class MultiDropdownRange extends Component {
 	}
 
 	componentDidUpdate(prevProps) {
-		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField'], () => {
+		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField', 'aggregationSize'], () => {
 			this.updateQuery(this.state.currentValue, this.props);
 		});
 

--- a/packages/web/src/components/range/MultiRange.js
+++ b/packages/web/src/components/range/MultiRange.js
@@ -344,7 +344,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.multiRange}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/range/MultiRange.js
+++ b/packages/web/src/components/range/MultiRange.js
@@ -64,7 +64,7 @@ class MultiRange extends Component {
 	}
 
 	componentDidUpdate(prevProps) {
-		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField'], () => {
+		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField', 'aggregationSize'], () => {
 			this.updateQuery(this.state.currentValue, this.props);
 		});
 

--- a/packages/web/src/components/range/RangeSlider.js
+++ b/packages/web/src/components/range/RangeSlider.js
@@ -140,7 +140,7 @@ class RangeSlider extends Component {
 			});
 		});
 
-		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField'], () => {
+		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField', 'aggregationSize'], () => {
 			this.updateQueryOptions(this.props);
 			this.handleChange(this.state.currentValue, this.props);
 		});

--- a/packages/web/src/components/range/RangeSlider.js
+++ b/packages/web/src/components/range/RangeSlider.js
@@ -663,7 +663,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.rangeSlider}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/range/RatingsFilter.js
+++ b/packages/web/src/components/range/RatingsFilter.js
@@ -294,7 +294,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.ratingsFilter}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/range/RatingsFilter.js
+++ b/packages/web/src/components/range/RatingsFilter.js
@@ -65,7 +65,7 @@ class RatingsFilter extends Component {
 	}
 
 	componentDidUpdate(prevProps) {
-		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField'], () => {
+		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField', 'aggregationSize'], () => {
 			this.updateQuery(this.state.currentValue, this.props);
 		});
 

--- a/packages/web/src/components/range/SingleDropdownRange.js
+++ b/packages/web/src/components/range/SingleDropdownRange.js
@@ -256,7 +256,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.singleDropdownRange}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/range/SingleDropdownRange.js
+++ b/packages/web/src/components/range/SingleDropdownRange.js
@@ -53,7 +53,7 @@ class SingleDropdownRange extends Component {
 	}
 
 	componentDidUpdate(prevProps) {
-		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField'], () => {
+		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField', 'aggregationSize'], () => {
 			this.updateQuery(this.state.currentValue, prevProps);
 		});
 

--- a/packages/web/src/components/range/SingleRange.js
+++ b/packages/web/src/components/range/SingleRange.js
@@ -269,7 +269,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.singleRange}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/range/SingleRange.js
+++ b/packages/web/src/components/range/SingleRange.js
@@ -51,7 +51,7 @@ class SingleRange extends Component {
 	}
 
 	componentDidUpdate(prevProps) {
-		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField'], () => {
+		checkSomePropChange(this.props, prevProps, ['dataField', 'nestedField', 'aggregationSize'], () => {
 			this.updateQuery(this.state.currentValue, this.props);
 		});
 

--- a/packages/web/src/components/result/ReactiveList.js
+++ b/packages/web/src/components/result/ReactiveList.js
@@ -1096,7 +1096,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				componentType={componentTypes.reactiveList}
 				{...preferenceProps}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/search/CategorySearch.js
+++ b/packages/web/src/components/search/CategorySearch.js
@@ -1677,7 +1677,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.categorySearch}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/search/DataSearch.js
+++ b/packages/web/src/components/search/DataSearch.js
@@ -1808,7 +1808,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				internalComponent
 				componentType={componentTypes.dataSearch}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/search/SearchBox.js
+++ b/packages/web/src/components/search/SearchBox.js
@@ -1767,7 +1767,14 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				componentType={componentTypes.searchBox}
 				mode={preferenceProps.testMode ? 'test' : ''}
 			>
-				{() => <ConnectedComponent {...preferenceProps} myForwardedRef={ref} />}
+				{
+					componentProps =>
+						(<ConnectedComponent
+							{...preferenceProps}
+							{...componentProps}
+							myForwardedRef={ref}
+						/>)
+				}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>


### PR DESCRIPTION
Components don't change when the props passed to them change. Should change majorly when `dataField`, `aggregationSize` is changed. Should also change when component specific properties such as `data` and `chartType` changes.

[Notion Card](https://www.notion.so/reactivesearch/Bug-RS-components-don-t-react-to-prop-change-3143e6fc530247adaf5c03919eda9296)

[ReactiveCore PR](https://github.com/appbaseio/reactivecore/pull/154)

