### PR TITLE
fix(web): Support focus for autosuggest = false

### DIFF
--- a/packages/web/src/components/search/SearchBox.js
+++ b/packages/web/src/components/search/SearchBox.js
@@ -1382,8 +1382,7 @@ const SearchBox = (props) => {
 												);
 											})}
 
-											{showSuggestionsFooter
-												? <SuggestionsFooter /> : null}
+											{showSuggestionsFooter ? <SuggestionsFooter /> : null}
 										</ul>
 									) : (
 										renderNoSuggestion(parsedSuggestions())
@@ -1469,6 +1468,7 @@ const SearchBox = (props) => {
 						{renderInputAddonBefore()}
 						<InputWrapper>
 							<Input
+								ref={_inputRef}
 								aria-label={props.componentId}
 								className={getClassName(props.innerClass, 'input') || null}
 								placeholder={props.placeholder}


### PR DESCRIPTION
**PR Type** `fix`

**Description** The PR fixes an issue with SearchBox where focus-shortcut would not focus the searchbox where `autosuggest = false`.

https://www.loom.com/share/fb676e934553436183b3c63ec9c7ea3c
