### PR TITLE
Check for invalid range in DynamicRangeSlider (Vue)

### DIFF
--- a/packages/vue/src/components/range/DynamicRangeSlider.jsx
+++ b/packages/vue/src/components/range/DynamicRangeSlider.jsx
@@ -320,7 +320,7 @@ const DynamicRangeSlider = {
 	},
 
 	render() {
-		if (!this.range || !this.currentValue) {
+		if (!this.range || !this.currentValue || this.range.start === null || this.range.end === null || this.range.start === this.range.end) {
 			return null;
 		}
 		const { start, end } = this.range;


### PR DESCRIPTION
The DynamicRangeSlider doesn't hide itself when the range is invalid. Currently it will:

- Show `null` as the range start and end if the variable is not relevant in the current aggregate (imagine there's an online store called Books&Bikes, and it's trying to show a "book page count" slider while only searching for bikes). Trying to "use" this broken slider causes some unexpected behavior.
- Have a range where the start and end are the exact same, making this slider irrelevant and also have some unexpected behavior.

This change causes the slider to not render itself in these scenarios.