### PR TITLE
feat(web): V3 support select type featured suggestion

### DIFF
--- a/packages/web/examples/SearchBox/src/index.js
+++ b/packages/web/examples/SearchBox/src/index.js
@@ -24,14 +24,36 @@ const Main = () => (
 			<div className="col">
 				<SearchBox
 					title="SearchBox"
+					defaultValue="Harry Potter"
 					dataField={['original_title', 'original_title.search']}
 					componentId="BookSensor"
-					highlight={false}
+					highlight
 					URLParams
-					searchboxId="select_action_test"
-					enableFeaturedSuggestions
-					size={10}
-					mode="tag"
+					enablePopularSuggestions
+					popularSuggestionsConfig={{
+						size: 3,
+						minChars: 2,
+						index: 'good-books-ds',
+					}}
+					enableRecentSuggestions
+					recentSuggestionsConfig={{
+						size: 3,
+						index: 'good-books-ds',
+						minChars: 4,
+					}}
+					size={5}
+					enablePredictiveSuggestions
+					index="good-books-ds"
+					onData={(props) => {
+						// eslint-disable-next-line
+						console.log(props);
+					}}
+					showClear
+					onValueSelected={(value, cause) => {
+						// eslint-disable-next-line
+						console.log(value, cause);
+					}}
+					renderNoSuggestion="No suggestions found."
 				/>
 			</div>
 

--- a/packages/web/src/components/search/SearchBox.js
+++ b/packages/web/src/components/search/SearchBox.js
@@ -539,6 +539,14 @@ const SearchBox = (props) => {
 				const func = new Function(`return ${suggestion.subAction}`)();
 				func(suggestion, currentValue, customEvents);
 			}
+			if (suggestion.action === featuredSuggestionsActionTypes.SELECT) {
+				setValue(
+					suggestion.value,
+					true,
+					props,
+					isTagsMode.current ? causes.SUGGESTION_SELECT : causes.ENTER_PRESS,
+				);
+			}
 			// blur is important to close the dropdown
 			// on selecting one of featured suggestions
 			// else Downshift probably is focusing the dropdown
@@ -1767,14 +1775,13 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				componentType={componentTypes.searchBox}
 				mode={preferenceProps.testMode ? 'test' : ''}
 			>
-				{
-					componentProps =>
-						(<ConnectedComponent
-							{...preferenceProps}
-							{...componentProps}
-							myForwardedRef={ref}
-						/>)
-				}
+				{componentProps => (
+					<ConnectedComponent
+						{...preferenceProps}
+						{...componentProps}
+						myForwardedRef={ref}
+					/>
+				)}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>

--- a/packages/web/src/components/search/SearchBox.js
+++ b/packages/web/src/components/search/SearchBox.js
@@ -539,6 +539,15 @@ const SearchBox = (props) => {
 				const func = new Function(`return ${suggestion.subAction}`)();
 				func(suggestion, currentValue, customEvents);
 			}
+			if (suggestion.action === featuredSuggestionsActionTypes.SELECT) {
+				setValue(
+					suggestion.value,
+					true,
+					props,
+					isTagsMode.current ? causes.SUGGESTION_SELECT : causes.ENTER_PRESS,
+				);
+				onValueSelected(suggestion.value, causes.SUGGESTION_SELECT);
+			}
 			// blur is important to close the dropdown
 			// on selecting one of featured suggestions
 			// else Downshift probably is focusing the dropdown
@@ -1767,14 +1776,13 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				componentType={componentTypes.searchBox}
 				mode={preferenceProps.testMode ? 'test' : ''}
 			>
-				{
-					componentProps =>
-						(<ConnectedComponent
-							{...preferenceProps}
-							{...componentProps}
-							myForwardedRef={ref}
-						/>)
-				}
+				{componentProps => (
+					<ConnectedComponent
+						{...preferenceProps}
+						{...componentProps}
+						myForwardedRef={ref}
+					/>
+				)}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>


### PR DESCRIPTION
**PR Type** `feat`

**Description** The PR adds functionality to support `select` type featured suggestions in SearchBox.

[📔 Notion](https://www.notion.so/reactivesearch/Searchbox-Featured-suggestions-Select-Action-49c6aca61b1f41b2b939f70db2708461)

Depending on  https://github.com/appbaseio/reactivecore/pull/158

https://www.loom.com/share/e819e3687e8a4f2d93b3919bfd7df846