### PR TITLE
fix(maps): breaking examples with RS v4 

### DIFF
--- a/packages/maps/examples/GeoDistanceDropdown/package.json
+++ b/packages/maps/examples/GeoDistanceDropdown/package.json
@@ -1,32 +1,38 @@
 {
-    "name": "geodistancedropdown",
-    "version": "1.0.0",
-    "description": "GeoDistanceDropdown example for ReactiveSearch",
-    "main": "index.js",
-    "license": "Apache-2.0",
-    "dependencies": {
-        "@appbaseio/reactivemaps": "3.0.2",
-        "@appbaseio/reactivesearch": "4.0.0-rc.1",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0",
-        "react-scripts": "3.0.1"
-    },
-    "scripts": {
-        "start": "react-scripts start",
-        "build": "react-scripts build",
-        "test": "react-scripts test",
-        "eject": "react-scripts eject"
-    },
-    "browserslist": {
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
-    }
+	"name": "geodistancedropdown",
+	"version": "1.0.0",
+	"description": "GeoDistanceDropdown example for ReactiveSearch",
+	"main": "index.js",
+	"license": "Apache-2.0",
+	"dependencies": {
+		"@appbaseio/reactivemaps": "3.0.2",
+		"@appbaseio/reactivesearch": "4.0.0-rc.1",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"react-scripts": "5.0.1"
+	},
+	"eslintConfig": {
+		"extends": [
+			"react-app",
+			"react-app/jest"
+		]
+	},
+	"scripts": {
+		"start": "react-scripts start",
+		"build": "react-scripts build",
+		"test": "react-scripts test",
+		"eject": "react-scripts eject"
+	},
+	"browserslist": {
+		"production": [
+			">0.2%",
+			"not dead",
+			"not op_mini all"
+		],
+		"development": [
+			"last 1 chrome version",
+			"last 1 firefox version",
+			"last 1 safari version"
+		]
+	}
 }

--- a/packages/maps/examples/GeoDistanceDropdown/public/index.html
+++ b/packages/maps/examples/GeoDistanceDropdown/public/index.html
@@ -1,44 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
-	<title>GeoDistanceDropdown</title>
-	<link href="https://use.fontawesome.com/releases/v5.0.2/css/all.css" rel="stylesheet">
-  <link
+	<head>
+		<meta charset="utf-8" />
+		<link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#000000" />
+		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
+		<title>GeoDistanceDropdown</title>
+		<link href="https://use.fontawesome.com/releases/v5.0.2/css/all.css" rel="stylesheet" />
+		<link
 			href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.4/leaflet.css"
 			rel="stylesheet"
 		/>
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-  </body>
+		<link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+	</head>
+	<body>
+		<noscript>You need to enable JavaScript to run this app.</noscript>
+		<div id="root"></div>
+	</body>
 </html>

--- a/packages/maps/examples/GeoDistanceDropdown/src/index.js
+++ b/packages/maps/examples/GeoDistanceDropdown/src/index.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
+import { Component } from 'react';
 import { ReactiveBase, SelectedFilters } from '@appbaseio/reactivesearch';
 import {
 	ReactiveOpenStreetMap,
@@ -18,7 +18,7 @@ const providers = [
 		value: 'openstreetMap',
 	},
 ];
-class App extends React.Component {
+class App extends Component {
 	constructor() {
 		super();
 
@@ -45,7 +45,7 @@ class App extends React.Component {
 			react: {
 				and: 'GeoDistanceDropdown',
 			},
-			onPopoverClick: item => <div>{item.venue.venue_name}</div>,
+			onPopoverClick: (item) => <div>{item.venue.venue_name}</div>,
 			showMapStyles: true,
 		};
 		return (
@@ -126,4 +126,5 @@ class App extends React.Component {
 	}
 }
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/packages/maps/examples/GeoDistanceSlider/package.json
+++ b/packages/maps/examples/GeoDistanceSlider/package.json
@@ -1,32 +1,38 @@
 {
-    "name": "geodistanceslider",
-    "version": "1.0.0",
-    "description": "GeoDistanceSlider example for ReactiveSearch",
-    "main": "index.js",
-    "license": "Apache-2.0",
-    "dependencies": {
-        "@appbaseio/reactivemaps": "3.0.2",
-        "@appbaseio/reactivesearch": "4.0.0-rc.1",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0",
-        "react-scripts": "3.0.1"
-    },
-    "scripts": {
-        "start": "react-scripts start",
-        "build": "react-scripts build",
-        "test": "react-scripts test",
-        "eject": "react-scripts eject"
-    },
-    "browserslist": {
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
-    }
+	"name": "geodistanceslider",
+	"version": "1.0.0",
+	"description": "GeoDistanceSlider example for ReactiveSearch",
+	"main": "index.js",
+	"license": "Apache-2.0",
+	"dependencies": {
+		"@appbaseio/reactivemaps": "3.0.2",
+		"@appbaseio/reactivesearch": "4.0.0-rc.1",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"react-scripts": "5.0.1"
+	},
+	"eslintConfig": {
+		"extends": [
+			"react-app",
+			"react-app/jest"
+		]
+	},
+	"scripts": {
+		"start": "react-scripts start",
+		"build": "react-scripts build",
+		"test": "react-scripts test",
+		"eject": "react-scripts eject"
+	},
+	"browserslist": {
+		"production": [
+			">0.2%",
+			"not dead",
+			"not op_mini all"
+		],
+		"development": [
+			"last 1 chrome version",
+			"last 1 firefox version",
+			"last 1 safari version"
+		]
+	}
 }

--- a/packages/maps/examples/GeoDistanceSlider/public/index.html
+++ b/packages/maps/examples/GeoDistanceSlider/public/index.html
@@ -12,6 +12,9 @@
 			href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.4/leaflet.css"
 			rel="stylesheet"
 		/>
+		<!-- one can add the below library to supress warning - "Consider marking event handler as
+		'passive' to make the page more responsive" -->
+		<!-- <script type="text/javascript" src="https://unpkg.com/default-passive-events"></script> -->
 
 		<link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 	</head>

--- a/packages/maps/examples/GeoDistanceSlider/public/index.html
+++ b/packages/maps/examples/GeoDistanceSlider/public/index.html
@@ -1,44 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
-	<title>GeoDistanceSlider</title>
-	<link href="https://use.fontawesome.com/releases/v5.0.2/css/all.css" rel="stylesheet">
-  <link
+	<head>
+		<meta charset="utf-8" />
+		<link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#000000" />
+		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
+		<title>GeoDistanceSlider</title>
+		<link href="https://use.fontawesome.com/releases/v5.0.2/css/all.css" rel="stylesheet" />
+		<link
 			href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.4/leaflet.css"
 			rel="stylesheet"
 		/>
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-  </body>
+		<link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+	</head>
+	<body>
+		<noscript>You need to enable JavaScript to run this app.</noscript>
+		<div id="root"></div>
+	</body>
 </html>

--- a/packages/maps/examples/GeoDistanceSlider/src/index.js
+++ b/packages/maps/examples/GeoDistanceSlider/src/index.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
+import { Component } from 'react';
 import { ReactiveBase, SelectedFilters } from '@appbaseio/reactivesearch';
 import {
 	ReactiveGoogleMap,
@@ -18,7 +18,7 @@ const providers = [
 		value: 'openstreetMap',
 	},
 ];
-class App extends React.Component {
+class App extends Component {
 	constructor() {
 		super();
 
@@ -128,4 +128,5 @@ class App extends React.Component {
 	}
 }
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/packages/maps/examples/ReactiveMap/package.json
+++ b/packages/maps/examples/ReactiveMap/package.json
@@ -1,32 +1,38 @@
 {
-    "name": "reactivemap",
-    "version": "1.0.0",
-    "description": "ReactiveMap example for ReactiveSearch",
-    "main": "index.js",
-    "license": "Apache-2.0",
-    "dependencies": {
-        "@appbaseio/reactivemaps": "3.0.2",
-        "@appbaseio/reactivesearch": "4.0.0-rc.1",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0",
-        "react-scripts": "3.0.1"
-    },
-    "scripts": {
-        "start": "react-scripts start",
-        "build": "react-scripts build",
-        "test": "react-scripts test",
-        "eject": "react-scripts eject"
-    },
-    "browserslist": {
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
-    }
+	"name": "reactivemap",
+	"version": "1.0.0",
+	"description": "ReactiveMap example for ReactiveSearch",
+	"main": "index.js",
+	"license": "Apache-2.0",
+	"dependencies": {
+		"@appbaseio/reactivemaps": "3.0.2",
+		"@appbaseio/reactivesearch": "4.0.0-rc.1",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"react-scripts": "5.0.1"
+	},
+	"scripts": {
+		"start": "react-scripts start",
+		"build": "react-scripts build",
+		"test": "react-scripts test",
+		"eject": "react-scripts eject"
+	},
+	"eslintConfig": {
+		"extends": [
+			"react-app",
+			"react-app/jest"
+		]
+	},
+	"browserslist": {
+		"production": [
+			">0.2%",
+			"not dead",
+			"not op_mini all"
+		],
+		"development": [
+			"last 1 chrome version",
+			"last 1 firefox version",
+			"last 1 safari version"
+		]
+	}
 }

--- a/packages/maps/examples/ReactiveMap/public/index.html
+++ b/packages/maps/examples/ReactiveMap/public/index.html
@@ -1,44 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
-	<title>ReactiveMap</title>
-	<link href="https://use.fontawesome.com/releases/v5.0.2/css/all.css" rel="stylesheet">
-  <link
+	<head>
+		<meta charset="utf-8" />
+		<link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#000000" />
+		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
+		<title>ReactiveMap</title>
+		<link href="https://use.fontawesome.com/releases/v5.0.2/css/all.css" rel="stylesheet" />
+		<link
 			href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.4/leaflet.css"
 			rel="stylesheet"
 		/>
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-  </body>
+		<link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+	</head>
+	<body>
+		<noscript>You need to enable JavaScript to run this app.</noscript>
+		<div id="root"></div>
+	</body>
 </html>

--- a/packages/maps/examples/ReactiveMap/src/index.js
+++ b/packages/maps/examples/ReactiveMap/src/index.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
+import { Component } from 'react';
 import { ReactiveBase, SingleList, SelectedFilters } from '@appbaseio/reactivesearch';
 import { ReactiveGoogleMap, ReactiveOpenStreetMap } from '@appbaseio/reactivemaps';
 import Dropdown from '@appbaseio/reactivesearch/lib/components/shared/Dropdown';
@@ -14,7 +14,7 @@ const providers = [
 		value: 'openstreetMap',
 	},
 ];
-class App extends React.Component {
+class App extends Component {
 	constructor() {
 		super();
 
@@ -125,5 +125,5 @@ class App extends React.Component {
 		);
 	}
 }
-
-ReactDOM.render(<App />, document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/packages/maps/examples/mongo-examples/GeoDistanceDropdown/package.json
+++ b/packages/maps/examples/mongo-examples/GeoDistanceDropdown/package.json
@@ -1,32 +1,38 @@
 {
-    "name": "geodistancedropdown-mongodb",
-    "version": "1.0.0",
-    "description": "GeoDistanceDropdown example for ReactiveSearch using mongodb backend",
-    "main": "index.js",
-    "license": "Apache-2.0",
-    "dependencies": {
-        "@appbaseio/reactivemaps": "3.0.2",
-        "@appbaseio/reactivesearch": "4.0.0-rc.1",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0",
-        "react-scripts": "3.0.1"
-    },
-    "scripts": {
-        "start": "react-scripts start",
-        "build": "react-scripts build",
-        "test": "react-scripts test",
-        "eject": "react-scripts eject"
-    },
-    "browserslist": {
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
-    }
+	"name": "geodistancedropdown-mongodb",
+	"version": "1.0.0",
+	"description": "GeoDistanceDropdown example for ReactiveSearch using mongodb backend",
+	"main": "index.js",
+	"license": "Apache-2.0",
+	"dependencies": {
+		"@appbaseio/reactivemaps": "3.0.2",
+		"@appbaseio/reactivesearch": "4.0.0-rc.1",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"react-scripts": "5.0.1"
+	},
+	"scripts": {
+		"start": "react-scripts start",
+		"build": "react-scripts build",
+		"test": "react-scripts test",
+		"eject": "react-scripts eject"
+	},
+	"eslintConfig": {
+		"extends": [
+			"react-app",
+			"react-app/jest"
+		]
+	},
+	"browserslist": {
+		"production": [
+			">0.2%",
+			"not dead",
+			"not op_mini all"
+		],
+		"development": [
+			"last 1 chrome version",
+			"last 1 firefox version",
+			"last 1 safari version"
+		]
+	}
 }

--- a/packages/maps/examples/mongo-examples/GeoDistanceDropdown/public/index.html
+++ b/packages/maps/examples/mongo-examples/GeoDistanceDropdown/public/index.html
@@ -1,44 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
-	<title>GeoDistanceDropdown(MongoDB)</title>
-	<link href="https://use.fontawesome.com/releases/v5.0.2/css/all.css" rel="stylesheet">
-  <link
+	<head>
+		<meta charset="utf-8" />
+		<link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#000000" />
+		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
+		<title>GeoDistanceDropdown(MongoDB)</title>
+		<link href="https://use.fontawesome.com/releases/v5.0.2/css/all.css" rel="stylesheet" />
+		<link
 			href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.4/leaflet.css"
 			rel="stylesheet"
 		/>
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-  </body>
+		<link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+	</head>
+	<body>
+		<noscript>You need to enable JavaScript to run this app.</noscript>
+		<div id="root"></div>
+	</body>
 </html>

--- a/packages/maps/examples/mongo-examples/GeoDistanceDropdown/src/index.js
+++ b/packages/maps/examples/mongo-examples/GeoDistanceDropdown/src/index.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
+import { Component } from 'react';
 import { ReactiveBase } from '@appbaseio/reactivesearch';
 import {
 	GeoDistanceDropdown,
@@ -18,7 +18,7 @@ const providers = [
 		value: 'openstreetMap',
 	},
 ];
-class App extends React.Component {
+class App extends Component {
 	constructor() {
 		super();
 
@@ -46,7 +46,7 @@ class App extends React.Component {
 			react: {
 				and: 'GeoDistanceDropdown',
 			},
-			onPopoverClick: item => (
+			onPopoverClick: (item) => (
 				<div
 					style={{
 						display: 'flex',
@@ -105,6 +105,7 @@ class App extends React.Component {
 				enableAppbase
 				mapKey="AIzaSyA9JzjtHeXg_C_hh_GdTBdLxREWdj3nsOU"
 				mapLibraries={['places']}
+				reactivesearchAPIConfig={{ recordAnalytics: false }}
 			>
 				<div>
 					<h3 style={{ textAlign: 'center' }}>Search properties across the globe</h3>
@@ -172,4 +173,5 @@ class App extends React.Component {
 	}
 }
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/packages/maps/examples/mongo-examples/GeoDistanceSlider/package.json
+++ b/packages/maps/examples/mongo-examples/GeoDistanceSlider/package.json
@@ -1,32 +1,38 @@
 {
-    "name": "geodistanceslider-mongodb",
-    "version": "1.0.0",
-    "description": "GeoDistanceSlider example for ReactiveSearch using mongodb backend",
-    "main": "index.js",
-    "license": "Apache-2.0",
-    "dependencies": {
-        "@appbaseio/reactivemaps": "3.0.2",
-        "@appbaseio/reactivesearch": "4.0.0-rc.1",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0",
-        "react-scripts": "3.0.1"
-    },
-    "scripts": {
-        "start": "react-scripts start",
-        "build": "react-scripts build",
-        "test": "react-scripts test",
-        "eject": "react-scripts eject"
-    },
-    "browserslist": {
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
-    }
+	"name": "geodistanceslider-mongodb",
+	"version": "1.0.0",
+	"description": "GeoDistanceSlider example for ReactiveSearch using mongodb backend",
+	"main": "index.js",
+	"license": "Apache-2.0",
+	"dependencies": {
+		"@appbaseio/reactivemaps": "3.0.2",
+		"@appbaseio/reactivesearch": "4.0.0-rc.1",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"react-scripts": "5.0.1"
+	},
+	"scripts": {
+		"start": "react-scripts start",
+		"build": "react-scripts build",
+		"test": "react-scripts test",
+		"eject": "react-scripts eject"
+	},
+	"eslintConfig": {
+		"extends": [
+			"react-app",
+			"react-app/jest"
+		]
+	},
+	"browserslist": {
+		"production": [
+			">0.2%",
+			"not dead",
+			"not op_mini all"
+		],
+		"development": [
+			"last 1 chrome version",
+			"last 1 firefox version",
+			"last 1 safari version"
+		]
+	}
 }

--- a/packages/maps/examples/mongo-examples/GeoDistanceSlider/public/index.html
+++ b/packages/maps/examples/mongo-examples/GeoDistanceSlider/public/index.html
@@ -1,44 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
-	<title>GeoDistanceSlider(MongoDB)</title>
-	<link href="https://use.fontawesome.com/releases/v5.0.2/css/all.css" rel="stylesheet">
-  <link
+	<head>
+		<meta charset="utf-8" />
+		<link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#000000" />
+		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
+		<title>GeoDistanceSlider(MongoDB)</title>
+		<link href="https://use.fontawesome.com/releases/v5.0.2/css/all.css" rel="stylesheet" />
+		<link
 			href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.4/leaflet.css"
 			rel="stylesheet"
 		/>
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-  </body>
+		<link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+	</head>
+	<body>
+		<noscript>You need to enable JavaScript to run this app.</noscript>
+		<div id="root"></div>
+	</body>
 </html>

--- a/packages/maps/examples/mongo-examples/GeoDistanceSlider/src/index.js
+++ b/packages/maps/examples/mongo-examples/GeoDistanceSlider/src/index.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
+import { Component } from 'react';
 import { ReactiveBase } from '@appbaseio/reactivesearch';
 import {
 	GeoDistanceSlider,
@@ -18,7 +18,7 @@ const providers = [
 		value: 'openstreetMap',
 	},
 ];
-class App extends React.Component {
+class App extends Component {
 	constructor() {
 		super();
 
@@ -105,6 +105,7 @@ class App extends React.Component {
 				enableAppbase
 				mapKey="AIzaSyA9JzjtHeXg_C_hh_GdTBdLxREWdj3nsOU"
 				mapLibraries={['places']}
+				reactivesearchAPIConfig={{ recordAnalytics: false }}
 			>
 				<div>
 					<h3 style={{ textAlign: 'center' }}>Search properties across the globe</h3>
@@ -174,4 +175,5 @@ class App extends React.Component {
 	}
 }
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/packages/maps/examples/mongo-examples/ReactiveMap/package.json
+++ b/packages/maps/examples/mongo-examples/ReactiveMap/package.json
@@ -1,32 +1,38 @@
 {
-    "name": "reactivemap-mongodb",
-    "version": "1.0.0",
-    "description": "ReactiveMap example for ReactiveSearch using mongodb backend",
-    "main": "index.js",
-    "license": "Apache-2.0",
-    "dependencies": {
-        "@appbaseio/reactivemaps": "3.0.2",
-        "@appbaseio/reactivesearch": "4.0.0-rc.1",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0",
-        "react-scripts": "3.0.1"
-    },
-    "scripts": {
-        "start": "react-scripts start",
-        "build": "react-scripts build",
-        "test": "react-scripts test",
-        "eject": "react-scripts eject"
-    },
-    "browserslist": {
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
-    }
+	"name": "reactivemap-mongodb",
+	"version": "1.0.0",
+	"description": "ReactiveMap example for ReactiveSearch using mongodb backend",
+	"main": "index.js",
+	"license": "Apache-2.0",
+	"dependencies": {
+		"@appbaseio/reactivemaps": "3.0.2",
+		"@appbaseio/reactivesearch": "4.0.0-rc.1",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"react-scripts": "5.0.1"
+	},
+	"scripts": {
+		"start": "react-scripts start",
+		"build": "react-scripts build",
+		"test": "react-scripts test",
+		"eject": "react-scripts eject"
+	},
+	"eslintConfig": {
+		"extends": [
+			"react-app",
+			"react-app/jest"
+		]
+	},
+	"browserslist": {
+		"production": [
+			">0.2%",
+			"not dead",
+			"not op_mini all"
+		],
+		"development": [
+			"last 1 chrome version",
+			"last 1 firefox version",
+			"last 1 safari version"
+		]
+	}
 }

--- a/packages/maps/examples/mongo-examples/ReactiveMap/public/index.html
+++ b/packages/maps/examples/mongo-examples/ReactiveMap/public/index.html
@@ -1,44 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
-	<title>ReactiveMap(MongoDB)</title>
-	<link href="https://use.fontawesome.com/releases/v5.0.2/css/all.css" rel="stylesheet">
-  <link
+	<head>
+		<meta charset="utf-8" />
+		<link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#000000" />
+		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
+		<title>ReactiveMap(MongoDB)</title>
+		<link href="https://use.fontawesome.com/releases/v5.0.2/css/all.css" rel="stylesheet" />
+		<link
 			href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.4/leaflet.css"
 			rel="stylesheet"
 		/>
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-  </body>
+		<link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+	</head>
+	<body>
+		<noscript>You need to enable JavaScript to run this app.</noscript>
+		<div id="root"></div>
+	</body>
 </html>

--- a/packages/maps/examples/mongo-examples/ReactiveMap/src/index.js
+++ b/packages/maps/examples/mongo-examples/ReactiveMap/src/index.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
+import { Component } from 'react';
 import { ReactiveBase, DataSearch } from '@appbaseio/reactivesearch';
 import { ReactiveGoogleMap, ReactiveOpenStreetMap } from '@appbaseio/reactivemaps';
 import Dropdown from '@appbaseio/reactivesearch/lib/components/shared/Dropdown';
@@ -43,7 +43,7 @@ class App extends React.Component {
 			},
 			showMarkerClusters: true,
 			size: 50,
-			onPopoverClick: item => (
+			onPopoverClick: (item) => (
 				<div
 					style={{
 						display: 'flex',
@@ -102,6 +102,7 @@ class App extends React.Component {
 				enableAppbase
 				mapLibraries={['places']}
 				mapKey="AIzaSyA9JzjtHeXg_C_hh_GdTBdLxREWdj3nsOU"
+				reactivesearchAPIConfig={{ recordAnalytics: false }}
 			>
 				<div>
 					<h3 style={{ textAlign: 'center' }}>Search Properties</h3>
@@ -156,4 +157,5 @@ class App extends React.Component {
 	}
 }
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/packages/maps/examples/mongo-examples/ReactiveMap/src/index.js
+++ b/packages/maps/examples/mongo-examples/ReactiveMap/src/index.js
@@ -1,6 +1,6 @@
 import ReactDOM from 'react-dom/client';
 import { Component } from 'react';
-import { ReactiveBase, DataSearch } from '@appbaseio/reactivesearch';
+import { ReactiveBase } from '@appbaseio/reactivesearch';
 import { ReactiveGoogleMap, ReactiveOpenStreetMap } from '@appbaseio/reactivemaps';
 import Dropdown from '@appbaseio/reactivesearch/lib/components/shared/Dropdown';
 
@@ -106,19 +106,7 @@ class App extends React.Component {
 			>
 				<div>
 					<h3 style={{ textAlign: 'center' }}>Search Properties</h3>
-					<div
-						style={{
-							position: 'relative',
-							zIndex: 2147483640,
-							marginBottom: '1rem',
-						}}
-					>
-						<DataSearch
-							dataField={[{ field: 'description', weight: 3 }]}
-							componentId="places-filter"
-							title="DataSearch: Search for properties"
-						/>
-					</div>
+
 					<div
 						style={{
 							position: 'relative',

--- a/packages/maps/examples/mongo-examples/ReactiveMap/src/index.js
+++ b/packages/maps/examples/mongo-examples/ReactiveMap/src/index.js
@@ -14,7 +14,7 @@ const providers = [
 		value: 'openstreetMap',
 	},
 ];
-class App extends React.Component {
+class App extends Component {
 	constructor() {
 		super();
 

--- a/packages/maps/src/components/result/addons/components/MarkerWithLabel.js
+++ b/packages/maps/src/components/result/addons/components/MarkerWithLabel.js
@@ -1,6 +1,8 @@
 /* eslint-disable react/forbid-prop-types */
 /* global google */
 import React, { Component } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
 import { MapContext } from '@react-google-maps/api';
 import * as ReactDOM from 'react-dom';
 import makeMarkerWithLabel from 'markerwithlabel';
@@ -150,11 +152,8 @@ class MarkerWithLabel extends Component {
 			instance: this.marker,
 		});
 		const container = document.createElement('div');
-		ReactDOM.unstable_renderSubtreeIntoContainer(
-			this,
-			React.Children.only(this.props.children),
-			container,
-		);
+		container.innerHTML = renderToStaticMarkup(<div>{this.props.children}</div>);
+
 		this.marker.set('labelContent', container);
 	}
 	componentDidUpdate(prevProps) {


### PR DESCRIPTION
**PR Type** `fix`

**Description** The PR aims to make the maps library work with React v18 and RS-v4.

[📔 Notion](https://www.notion.so/reactivesearch/Maps-ReactiveSearch-v4-React-v18-ee6004e4d4d042d3ac3593f68bb72fab)

https://www.loom.com/share/c359258d5f38472793996152c03b4bf1

https://www.loom.com/share/6c36c82a521d45739485181d35b037bc