### PR TITLE
fix: add npm bugs metadata

### DIFF
--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -13,6 +13,9 @@
     "author": "Appbase Inc. <info@appbase.io> (https://github.com/appbaseio)",
     "license": "Apache-2.0",
     "homepage": "https://github.com/appbaseio/reactivesearch",
+    "bugs": {
+        "url": "https://github.com/appbaseio/reactivesearch/issues"
+    },
     "keywords": [
         "appbaseio",
         "appbase",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -15,6 +15,9 @@
 		"type": "git",
 		"url": "https://github.com/appbaseio/reactivesearch.git"
 	},
+	"bugs": {
+		"url": "https://github.com/appbaseio/reactivesearch/issues"
+	},
 	"author": "Kuldeep Saxena <kuldepsaxena155@gmail.com>",
 	"license": "Apache-2.0",
 	"scripts": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,6 +7,9 @@
 	"module": "lib/index.es.js",
 	"js:next": "lib/index.es.js",
 	"sideEffects": false,
+	"bugs": {
+		"url": "https://github.com/appbaseio/reactivesearch/issues"
+	},
 	"files": [
 		"lib/",
 		"umd"


### PR DESCRIPTION
## Summary
- Add npm `bugs` metadata to the published ReactiveSearch package manifests.
- Point all packages to the repository issue tracker.

Updated packages:
- `@appbaseio/reactivesearch`
- `@appbaseio/reactivesearch-vue`
- `@appbaseio/reactivesearch-native`

## Validation
- Manifest assertion across all 3 packages
- `git diff --check`
- `npm pack --dry-run --json --ignore-scripts` for all 3 package directories