### PR TITLE
[Vue] Use lazy & onChange for DynamicRangeSlider

### DIFF
--- a/packages/vue/src/components/range/DynamicRangeSlider.jsx
+++ b/packages/vue/src/components/range/DynamicRangeSlider.jsx
@@ -341,7 +341,8 @@ const DynamicRangeSlider = {
 							]}
 							min={Math.floor(Math.min(start, this.currentValue[0]))}
 							max={Math.ceil(Math.max(end, this.currentValue[1]))}
-							onDrag-end={this.handleSlider}
+							onChange={this.handleSlider}
+							lazy={true}
 							dotSize={20}
 							height={4}
 							enable-cross={false}


### PR DESCRIPTION
Currently, the Vue DynamicRangeSlider will not update the search query if you click on the rail or if you use the keyboard controls.

By listening to the `change` event from the VueSlider and setting it to `lazy`, we get the same behavior as the listening `drag-end` event except clicking on the rail actually works properly.

I will add that it might be worth disabling the keyboard controls entirely with `useKeyboard={false}`. The keyboard controls will cause many requests if you, for example, hold a direction, and the lazy property does not fix that. Plus the keyboard controls are kinda bad anyway 😅
