### PR TITLE
[Vue-2.x] Dynamic Range Slider fixes

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -58,6 +58,7 @@
 		"@babel/plugin-external-helpers": "^7.2.0",
 		"@babel/plugin-proposal-class-properties": "^7.5.5",
 		"@babel/plugin-proposal-json-strings": "^7.2.0",
+		"@babel/plugin-proposal-private-methods": "^7.2.0",
 		"@babel/plugin-syntax-dynamic-import": "^7.2.0",
 		"@babel/plugin-syntax-import-meta": "^7.2.0",
 		"@babel/plugin-syntax-jsx": "^7.2.0",

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -136,7 +136,6 @@ export default {
 			plugins: [
 				'@babel/plugin-syntax-dynamic-import',
 				'@babel/plugin-syntax-import-meta',
-				['@babel/plugin-proposal-private-methods', { loose: true }],
 				['@babel/plugin-proposal-class-properties', { loose: true }],
 				'@babel/plugin-proposal-json-strings',
 			],

--- a/packages/vue/src/components/range/DynamicRangeSlider.jsx
+++ b/packages/vue/src/components/range/DynamicRangeSlider.jsx
@@ -319,7 +319,7 @@ const DynamicRangeSlider = {
 	},
 
 	render() {
-		if (!this.range || !this.currentValue) {
+		if (!this.range || !this.currentValue || this.range.start === null || this.range.end === null || this.range.start === this.range.end) {
 			return null;
 		}
 		const { start, end } = this.range;

--- a/packages/vue/src/components/range/DynamicRangeSlider.jsx
+++ b/packages/vue/src/components/range/DynamicRangeSlider.jsx
@@ -340,45 +340,47 @@ const DynamicRangeSlider = {
 		return (
 			<Container class={this.$props.className}>
 				{this.$scopedSlots.title ? this.$scopedSlots.title() : null}
-				<NoSSR class={getClassName(this.$props.innerClass, 'outer')}>
-					<Slider class={getClassName(this.$props.innerClass, 'slider')}>
-						<vue-slider-component
-							ref="slider"
-							value={[
-								Math.floor(Math.max(start, this.currentValue[0])),
-								Math.ceil(Math.min(end, this.currentValue[1])),
-							]}
-							min={Math.floor(Math.min(start, this.currentValue[0]))}
-							max={Math.ceil(Math.max(end, this.currentValue[1]))}
-							onDrag-end={this.handleSlider}
-							dotSize={20}
-							height={4}
-							enable-cross={false}
-							tooltip="always"
-							{...{ props: this.$props.sliderOptions }}
-						/>
+				<NoSSR>
+					<div class={getClassName(this.$props.innerClass, 'outer')}>
+						<Slider class={getClassName(this.$props.innerClass, 'slider')}>
+							<vue-slider-component
+								ref="slider"
+								value={[
+									Math.floor(Math.max(start, this.currentValue[0])),
+									Math.ceil(Math.min(end, this.currentValue[1])),
+								]}
+								min={Math.floor(Math.min(start, this.currentValue[0]))}
+								max={Math.ceil(Math.max(end, this.currentValue[1]))}
+								onDrag-end={this.handleSlider}
+								dotSize={20}
+								height={4}
+								enable-cross={false}
+								tooltip="always"
+								{...{ props: this.$props.sliderOptions }}
+							/>
 
-						{this.labels ? (
-							<div class="label-container">
-								<label
-									class={
-										getClassName(this.$props.innerClass, 'label')
-										|| 'range-label-left'
-									}
-								>
-									{this.labels.start}
-								</label>
-								<label
-									class={
-										getClassName(this.$props.innerClass, 'label')
-										|| 'range-label-right'
-									}
-								>
-									{this.labels.end}
-								</label>
-							</div>
-						) : null}
-					</Slider>
+							{this.labels ? (
+								<div class="label-container">
+									<label
+										class={
+											getClassName(this.$props.innerClass, 'label')
+											|| 'range-label-left'
+										}
+									>
+										{this.labels.start}
+									</label>
+									<label
+										class={
+											getClassName(this.$props.innerClass, 'label')
+											|| 'range-label-right'
+										}
+									>
+										{this.labels.end}
+									</label>
+								</div>
+							) : null}
+						</Slider>
+					</div>
 				</NoSSR>
 			</Container>
 		);

--- a/packages/vue/src/components/range/DynamicRangeSlider.jsx
+++ b/packages/vue/src/components/range/DynamicRangeSlider.jsx
@@ -242,9 +242,10 @@ const DynamicRangeSlider = {
 			// check if the slider is at its initial position
 			const isInitialValue = currentStart === start && currentEnd === end;
 
+
 			this.updateQuery({
 				componentId: this.$props.componentId,
-				query,
+				query: (isInitialValue ? null : query),
 				value,
 				label: this.$props.filterLabel,
 				showFilter: this.$props.showFilter && !isInitialValue,

--- a/packages/vue/src/components/range/DynamicRangeSlider.jsx
+++ b/packages/vue/src/components/range/DynamicRangeSlider.jsx
@@ -204,6 +204,14 @@ const DynamicRangeSlider = {
 				this.range ? Math.min(this.range.end, currentValue[1]) : currentValue[1],
 			];
 
+			if (currentValue[0] === null) {
+				normalizedValue[0] = this.range.start
+			}
+
+			if (currentValue[1] === null) {
+				normalizedValue[1] = this.range.end
+			}
+
 			const performUpdate = () => {
 				this.currentValue = normalizedValue;
 				this.updateQueryHandler(normalizedValue, this.$props);
@@ -240,8 +248,11 @@ const DynamicRangeSlider = {
 			const { start, end } = this.range || { start: value[0], end: value[1] };
 			const [currentStart, currentEnd] = value;
 			// check if the slider is at its initial position
-			const isInitialValue = currentStart === start && currentEnd === end;
-
+			const isInitialValue = currentStart === start && currentEnd === end
+				|| !this.range
+				|| !this.currentValue
+				|| start === null
+				|| end === null
 
 			this.updateQuery({
 				componentId: this.$props.componentId,

--- a/packages/vue/src/components/range/DynamicRangeSlider.jsx
+++ b/packages/vue/src/components/range/DynamicRangeSlider.jsx
@@ -204,12 +204,14 @@ const DynamicRangeSlider = {
 				this.range ? Math.min(this.range.end, currentValue[1]) : currentValue[1],
 			];
 
-			if (currentValue[0] === null) {
-				normalizedValue[0] = this.range.start
-			}
+			if(this.range) {
+				if (currentValue[0] === null) {
+					normalizedValue[0] = this.range.start
+				}
 
-			if (currentValue[1] === null) {
-				normalizedValue[1] = this.range.end
+				if (currentValue[1] === null) {
+					normalizedValue[1] = this.range.end
+				}
 			}
 
 			const performUpdate = () => {

--- a/packages/vue/src/components/range/DynamicRangeSlider.jsx
+++ b/packages/vue/src/components/range/DynamicRangeSlider.jsx
@@ -339,12 +339,8 @@ const DynamicRangeSlider = {
 		const { start, end } = this.range;
 		return (
 			<Container class={this.$props.className}>
-				{this.$props.title && (
-					<Title class={getClassName(this.$props.innerClass, 'title')}>
-						{this.$props.title}
-					</Title>
-				)}
-				<NoSSR>
+				{this.$scopedSlots.title ? this.$scopedSlots.title() : null}
+				<NoSSR class={getClassName(this.$props.innerClass, 'outer')}>
 					<Slider class={getClassName(this.$props.innerClass, 'slider')}>
 						<vue-slider-component
 							ref="slider"


### PR DESCRIPTION
This PR contains a few updates to the DynamicRangeSlider in the Vue2 branch:

- Make sure ranges stay within range
- Hide the slider if the range is nonsensical (null or min/max equal)
- Add an extra class list for the outer div
- Turn the title into a slot, as god intended

I figure this branch is probably EOL because Vue2 is, but I also figure it's worth a try.