### PR TITLE
fix(vue): range slider rendering bug

### DIFF
--- a/packages/vue/src/components/range/DynamicRangeSlider.jsx
+++ b/packages/vue/src/components/range/DynamicRangeSlider.jsx
@@ -1,6 +1,8 @@
 import VueTypes from 'vue-types';
 import { Actions, helper } from '@appbaseio/reactivecore';
 import { componentTypes } from '@appbaseio/reactivecore/lib/utils/constants';
+import VueSlider from 'vue-slider-component';
+import 'vue-slider-component/theme/antd.css';
 import Container from '../../styles/Container';
 import PreferencesConsumer from '../basic/PreferencesConsumer.jsx';
 import NoSSR from '../basic/NoSSR.jsx';
@@ -328,7 +330,7 @@ const DynamicRangeSlider = {
 				)}
 				<NoSSR>
 					<Slider class={getClassName(this.$props.innerClass, 'slider')}>
-						<vue-slider-component
+						<VueSlider
 							ref="slider"
 							modelValue={[
 								Math.floor(Math.max(start, this.currentValue[0])),

--- a/packages/vue/src/components/range/RangeSlider.jsx
+++ b/packages/vue/src/components/range/RangeSlider.jsx
@@ -1,6 +1,8 @@
 import VueTypes from 'vue-types';
 import { Actions, helper } from '@appbaseio/reactivecore';
 import { componentTypes } from '@appbaseio/reactivecore/lib/utils/constants';
+import VueSlider from 'vue-slider-component';
+import 'vue-slider-component/theme/antd.css';
 import Container from '../../styles/Container';
 import { connect, updateCustomQuery, isQueryIdentical } from '../../utils/index';
 import ComponentWrapper from '../basic/ComponentWrapper.jsx';
@@ -184,7 +186,7 @@ const RangeSlider = {
 				{this.$props.range ? (
 					<NoSSR>
 						<Slider class={getClassName(this.$props.innerClass, 'slider')}>
-							<vue-slider-component
+							<VueSlider
 								ref="slider"
 								modelValue={this.currentValue}
 								min={this.$props.range.start}


### PR DESCRIPTION
**PR Type** `fix`

**Description** The PR fixes the bug with the slider component not rendering for range components.

[📔 Notion](https://www.notion.so/reactivesearch/Vue-Range-demo-bug-ed36d5542cc34d918f7451c7f7235066)

<img width="1180" alt="image" src="https://github.com/appbaseio/reactivesearch/assets/57627350/c41bac41-c6c8-47ee-8499-d142957cb72f">
