### PR TITLE
fix(web): custom query fired on clearing input via keyboard

### DIFF
--- a/packages/web/src/components/search/SearchBox.js
+++ b/packages/web/src/components/search/SearchBox.js
@@ -548,7 +548,14 @@ const SearchBox = (props) => {
 	};
 
 	const clearValue = () => {
-		setValue('', false, props, causes.CLEAR_VALUE, true, false);
+		setValue(
+			'',
+			false,
+			props,
+			!isTagsMode.current ? causes.CLEAR_VALUE : undefined,
+			true,
+			false,
+		);
 		if (onChange) {
 			onChange('', ({ isOpen } = {}) =>
 				triggerQuery({

--- a/packages/web/src/components/search/SearchBox.js
+++ b/packages/web/src/components/search/SearchBox.js
@@ -504,14 +504,7 @@ const SearchBox = (props) => {
 			setIsOpen(true);
 		}
 		if (value === undefined) {
-			setValue(
-				inputValue,
-				false,
-				props,
-				inputValue === '' ? causes.CLEAR_VALUE : undefined,
-				true,
-				false,
-			);
+			setValue(inputValue, false, props, undefined, true, false);
 		} else if (onChange) {
 			// handle caret position in controlled components
 			handleCaretPosition(e);
@@ -765,11 +758,9 @@ const SearchBox = (props) => {
 				return props.icon;
 			}
 			if (props.iconURL) {
-				return (<img
-					style={{ maxHeight: '25px' }}
-					src={XSS(props.iconURL)}
-					alt="search-icon"
-				/>);
+				return (
+					<img style={{ maxHeight: '25px' }} src={XSS(props.iconURL)} alt="search-icon" />
+				);
 			}
 			return <SearchSvg />;
 		}
@@ -814,14 +805,11 @@ const SearchBox = (props) => {
 							{renderCancelIcon()}
 						</IconWrapper>
 					)}
-					{
-						showFocusShortcutsIcon
-						&& (
-							<ButtonIconWrapper onClick={e => focusSearchBox(e)}>
-								{renderShortcut()}
-							</ButtonIconWrapper>
-						)
-					}
+					{showFocusShortcutsIcon && (
+						<ButtonIconWrapper onClick={e => focusSearchBox(e)}>
+							{renderShortcut()}
+						</ButtonIconWrapper>
+					)}
 					{shouldMicRender(showVoiceSearch) && (
 						<Mic
 							getInstance={getMicInstance}
@@ -840,20 +828,18 @@ const SearchBox = (props) => {
 						<IconWrapper onClick={handleSearchIconClick}>{renderIcon()}</IconWrapper>
 					)}
 				</IconGroup>
-
 			</div>
 		);
 	};
-	const SuggestionsFooter = () => (
-		typeof renderSuggestionsFooter === 'function'
-	 		? renderSuggestionsFooter()
-			: ((
-				<AutosuggestFooterContainer>
-					<div>↑↓ Navigate</div>
-					<div>↩ Go</div>
-				</AutosuggestFooterContainer>))
-	);
-
+	const SuggestionsFooter = () =>
+		(typeof renderSuggestionsFooter === 'function' ? (
+			renderSuggestionsFooter()
+		) : (
+			<AutosuggestFooterContainer>
+				<div>↑↓ Navigate</div>
+				<div>↩ Go</div>
+			</AutosuggestFooterContainer>
+		));
 
 	const onAutofillClick = (suggestion) => {
 		const { value } = suggestion;
@@ -1391,8 +1377,7 @@ const SearchBox = (props) => {
 												);
 											})}
 
-											{showSuggestionsFooter
-												? <SuggestionsFooter /> : null}
+											{showSuggestionsFooter ? <SuggestionsFooter /> : null}
 										</ul>
 									) : (
 										renderNoSuggestion(parsedSuggestions())
@@ -1706,14 +1691,13 @@ const ForwardRefComponent = React.forwardRef((props, ref) => (
 				componentType={componentTypes.searchBox}
 				mode={preferenceProps.testMode ? 'test' : ''}
 			>
-				{
-					componentProps =>
-						(<ConnectedComponent
-							{...preferenceProps}
-							{...componentProps}
-							myForwardedRef={ref}
-						/>)
-				}
+				{componentProps => (
+					<ConnectedComponent
+						{...preferenceProps}
+						{...componentProps}
+						myForwardedRef={ref}
+					/>
+				)}
 			</ComponentWrapper>
 		)}
 	</PreferencesConsumer>


### PR DESCRIPTION
**PR Type** `fix`

**Description** The PR fixes an issue with the SearchBox component wherein the results query is fired even on clearing the input via keyboard typing action. 
- Additionally, fixes another issue with `tags` mode wherein the clicking on the clear icon of the input box cleared off the tags as well although expectation is to clear the input value only and fire a suggestions query instead.

[📔 Notion](https://www.notion.so/reactivesearch/SearchBox-fires-an-query-on-empty-value-without-a-trigger-from-user-83b0e2b46d84447a93ce7bb672c87156)

https://www.loom.com/share/5cf75fbe793848ac97e0e147088dbe0e