### PR TITLE
docs: add bugs metadata to reactivesearch packages

### DIFF
--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -12,6 +12,9 @@
     },
     "author": "Appbase Inc. <info@appbase.io> (https://github.com/appbaseio)",
     "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/appbaseio/reactivesearch/issues"
+    },
     "homepage": "https://github.com/appbaseio/reactivesearch",
     "keywords": [
         "appbaseio",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -17,6 +17,9 @@
 	},
 	"author": "Kuldeep Saxena <kuldepsaxena155@gmail.com>",
 	"license": "Apache-2.0",
+	"bugs": {
+		"url": "https://github.com/appbaseio/reactivesearch/issues"
+	},
 	"scripts": {
 		"watch": "nps watch",
 		"serve": "vue-cli-service serve",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -37,6 +37,9 @@
 	},
 	"author": "metagrover",
 	"license": "Apache-2.0",
+	"bugs": {
+		"url": "https://github.com/appbaseio/reactivesearch/issues"
+	},
 	"dependencies": {
 		"@appbaseio/analytics": "^1.2.0-alpha.1",
 		"@appbaseio/reactivecore": "10.4.0",


### PR DESCRIPTION
This PR adds the missing `bugs` metadata to the `@appbaseio/reactivesearch`, `@appbaseio/reactivesearch-vue`, and `@appbaseio/reactivesearch-native` packages, as requested in the microbounty issue #1154.

- Added `bugs` URL pointing to the main repository issues for all three packages.

Fixes #1154