### PR TITLE
feat(web): V4 support select type featured suggestion

### DIFF
--- a/packages/web/src/components/search/SearchBox.js
+++ b/packages/web/src/components/search/SearchBox.js
@@ -416,6 +416,15 @@ const SearchBox = (props) => {
 				const func = new Function(`return ${suggestion.subAction}`)();
 				func(suggestion, currentValue, customEvents);
 			}
+			if (suggestion.action === featuredSuggestionsActionTypes.SELECT) {
+				setValue(
+					suggestion.value,
+					true,
+					props,
+					isTagsMode.current ? causes.SUGGESTION_SELECT : causes.ENTER_PRESS,
+				);
+				onValueSelected(suggestion.value, causes.SUGGESTION_SELECT);
+			}
 			// blur is important to close the dropdown
 			// on selecting one of featured suggestions
 			// else Downshift probably is focusing the dropdown
@@ -1642,14 +1651,13 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				componentType={componentTypes.searchBox}
 				mode={preferenceProps.testMode ? 'test' : ''}
 			>
-				{
-					componentProps =>
-						(<ConnectedComponent
-							{...preferenceProps}
-							{...componentProps}
-							myForwardedRef={ref}
-						/>)
-				}
+				{componentProps => (
+					<ConnectedComponent
+						{...preferenceProps}
+						{...componentProps}
+						myForwardedRef={ref}
+					/>
+				)}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>


### PR DESCRIPTION
**PR Type** `feat`

**Description** The PR adds functionality to support `select` type featured suggestions in SearchBox.

[📔 Notion](https://www.notion.so/reactivesearch/Searchbox-Featured-suggestions-Select-Action-49c6aca61b1f41b2b939f70db2708461)

Depending on  https://github.com/appbaseio/reactivecore/pull/159

https://www.loom.com/share/e819e3687e8a4f2d93b3919bfd7df846