### PR TITLE
Hotfix for Vue Searchbox focusshortcuts bug

### DIFF
--- a/packages/vue/src/components/search/SearchBox.jsx
+++ b/packages/vue/src/components/search/SearchBox.jsx
@@ -1132,7 +1132,7 @@ const SearchBox = defineComponent({
 				return;
 			}
 
-			this.$refs?.[this.$props.innerRef]?.focus(); // eslint-disable-line
+			this.$refs?.[this.$props.innerRef]?.$el?.focus(); // eslint-disable-line
 		},
 		listenForFocusShortcuts() {
 			const { focusShortcuts = ['/'] } = this.$props;


### PR DESCRIPTION
**PR Type** `fix`



This PR fixes a bug in Vue Searchbox that prevented the focusshortcuts functionality from working.