### PR TITLE
fix(web): searchbox cursor shifts to end in controlled component

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
 		"babel-loader": "^8.2.3"
 	},
 	"engines": {
-		"node": ">=10.16"
+		"node": ">=16"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
 		"babel-loader": "^8.2.3"
 	},
 	"engines": {
-		"node": ">=16"
+		"node": ">=10.16"
 	}
 }

--- a/packages/web/src/components/search/SearchBox.js
+++ b/packages/web/src/components/search/SearchBox.js
@@ -1427,6 +1427,8 @@ const SearchBox = (props) => {
 											{...getInputProps({
 												className: getClassName(props.innerClass, 'input'),
 												placeholder: props.placeholder,
+												// When props.value is defined,
+												// it means SearchBox is used as a controlled component
 												value: Object.hasOwn(props, 'value') ? props.value : currentValue || '',
 												onChange: onInputChange,
 												onBlur: withTriggerQuery(props.onBlur),

--- a/packages/web/src/components/search/SearchBox.js
+++ b/packages/web/src/components/search/SearchBox.js
@@ -56,7 +56,6 @@ import {
 	connect,
 	decodeHtml,
 	extractModifierKeysFromFocusShortcuts,
-	handleCaretPosition,
 	isEmpty,
 	parseFocusShortcuts,
 } from '../../utils';
@@ -74,6 +73,19 @@ const useConstructor = (callBack = () => {}) => {
 	callBack();
 	setHasBeenCalled(true);
 };
+
+/**
+ * inputValue:
+ * The value which is passed to the html input box.
+ * The onChange handler(event listener on input box) should directly update inputValue.
+ *
+ * For uncontrolled components, we maintain the input value(useState - currentValue).
+ * Hence, onChange should call setValue to update currentValue directly.
+ *
+ * For controlled components, we get the input value(props.value).
+ * Hence, onChange should call props.onChange,
+ * which then updates currentValue by calling setValue in useEffect.
+ */
 
 const SearchBox = (props) => {
 	const {
@@ -506,9 +518,6 @@ const SearchBox = (props) => {
 		if (value === undefined) {
 			setValue(inputValue, false, props, undefined, true, false);
 		} else if (onChange) {
-			// handle caret position in controlled components
-			handleCaretPosition(e);
-
 			onChange(
 				inputValue,
 				({ isOpen } = {}) => {
@@ -992,6 +1001,11 @@ const SearchBox = (props) => {
 		}
 	}, [rawData, aggregationData, isLoading, error]);
 
+	/**
+	 * For uncontrolled component,
+	 * props.value would be changed directly,
+	 * which then needs to update currentValue by calling setValue
+	 */
 	useEffect(() => {
 		if (hasMounted.current) {
 			if (
@@ -1413,7 +1427,7 @@ const SearchBox = (props) => {
 											{...getInputProps({
 												className: getClassName(props.innerClass, 'input'),
 												placeholder: props.placeholder,
-												value: currentValue === null ? '' : currentValue,
+												value: Object.hasOwn(props, 'value') ? props.value : currentValue || '',
 												onChange: onInputChange,
 												onBlur: withTriggerQuery(props.onBlur),
 												onFocus: handleFocus,
@@ -1473,7 +1487,7 @@ const SearchBox = (props) => {
 								aria-label={props.componentId}
 								className={getClassName(props.innerClass, 'input') || null}
 								placeholder={props.placeholder}
-								value={currentValue || ''}
+								value={Object.hasOwn(props, 'value') ? props.value : currentValue || ''}
 								onChange={onInputChange}
 								onBlur={withTriggerQuery(props.onBlur)}
 								onFocus={withTriggerQuery(props.onFocus)}

--- a/packages/web/src/utils/index.js
+++ b/packages/web/src/utils/index.js
@@ -50,20 +50,6 @@ export const isIdentical = (a, b) => {
 };
 export const getValidPropsKeys = (props = {}) =>
 	Object.keys(props).filter(i => validProps.includes(i));
-/**
- * Handles the caret position for input components
- * @param {HTMLInputElement} e
- */
-export const handleCaretPosition = (e) => {
-	if (window) {
-		const caret = e.target.selectionStart;
-		const element = e.target;
-		window.requestAnimationFrame(() => {
-			element.selectionStart = caret;
-			element.selectionEnd = caret;
-		});
-	}
-};
 // elastic search query for including null values
 export const getNullValuesQuery = fieldName => ({
 	bool: {


### PR DESCRIPTION
When SearchBox is used as a controlled component, the cursor shifts to the end while typing in between words.

This happens because:
`props.value` is the directly synced value with the input when used as a controlled component. 

[Notion Card](https://www.notion.so/reactivesearch/Search-box-controlled-usage-typing-amid-input-issue-cad3e73b60244f43addee656a77823ca)

Loom preview attached in notion comments