### PR TITLE
chore: add npm bugs metadata to all published packages

### DIFF
--- a/packages/maps-native/package.json
+++ b/packages/maps-native/package.json
@@ -54,4 +54,8 @@
         "native-base": "^2.4.2",
         "prop-types": "^15.6.1"
     }
+,
+  "bugs": {
+    "url": "https://github.com/appbaseio/reactivesearch/issues"
+  }
 }

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -57,4 +57,8 @@
 		"react-dom": "^18.2.0",
 		"webpack": "^4.18.0"
 	}
+,
+	"bugs": {
+		"url": "https://github.com/appbaseio/reactivesearch/issues"
+	}
 }

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -55,4 +55,8 @@
         "react-native-calendars": "^1.18.2",
         "react-redux": "^5.0.7"
     }
+,
+  "bugs": {
+    "url": "https://github.com/appbaseio/reactivesearch/issues"
+  }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -91,4 +91,8 @@
 		"typescript": "^5.0.0",
 		"vue-eslint-parser": "^3.2.2"
 	}
+,
+	"bugs": {
+		"url": "https://github.com/appbaseio/reactivesearch/issues"
+	}
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -95,4 +95,8 @@
 	"resolutions": {
 		"@types/react": "16.3.7"
 	}
+,
+	"bugs": {
+		"url": "https://github.com/appbaseio/reactivesearch/issues"
+	}
 }


### PR DESCRIPTION
All 5 `@appbaseio` packages (`reactivesearch`, `reactivesearch-vue`, `reactivemaps`, `reactivesearch-native`, `reactivemaps-native`) are missing the `bugs` field in their npm metadata.

This adds `bugs.url` pointing to the GitHub issue tracker for all published packages.

No runtime code, dependencies, or tests changed.