### PR TITLE
Update Node version for workflow tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Updates Node version to v20 fix snapshot tests requirement: e.g. https://github.com/appbaseio/reactivesearch/actions/runs/13175923320/job/36775071756#step:4:14

> error isomorphic-dompurify@1.13.0: The engine "node" is incompatible with this module. Expected version ">=18". Got "16.20.2"