### PR TITLE
fix: prevent ErrorBoundary onError from spamming null callbacks on every update

### DIFF
--- a/packages/web/src/components/basic/ErrorBoundary.js
+++ b/packages/web/src/components/basic/ErrorBoundary.js
@@ -28,7 +28,9 @@ class ErrorBoundary extends Component {
 			// eslint-disable-next-line react/no-did-update-set-state
 			this.setState({ error: this.props.error });
 		}
-		this.invokeErrorCallback();
+		if (this.state.error) {
+			this.invokeErrorCallback();
+		}
 	}
 
 	render() {


### PR DESCRIPTION
## Problem

The `componentDidUpdate` method in ErrorBoundary unconditionally called `invokeErrorCallback()`, which fires `this.props.onError(null, componentId)` on **every** re-render — even when no error exists. This spams consumer error monitoring with null-error notifications on every component update.

## Root Cause

```js
componentDidUpdate() {
    if (this.props.error && !this.state.error) {
        this.setState({ error: this.props.error });
    }
    this.invokeErrorCallback();  // ← fires on every update, even without error
}
```

## Fix

Guard `invokeErrorCallback()` behind `this.state.error`, so it only fires when an actual error exists in state:

```js
if (this.state.error) {
    this.invokeErrorCallback();
}
```

## Testing

Snapshot test already exists. The render output is unchanged — only the callback invocation path is gated. No visual regression.