### PR TITLE
Migrate web examples to Render ReactiveSearch API

### DIFF
--- a/packages/maps/examples/GeoDistanceDropdown/src/index.js
+++ b/packages/maps/examples/GeoDistanceDropdown/src/index.js
@@ -51,7 +51,8 @@ class App extends Component {
 		return (
 			<ReactiveBase
 				app="meetup_dataset"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 				enableAppbase
 				mapKey="AIzaSyA9JzjtHeXg_C_hh_GdTBdLxREWdj3nsOU"
 				mapLibraries={['places']}

--- a/packages/maps/examples/GeoDistanceDropdown/src/index.js
+++ b/packages/maps/examples/GeoDistanceDropdown/src/index.js
@@ -45,12 +45,12 @@ class App extends Component {
 			react: {
 				and: 'GeoDistanceDropdown',
 			},
-			onPopoverClick: (item) => <div>{item.venue.venue_name}</div>,
+			onPopoverClick: (item) => <div>{item.place}</div>,
 			showMapStyles: true,
 		};
 		return (
 			<ReactiveBase
-				app="meetup_dataset"
+				app="earthquakes"
 				url="https://reactivesearch-api-9-4-0.onrender.com"
 				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 				enableAppbase
@@ -80,7 +80,7 @@ class App extends Component {
 								{ distance: 300, label: 'Under 300 miles' },
 							]}
 							defaultValue={{
-								location: 'London, UK',
+								location: 'California, USA',
 								label: 'Within 10 miles',
 							}}
 						/>

--- a/packages/maps/examples/GeoDistanceSlider/src/index.js
+++ b/packages/maps/examples/GeoDistanceSlider/src/index.js
@@ -51,7 +51,8 @@ class App extends Component {
 		return (
 			<ReactiveBase
 				app="meetup_dataset"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 				enableAppbase
 				mapKey="AIzaSyA9JzjtHeXg_C_hh_GdTBdLxREWdj3nsOU"
 				mapLibraries={['places']}

--- a/packages/maps/examples/GeoDistanceSlider/src/index.js
+++ b/packages/maps/examples/GeoDistanceSlider/src/index.js
@@ -45,12 +45,12 @@ class App extends Component {
 			react: {
 				and: 'GeoDistanceSlider',
 			},
-			onPopoverClick: item => <div>{item.venue.venue_name}</div>,
+			onPopoverClick: item => <div>{item.place}</div>,
 			showMapStyles: true,
 		};
 		return (
 			<ReactiveBase
-				app="meetup_dataset"
+				app="earthquakes"
 				url="https://reactivesearch-api-9-4-0.onrender.com"
 				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 				enableAppbase
@@ -82,7 +82,7 @@ class App extends Component {
 								end: '300mi',
 							}}
 							defaultValue={{
-								location: 'London, UK',
+								location: 'California, USA',
 								distance: 10,
 							}}
 						/>

--- a/packages/maps/examples/QuickStartStep1/src/index.js
+++ b/packages/maps/examples/QuickStartStep1/src/index.js
@@ -7,7 +7,8 @@ class App extends Component {
 		return (
 			<ReactiveBase
 				app="earthquakes"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 				enableAppbase
 				mapKey="AIzaSyA9JzjtHeXg_C_hh_GdTBdLxREWdj3nsOU"
 			>

--- a/packages/maps/examples/QuickStartStep2/src/index.js
+++ b/packages/maps/examples/QuickStartStep2/src/index.js
@@ -8,7 +8,8 @@ class App extends Component {
 		return (
 			<ReactiveBase
 				app="earthquakes"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 				enableAppbase
 				mapKey="AIzaSyA9JzjtHeXg_C_hh_GdTBdLxREWdj3nsOU"
 			>

--- a/packages/maps/examples/ReactiveMap/src/index.js
+++ b/packages/maps/examples/ReactiveMap/src/index.js
@@ -64,7 +64,8 @@ class App extends Component {
 		return (
 			<ReactiveBase
 				app="earthquakes"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 				enableAppbase
 				mapKey="AIzaSyA9JzjtHeXg_C_hh_GdTBdLxREWdj3nsOU"
 			>

--- a/packages/vue/examples/ai-answer/src/App.vue
+++ b/packages/vue/examples/ai-answer/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
       theme-preset="light"
     >
       <search-box

--- a/packages/vue/examples/ai-answer/vite.config.js
+++ b/packages/vue/examples/ai-answer/vite.config.js
@@ -12,6 +12,6 @@ export default {
 		],
 	},
     server: {
-        allowedHosts: ['h83tzz-5173.csb.app']
-    }
+		allowedHosts: true,
+	}
 };

--- a/packages/vue/examples/analytics-with-hook/src/App.vue
+++ b/packages/vue/examples/analytics-with-hook/src/App.vue
@@ -5,7 +5,8 @@
         recordAnalytics: true,
       }"
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <search-box
         :data-field="['original_title', 'original_title.search']"

--- a/packages/vue/examples/analytics-with-hook/vite.config.js
+++ b/packages/vue/examples/analytics-with-hook/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/dynamic-range-slider/src/App.vue
+++ b/packages/vue/examples/dynamic-range-slider/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <div class="row">
         <div class="col">

--- a/packages/vue/examples/dynamic-range-slider/vite.config.js
+++ b/packages/vue/examples/dynamic-range-slider/vite.config.js
@@ -12,6 +12,6 @@ export default {
 		],
 	},
     server: {
-        allowedHosts: ['xzjwp6n89w-5173.csb.app']
-    }
+		allowedHosts: true,
+	}
 };

--- a/packages/vue/examples/mongo-examples/multi-list/vite.config.js
+++ b/packages/vue/examples/mongo-examples/multi-list/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/mongo-examples/range-input/vite.config.js
+++ b/packages/vue/examples/mongo-examples/range-input/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/mongo-examples/search-box/vite.config.js
+++ b/packages/vue/examples/mongo-examples/search-box/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/multi-Range/src/App.vue
+++ b/packages/vue/examples/multi-Range/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <div class="row">
         <div class="col">

--- a/packages/vue/examples/multi-Range/vite.config.js
+++ b/packages/vue/examples/multi-Range/vite.config.js
@@ -12,6 +12,6 @@ export default {
 		],
 	},
     server: {
-        allowedHosts: ['le79r-5173.csb.app']
-    }
+		allowedHosts: true,
+	}
 };

--- a/packages/vue/examples/multi-dropdown-list/src/App.vue
+++ b/packages/vue/examples/multi-dropdown-list/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <multi-dropdown-list 
         component-id="BookSensor" 

--- a/packages/vue/examples/multi-dropdown-list/vite.config.js
+++ b/packages/vue/examples/multi-dropdown-list/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/multi-list-nested/src/App.vue
+++ b/packages/vue/examples/multi-list-nested/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <multi-list
         :show-count="true"

--- a/packages/vue/examples/multi-list-nested/vite.config.js
+++ b/packages/vue/examples/multi-list-nested/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/multi-list/src/App.vue
+++ b/packages/vue/examples/multi-list/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <multi-list
         :show-count="true"

--- a/packages/vue/examples/multi-list/vite.config.js
+++ b/packages/vue/examples/multi-list/vite.config.js
@@ -12,6 +12,6 @@ export default {
 		],
 	},
     server: {
-        allowedHosts: ['3v307xo5q-5173.csb.app']
-    }
+		allowedHosts: true,
+	}
 };

--- a/packages/vue/examples/preferences/src/App.vue
+++ b/packages/vue/examples/preferences/src/App.vue
@@ -3,7 +3,8 @@
     <reactive-base
       :preferences="preferences"
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <search-box
         component-id="BookSensor"

--- a/packages/vue/examples/preferences/vite.config.js
+++ b/packages/vue/examples/preferences/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/range-input/src/App.vue
+++ b/packages/vue/examples/range-input/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <div class="row">
         <div class="col">

--- a/packages/vue/examples/range-input/vite.config.js
+++ b/packages/vue/examples/range-input/vite.config.js
@@ -12,6 +12,6 @@ export default {
 		],
 	},
     server: {
-        allowedHosts: ['zjdo8-5173.csb.app']
-    }
+		allowedHosts: true,
+	}
 };

--- a/packages/vue/examples/range-slider/src/App.vue
+++ b/packages/vue/examples/range-slider/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <div class="row">
         <div class="col">

--- a/packages/vue/examples/range-slider/vite.config.js
+++ b/packages/vue/examples/range-slider/vite.config.js
@@ -12,6 +12,6 @@ export default {
 		],
 	},
     server: {
-        allowedHosts: ['2zqz3m1r3r-5173.csb.app']
-    }
+		allowedHosts: true,
+	}
 };

--- a/packages/vue/examples/reactive-component-with-custom-query/src/App.vue
+++ b/packages/vue/examples/reactive-component-with-custom-query/src/App.vue
@@ -2,7 +2,8 @@
   <reactive-base
     :enable-appbase="true"
     app="carstore-dataset"
-    url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+    url="https://reactivesearch-api-9-4-0.onrender.com"
+    credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
   >
     <div class="row">
       <div class="col">

--- a/packages/vue/examples/reactive-component-with-custom-query/vite.config.js
+++ b/packages/vue/examples/reactive-component-with-custom-query/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/reactive-component/src/App.vue
+++ b/packages/vue/examples/reactive-component/src/App.vue
@@ -2,7 +2,8 @@
   <reactive-base
     :enable-appbase="true"
     app="carstore-dataset"
-    url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+    url="https://reactivesearch-api-9-4-0.onrender.com"
+    credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
   >
     <div class="row">
       <div class="col">

--- a/packages/vue/examples/reactive-component/vite.config.js
+++ b/packages/vue/examples/reactive-component/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/reactive-google-map-aggregations/src/App.vue
+++ b/packages/vue/examples/reactive-google-map-aggregations/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="earthquakes"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <div class="row">
         <div class="col">

--- a/packages/vue/examples/reactive-google-map-aggregations/vite.config.js
+++ b/packages/vue/examples/reactive-google-map-aggregations/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/reactive-google-map-default-query/src/App.vue
+++ b/packages/vue/examples/reactive-google-map-default-query/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="earthquakes"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <div class="row">
         <div class="col">

--- a/packages/vue/examples/reactive-google-map-default-query/vite.config.js
+++ b/packages/vue/examples/reactive-google-map-default-query/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/reactive-google-map-nuxt/pages/index.vue
+++ b/packages/vue/examples/reactive-google-map-nuxt/pages/index.vue
@@ -3,7 +3,8 @@
     <reactive-base
       :enable-appbase="true"
       app="earthquakes"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <div class="row">
         <div class="col">

--- a/packages/vue/examples/reactive-google-map/src/App.vue
+++ b/packages/vue/examples/reactive-google-map/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="earthquakes"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <div class="row">
         <div class="col">

--- a/packages/vue/examples/reactive-google-map/vite.config.js
+++ b/packages/vue/examples/reactive-google-map/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/reactive-list-custom-pagination/src/App.vue
+++ b/packages/vue/examples/reactive-list-custom-pagination/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <reactive-list
         :pagination="true"

--- a/packages/vue/examples/reactive-list-custom-pagination/vite.config.js
+++ b/packages/vue/examples/reactive-list-custom-pagination/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/reactive-list/src/App.vue
+++ b/packages/vue/examples/reactive-list/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <reactive-list
         :pagination="true"

--- a/packages/vue/examples/reactive-list/vite.config.js
+++ b/packages/vue/examples/reactive-list/vite.config.js
@@ -12,6 +12,6 @@ export default {
         ],
     },
     server: {
-        allowedHosts: ['6yw6vwyywr-5173.csb.app'],
-    },
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/reactivelist-with-aggregation/src/App.vue
+++ b/packages/vue/examples/reactivelist-with-aggregation/src/App.vue
@@ -2,7 +2,8 @@
 	<div id="app">
 		<reactive-base
 			app="carstore-dataset"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<reactive-list
 				componentId="SearchResult"

--- a/packages/vue/examples/reactivelist-with-aggregation/vite.config.js
+++ b/packages/vue/examples/reactivelist-with-aggregation/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/reactivelist-without-aggregation/src/App.vue
+++ b/packages/vue/examples/reactivelist-without-aggregation/src/App.vue
@@ -2,7 +2,8 @@
 	<div id="app">
 		<reactive-base
 			app="carstore-dataset"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<reactive-list
 				componentId="SearchResult"

--- a/packages/vue/examples/reactivelist-without-aggregation/vite.config.js
+++ b/packages/vue/examples/reactivelist-without-aggregation/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/result-card/src/App.vue
+++ b/packages/vue/examples/result-card/src/App.vue
@@ -2,7 +2,8 @@
 	<div id="app">
 		<reactive-base
 			app="meetup_dataset"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<div class="row">
 				<reactive-list

--- a/packages/vue/examples/result-card/vite.config.js
+++ b/packages/vue/examples/result-card/vite.config.js
@@ -12,6 +12,6 @@ export default {
 		],
 	},
     server: {
-        allowedHosts: ['bmkc4-5173.csb.app']
-    }
+		allowedHosts: true,
+	}
 };

--- a/packages/vue/examples/result-list/src/App.vue
+++ b/packages/vue/examples/result-list/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="meetup_dataset"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <div class="row">
         <reactive-list

--- a/packages/vue/examples/result-list/vite.config.js
+++ b/packages/vue/examples/result-list/vite.config.js
@@ -12,6 +12,6 @@ export default {
 		],
 	},
     server: {
-        allowedHosts: ['3407lk5w7p-5173.csb.app'],
-    },
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/saved-search/src/App.vue
+++ b/packages/vue/examples/saved-search/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     ><div class="row">
       <div class="col">
         <state-provider>

--- a/packages/vue/examples/saved-search/vite.config.js
+++ b/packages/vue/examples/saved-search/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/search-box-custom-suggestions/src/App.vue
+++ b/packages/vue/examples/search-box-custom-suggestions/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <search-box
         :data-field="['original_title', 'original_title.search']"

--- a/packages/vue/examples/search-box-custom-suggestions/vite.config.js
+++ b/packages/vue/examples/search-box-custom-suggestions/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/search-box/src/App.vue
+++ b/packages/vue/examples/search-box/src/App.vue
@@ -6,18 +6,9 @@
       credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <search-box
-        :data-field="['original_title', 'original_title.search']"
+        :data-field="['original_title', 'original_title.search', 'authors']"
         :urlparams="true"
         :size="10"
-        :enable-popular-suggestions="true"
-        :popular-suggestions-config="{ size: 3, minChars: 2, index: 'good-books-ds', sectionLabel: '<b>Popular suggestions 🙌🏻</b>' }"
-        :enable-recent-suggestions="true"
-        :recent-suggestions-config="{
-          size: 3,
-          index: 'good-books-ds',
-          minChars: 4,
-          sectionLabel: '<b>Recent suggestions 🙌🏻</b>'
-        }"
         :autosuggest="true"
         class-name="result-list-container"
         component-id="BookSensor"
@@ -27,7 +18,7 @@
         :size="5"
         :react="{ and: ['BookSensor'] }"
         component-id="SearchResult"
-        data-field="_score"
+        data-field="original_title.keyword"
         class-name="result-list-container"
       >
         <template #renderItem="{ item }">

--- a/packages/vue/examples/search-box/src/App.vue
+++ b/packages/vue/examples/search-box/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <search-box
         :data-field="['original_title', 'original_title.search']"

--- a/packages/vue/examples/search-box/src/Wrapper.vue
+++ b/packages/vue/examples/search-box/src/Wrapper.vue
@@ -2,7 +2,8 @@
 	<div id="app">
 		<reactive-base
 			app="good-books-ds"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
             <slot />
 		</reactive-base>

--- a/packages/vue/examples/search-box/vite.config.js
+++ b/packages/vue/examples/search-box/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/search-showcase/ai-answer-simple/src/App.vue
+++ b/packages/vue/examples/search-showcase/ai-answer-simple/src/App.vue
@@ -2,7 +2,8 @@
 	<div id="app">
 		<reactive-base
 			app="good-books-ds"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 			themePreset="light"
 		>
 			<search-box

--- a/packages/vue/examples/search-showcase/ai-answer-simple/vite.config.js
+++ b/packages/vue/examples/search-showcase/ai-answer-simple/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/search-showcase/auto-suggestions/src/App.vue
+++ b/packages/vue/examples/search-showcase/auto-suggestions/src/App.vue
@@ -2,7 +2,8 @@
 	<div id="app">
 		<reactive-base
 			app="good-books-ds"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<search-box
 				className="result-list-container"

--- a/packages/vue/examples/search-showcase/auto-suggestions/vite.config.js
+++ b/packages/vue/examples/search-showcase/auto-suggestions/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/search-showcase/faq-suggestions/src/App.vue
+++ b/packages/vue/examples/search-showcase/faq-suggestions/src/App.vue
@@ -2,7 +2,8 @@
 	<div id="app">
 		<reactive-base
 			app="good-books-ds"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<search-box
 				className="result-list-container"

--- a/packages/vue/examples/search-showcase/faq-suggestions/vite.config.js
+++ b/packages/vue/examples/search-showcase/faq-suggestions/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/search-showcase/featured-suggestions/src/App.vue
+++ b/packages/vue/examples/search-showcase/featured-suggestions/src/App.vue
@@ -2,7 +2,8 @@
 	<div id="app">
 		<reactive-base
 			app="good-books-ds"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<search-box
 				className="result-list-container"

--- a/packages/vue/examples/search-showcase/featured-suggestions/vite.config.js
+++ b/packages/vue/examples/search-showcase/featured-suggestions/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/search-showcase/focus-shortcuts/src/App.vue
+++ b/packages/vue/examples/search-showcase/focus-shortcuts/src/App.vue
@@ -2,7 +2,8 @@
 	<div id="app">
 		<reactive-base
 			app="good-books-ds"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<search-box
 				className="result-list-container"

--- a/packages/vue/examples/search-showcase/focus-shortcuts/vite.config.js
+++ b/packages/vue/examples/search-showcase/focus-shortcuts/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/search-showcase/instant-search/src/App.vue
+++ b/packages/vue/examples/search-showcase/instant-search/src/App.vue
@@ -2,7 +2,8 @@
 	<div id="app">
 		<reactive-base
 			app="good-books-ds"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<search-box
 				className="result-list-container"

--- a/packages/vue/examples/search-showcase/instant-search/vite.config.js
+++ b/packages/vue/examples/search-showcase/instant-search/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/search-showcase/movie-search-ai-demo/src/App.vue
+++ b/packages/vue/examples/search-showcase/movie-search-ai-demo/src/App.vue
@@ -12,7 +12,8 @@
         },
       }"
       app="movies-demo-app"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
       theme-preset="light"
       enable-appbase
     >

--- a/packages/vue/examples/search-showcase/movie-search-ai-demo/vite.config.js
+++ b/packages/vue/examples/search-showcase/movie-search-ai-demo/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/search-showcase/pill-suggestions/src/App.vue
+++ b/packages/vue/examples/search-showcase/pill-suggestions/src/App.vue
@@ -9,7 +9,8 @@
 		>
 		<reactive-base
 			app="good-books-ds"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<div class="container">
 				<div id="row">

--- a/packages/vue/examples/search-showcase/pill-suggestions/vite.config.js
+++ b/packages/vue/examples/search-showcase/pill-suggestions/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/search-showcase/searchbox-inline-ai-response/src/App.vue
+++ b/packages/vue/examples/search-showcase/searchbox-inline-ai-response/src/App.vue
@@ -12,7 +12,8 @@
         userId: 'jon',
       }"
       app="reactivesearch_docs_v2"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <search-box
         :data-field="[

--- a/packages/vue/examples/search-showcase/searchbox-inline-ai-response/vite.config.js
+++ b/packages/vue/examples/search-showcase/searchbox-inline-ai-response/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/search-showcase/simple-search/src/App.vue
+++ b/packages/vue/examples/search-showcase/simple-search/src/App.vue
@@ -2,7 +2,8 @@
 	<div id="app">
 		<reactive-base
 			app="good-books-ds"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<search-box
 				className="result-list-container"

--- a/packages/vue/examples/search-showcase/simple-search/vite.config.js
+++ b/packages/vue/examples/search-showcase/simple-search/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/search-showcase/voice-search/src/App.vue
+++ b/packages/vue/examples/search-showcase/voice-search/src/App.vue
@@ -8,7 +8,8 @@
       referrerpolicy="no-referrer" >
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <div class="container">
         <div class="row">

--- a/packages/vue/examples/search-showcase/voice-search/vite.config.js
+++ b/packages/vue/examples/search-showcase/voice-search/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/selected-filters-custom/src/App.vue
+++ b/packages/vue/examples/selected-filters-custom/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <div class="row">
         <div class="col">

--- a/packages/vue/examples/selected-filters-custom/vite.config.js
+++ b/packages/vue/examples/selected-filters-custom/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/vue/examples/single-dropdown-list/src/App.vue
+++ b/packages/vue/examples/single-dropdown-list/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <single-dropdown-list 
         component-id="BookSensor" 

--- a/packages/vue/examples/single-dropdown-list/vite.config.js
+++ b/packages/vue/examples/single-dropdown-list/vite.config.js
@@ -12,6 +12,6 @@ export default {
 		],
 	},
     server: {
-        allowedHosts: ['0pkoi-5173.csb.app']
-    }
+		allowedHosts: true,
+	}
 };

--- a/packages/vue/examples/single-list/src/App.vue
+++ b/packages/vue/examples/single-list/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <single-list
         component-id="Authors"

--- a/packages/vue/examples/single-list/vite.config.js
+++ b/packages/vue/examples/single-list/vite.config.js
@@ -13,6 +13,6 @@ export default {
 		],
 	},
     server: {
-        allowedHosts: ['nrxz2zv84-5173.csb.app']
-    }
+		allowedHosts: true,
+	}
 };

--- a/packages/vue/examples/single-range/src/App.vue
+++ b/packages/vue/examples/single-range/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <single-range
         :data="[

--- a/packages/vue/examples/single-range/vite.config.js
+++ b/packages/vue/examples/single-range/vite.config.js
@@ -12,6 +12,6 @@ export default {
 		],
 	},
     server: {
-        allowedHosts: ['7qez3-5173.csb.app']
-    }
+		allowedHosts: true,
+	}
 };

--- a/packages/vue/examples/toggle-button/src/App.vue
+++ b/packages/vue/examples/toggle-button/src/App.vue
@@ -27,7 +27,7 @@
             }"
             :pagination="true"
             component-id="SearchResult"
-            data-field="original_title"
+            data-field="original_title.keyword"
             title="Results"
             sort-by="asc"
             class="result-list-container"

--- a/packages/vue/examples/toggle-button/src/App.vue
+++ b/packages/vue/examples/toggle-button/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app">
     <reactive-base
-      app="meetup_dataset"
+      app="good-books-ds"
       url="https://reactivesearch-api-9-4-0.onrender.com"
       credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
@@ -9,54 +9,58 @@
         <div class="col">
           <toggle-button
             :data="[
-              { label: 'Social', value: 'Social' },
-              { label: 'Adventure', value: 'Adventure' },
-              { label: 'Music', value: 'Music' },
+              { label: 'English', value: 'eng' },
+              { label: 'French', value: 'fre' },
+              { label: 'Spanish', value: 'spa' },
             ]"
-            component-id="CitySensor"
-            data-field="group.group_topics.topic_name_raw.keyword"
+            component-id="LanguageSensor"
+            data-field="language_code"
           />
         </div>
         <div class="col">
-          <selected-filters component-id="CitySensor" />
+          <selected-filters component-id="LanguageSensor" />
           <reactive-list
             :from="0"
             :size="5"
-            :inner-class="{
-              image: 'meetup-list-image',
-            }"
             :react="{
-              and: ['CitySensor']
+              and: ['LanguageSensor']
             }"
             :pagination="true"
             component-id="SearchResult"
-            data-field="group.group_topics.topic_name_raw.keyword"
+            data-field="original_title"
             title="Results"
             sort-by="asc"
             class="result-list-container"
           >
-            <template #render="{ data }">
-              <ResultListWrapper>
-                <ResultList
-                  v-for="result in data"
-                  :key="result._id"
-                  :href="result.event.event_url"
+            <template #renderItem="{ item }">
+              <div class="flex book-content">
+                <img
+                  :src="item.image"
+                  alt="Book Cover"
+                  class="book-image"
                 >
-                  <ResultListImage 
-                    :small="true" 
-                    :src="result.member.photo" />
-                  <ResultListContent>
-                    <ResultListTitle>
-                      {{ result.member ? result.member.member_name : '' }} is
-                      going to
-                      {{ result.event ? result.event.event_name : '' }}
-                    </ResultListTitle>
-                    <ResultListDescription>
-                      {{ result.group ? result.group.group_city : '' }}
-                    </ResultListDescription>
-                  </ResultListContent>
-                </ResultList>
-              </ResultListWrapper>
+                <div class="flex column justify-center ml20">
+                  <div class="book-header">{{ item.original_title }}</div>
+                  <div class="flex column justify-space-between">
+                    <div>
+                      <div>
+                        by <span class="authors-list">{{ item.authors }}</span>
+                      </div>
+                      <div class="ratings-list flex align-center">
+                        <span class="stars">
+                          <i
+                            v-for="(star, index) in Array(item.average_rating_rounded).fill('x')"
+                            :key="index"
+                            class="fas fa-star"
+                          />
+                        </span>
+                        <span class="avg-rating">({{ item.average_rating }} avg)</span>
+                      </div>
+                    </div>
+                    <span class="pub-year">Pub {{ item.original_publication_year }}</span>
+                  </div>
+                </div>
+              </div>
             </template>
           </reactive-list>
         </div>
@@ -67,7 +71,7 @@
 
 <script>
 import './styles.css';
-import { ReactiveBase, ReactiveList, ToggleButton, SelectedFilters, ResultList  } from '@appbaseio/reactivesearch-vue'
+import { ReactiveBase, ReactiveList, ToggleButton, SelectedFilters } from '@appbaseio/reactivesearch-vue'
 
 export default {
 	name: 'App',
@@ -76,7 +80,6 @@ export default {
 		ReactiveList,
 		ToggleButton,
 		SelectedFilters,
-		ResultList
 	},
 };
 </script>

--- a/packages/vue/examples/toggle-button/src/App.vue
+++ b/packages/vue/examples/toggle-button/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <reactive-base
       app="meetup_dataset"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <div class="parent-row">
         <div class="col">

--- a/packages/vue/examples/toggle-button/vite.config.js
+++ b/packages/vue/examples/toggle-button/vite.config.js
@@ -12,6 +12,6 @@ export default {
 		],
 	},
     server: {
-        allowedHosts: ['2v265qx5pr-5173.csb.app']
-    }
+		allowedHosts: true,
+	}
 };

--- a/packages/vue/examples/tree-list/src/App.vue
+++ b/packages/vue/examples/tree-list/src/App.vue
@@ -3,7 +3,8 @@
     <ReactiveBase
       :enable-appbase="true"
       app="best-buy-dataset"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <div class="row">
         <div class="col">

--- a/packages/vue/examples/tree-list/vite.config.js
+++ b/packages/vue/examples/tree-list/vite.config.js
@@ -12,6 +12,6 @@ export default {
 		],
 	},
     server: {
-        allowedHosts: ['6l3wny-5173.csb.app']
-    }
+		allowedHosts: true,
+	}
 };

--- a/packages/vue/examples/vector-search/src/App.vue
+++ b/packages/vue/examples/vector-search/src/App.vue
@@ -1,8 +1,8 @@
 <template>
   <reactive-base
     app="yc-companies-dataset"
-    url="https://appbase-demo-ansible-abxiydt-arc.searchbase.io"
-    credentials="a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61"
+    url="https://reactivesearch-api-9-4-0.onrender.com"
+    credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     :enable-appbase="true"
   >
     <div class="container">

--- a/packages/vue/examples/vector-search/vite.config.js
+++ b/packages/vue/examples/vector-search/vite.config.js
@@ -3,5 +3,8 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue()]
+  plugins: [vue()],
+  server: {
+    allowedHosts: true,
+  },
 })

--- a/packages/vue/examples/with-nuxt-typescript/components/search.vue
+++ b/packages/vue/examples/with-nuxt-typescript/components/search.vue
@@ -10,7 +10,8 @@
 			:context-collector="contextCollector"
 			:initial-state="initialState"
 			app="good-books-ds"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<nav class="nav">
 				<div class="title">Books Search</div>

--- a/packages/vue/examples/with-ssr/components/search.vue
+++ b/packages/vue/examples/with-ssr/components/search.vue
@@ -11,7 +11,8 @@
 			:context-collector="contextCollector"
 			:initial-state="initialState"
 			app="good-books-ds"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<nav class="nav">
 				<div class="title">Books Search</div>

--- a/packages/vue/examples/with-tailwind-css/src/App.vue
+++ b/packages/vue/examples/with-tailwind-css/src/App.vue
@@ -4,7 +4,8 @@
     class="p-3 bg-gradient-to-r from-green-400 to-blue-500 text-center">
     <reactive-base
       app="good-books-ds"
-      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <search-box
         :data-field="['original_title', 'original_title.search', 'authors', 'authors.search']"

--- a/packages/vue/examples/with-tailwind-css/vite.config.js
+++ b/packages/vue/examples/with-tailwind-css/vite.config.js
@@ -11,4 +11,7 @@ export default {
 			'fast-deep-equal',
 		],
 	},
+	server: {
+		allowedHosts: true,
+	},
 };

--- a/packages/web/examples/AIAnswer/src/index.js
+++ b/packages/web/examples/AIAnswer/src/index.js
@@ -14,7 +14,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		reactivesearchAPIConfig={{
 			recordAnalytics: false,
 			userId: 'jon',

--- a/packages/web/examples/AnalyticsWithHook/src/index.js
+++ b/packages/web/examples/AnalyticsWithHook/src/index.js
@@ -40,7 +40,8 @@ const VisitStoreButton = () => {
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		enableAppbase
 		reactivesearchAPIConfig={{
 			recordAnalytics: true,

--- a/packages/web/examples/CustomSelectedFilters/src/index.js
+++ b/packages/web/examples/CustomSelectedFilters/src/index.js
@@ -16,7 +16,8 @@ class Main extends Component {
 		return (
 			<ReactiveBase
 				app="good-books-ds"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 			>
 				<div className="row">
 					<div className="col">

--- a/packages/web/examples/DatePicker/src/index.js
+++ b/packages/web/examples/DatePicker/src/index.js
@@ -16,7 +16,8 @@ class Main extends Component {
 		return (
 			<ReactiveBase
 				app="clone-airbeds"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 				type="listing"
 			>
 				<div className="row">

--- a/packages/web/examples/DateRange/src/index.js
+++ b/packages/web/examples/DateRange/src/index.js
@@ -39,7 +39,8 @@ class Main extends Component {
 		return (
 			<ReactiveBase
 				app="airbnb-dev"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 				type="listing"
 			>
 				<div className="row">

--- a/packages/web/examples/DateRangeControlled/src/index.js
+++ b/packages/web/examples/DateRangeControlled/src/index.js
@@ -44,7 +44,8 @@ class Main extends Component {
 		return (
 			<ReactiveBase
 				app="airbnb-dev"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 				enableAppbase
 			>
 				<div className="row">

--- a/packages/web/examples/DynamicRangeSlider/src/index.js
+++ b/packages/web/examples/DynamicRangeSlider/src/index.js
@@ -12,7 +12,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row">
 			<div className="col">

--- a/packages/web/examples/ErrorBoundary/src/index.js
+++ b/packages/web/examples/ErrorBoundary/src/index.js
@@ -13,7 +13,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<ErrorBoundary
 			renderError={(error) => (

--- a/packages/web/examples/FavoritesAnalytics/src/index.js
+++ b/packages/web/examples/FavoritesAnalytics/src/index.js
@@ -7,8 +7,8 @@ import './index.css';
 
 const AppbaseConfig = {
 	app: 'good-books-ds',
-	url: 'https://@appbase-demo-ansible-abxiydt-arc.searchbase.io',
-	credentials: 'a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 };
 const aaInstance = aa.init({
 	index: AppbaseConfig.app,

--- a/packages/web/examples/MultiDataList/src/index.js
+++ b/packages/web/examples/MultiDataList/src/index.js
@@ -12,7 +12,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="meetup_app"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row">
 			<div className="col">

--- a/packages/web/examples/MultiDataListControlled/src/index.js
+++ b/packages/web/examples/MultiDataListControlled/src/index.js
@@ -15,7 +15,8 @@ const Main = () => {
 	return (
 		<ReactiveBase
 			app="meetup_app"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<div className="row">
 				<div className="col">

--- a/packages/web/examples/MultiDropdownList/src/index.js
+++ b/packages/web/examples/MultiDropdownList/src/index.js
@@ -14,7 +14,8 @@ class Main extends Component {
 		return (
 			<ReactiveBase
 				app="good-books-ds"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 							>
 				<div className="row">
 					<div className="col">

--- a/packages/web/examples/MultiDropdownListControlled/src/index.js
+++ b/packages/web/examples/MultiDropdownListControlled/src/index.js
@@ -45,7 +45,8 @@ function Main() {
 	return (
 		<ReactiveBase
 			app="good-books-ds"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<div className="row">
 				<div className="col">

--- a/packages/web/examples/MultiDropdownRange/src/index.js
+++ b/packages/web/examples/MultiDropdownRange/src/index.js
@@ -12,7 +12,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row reverse-labels">
 			<div className="col">

--- a/packages/web/examples/MultiDropdownRangeControlled/src/index.js
+++ b/packages/web/examples/MultiDropdownRangeControlled/src/index.js
@@ -15,7 +15,8 @@ const Main = () => {
 	return (
 		<ReactiveBase
 			app="good-books-ds"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<div className="row reverse-labels">
 				<div className="col">

--- a/packages/web/examples/MultiIndexFacet/src/index.js
+++ b/packages/web/examples/MultiIndexFacet/src/index.js
@@ -9,7 +9,8 @@ class Main extends Component {
 		return (
 			<ReactiveBase
 				app="good-books-ds,good-books-authors"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 			>
 				<div className="row">
 					<div className="col">

--- a/packages/web/examples/MultiIndexSearch/src/index.js
+++ b/packages/web/examples/MultiIndexSearch/src/index.js
@@ -17,7 +17,8 @@ const badge = {
 const Main = () => (
 	<ReactiveBase
 		app="good-books,good-books-ds"
-		url="https://b59ca4ceab0d:00a2085f-8794-4a7e-96af-041f45332f0e@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		reactivesearchAPIConfig={{
 			recordAnalytics: true,
 			userId: 'jon',

--- a/packages/web/examples/MultiList/src/index.js
+++ b/packages/web/examples/MultiList/src/index.js
@@ -9,7 +9,8 @@ class Main extends Component {
 		return (
 			<ReactiveBase
 				app="good-books-ds"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 			>
 				<div className="row">
 					<div className="col">

--- a/packages/web/examples/MultiListAntd/src/index.js
+++ b/packages/web/examples/MultiListAntd/src/index.js
@@ -9,7 +9,8 @@ const { Meta } = Card;
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row">
 			<div

--- a/packages/web/examples/MultiListControlled/src/index.js
+++ b/packages/web/examples/MultiListControlled/src/index.js
@@ -39,7 +39,8 @@ function Main() {
 	return (
 		<ReactiveBase
 			app="good-books-ds"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<div className="row">
 				<div className="col">

--- a/packages/web/examples/MultiRange/src/index.js
+++ b/packages/web/examples/MultiRange/src/index.js
@@ -12,7 +12,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row reverse-labels">
 			<div className="col">

--- a/packages/web/examples/MultiRangeControlled/src/index.js
+++ b/packages/web/examples/MultiRangeControlled/src/index.js
@@ -15,7 +15,8 @@ const Main = () => {
 	return (
 		<ReactiveBase
 			app="good-books-ds"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 					>
 			<div className="row reverse-labels">
 				<div className="col">

--- a/packages/web/examples/MyAwesomeSearchStep1/src/App.js
+++ b/packages/web/examples/MyAwesomeSearchStep1/src/App.js
@@ -4,9 +4,9 @@ import { ReactiveBase } from '@appbaseio/reactivesearch';
 function App() {
 	return (
 		<ReactiveBase
-			url="https://appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
 			app="good-books-ds"
-			credentials="04717bb076f7:be54685e-db84-4243-975b-5b32ee241d31"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			{/* Our components will go over here */}
 			Hello from ReactiveSearch 👋

--- a/packages/web/examples/MyAwesomeSearchStep2/src/App.js
+++ b/packages/web/examples/MyAwesomeSearchStep2/src/App.js
@@ -4,9 +4,9 @@ import { ReactiveBase, SearchBox } from '@appbaseio/reactivesearch';
 function App() {
 	return (
 		<ReactiveBase
-			url="https://appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
 			app="good-books-ds"
-			credentials="04717bb076f7:be54685e-db84-4243-975b-5b32ee241d31"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<SearchBox
 				componentId="searchbox"

--- a/packages/web/examples/MyAwesomeSearchStep3/src/App.js
+++ b/packages/web/examples/MyAwesomeSearchStep3/src/App.js
@@ -4,9 +4,9 @@ import { ReactiveBase, SearchBox, MultiList, SingleRange } from '@appbaseio/reac
 function App() {
 	return (
 		<ReactiveBase
-			url="https://appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
 			app="good-books-ds"
-			credentials="04717bb076f7:be54685e-db84-4243-975b-5b32ee241d31"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<SearchBox
 				componentId="searchbox"

--- a/packages/web/examples/MyAwesomeSearchStep4/src/App.js
+++ b/packages/web/examples/MyAwesomeSearchStep4/src/App.js
@@ -11,9 +11,9 @@ import {
 function App() {
 	return (
 		<ReactiveBase
-			url="https://appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
 			app="good-books-ds"
-			credentials="04717bb076f7:be54685e-db84-4243-975b-5b32ee241d31"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<SearchBox
 				componentId="searchbox"

--- a/packages/web/examples/MyAwesomeSearchStep5/src/App.js
+++ b/packages/web/examples/MyAwesomeSearchStep5/src/App.js
@@ -11,9 +11,9 @@ import {
 function App() {
 	return (
 		<ReactiveBase
-			url="https://appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
 			app="good-books-ds"
-			credentials="04717bb076f7:be54685e-db84-4243-975b-5b32ee241d31"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<div style={{ display: 'flex', flexDirection: 'row' }}>
 				<div

--- a/packages/web/examples/NumberBox/src/index.js
+++ b/packages/web/examples/NumberBox/src/index.js
@@ -6,7 +6,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 			>
 		<div className="row reverse-labels">
 			<div className="col">

--- a/packages/web/examples/PathBasedRouting/src/components/SearchUI.js
+++ b/packages/web/examples/PathBasedRouting/src/components/SearchUI.js
@@ -76,7 +76,8 @@ const SearchUI = () => {
 	return (
 		<ReactiveBase
 			app="best-buy-dataset"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 			enableAppbase
 			getSearchParams={getSearchParams}
 			setSearchParams={setSearchParams}

--- a/packages/web/examples/Preferences/src/index.js
+++ b/packages/web/examples/Preferences/src/index.js
@@ -12,7 +12,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		reactivesearchAPIConfig={{
 			recordAnalytics: true,
 		}}

--- a/packages/web/examples/QuerySuggestion/src/App.js
+++ b/packages/web/examples/QuerySuggestion/src/App.js
@@ -1,27 +1,6 @@
 import { SearchBox, ReactiveList, ResultCard } from '@appbaseio/reactivesearch';
 
-import { magnifyingGlassIcon, trendingIcon } from './icons';
-
-function getCategoryResults(data) {
-	const results = {};
-	// eslint-disable-next-line no-plusplus
-	for (let i = 0; i < data.length; i++) {
-		const result = data[i];
-		const category = result._category.split(',');
-		if (Array.isArray(category)) {
-			// eslint-disable-next-line no-plusplus
-			for (let j = 0; j < category.length; j++) {
-				if (!results[category[j]]) {
-					results[category[j]] = Object.assign({}, result, {
-						_category: category[j],
-						value: category[j],
-					});
-				}
-			}
-		}
-	}
-	return Object.keys(results).map((k) => results[k]);
-}
+import { magnifyingGlassIcon } from './icons';
 
 const App = () => (
 	<div className="page">
@@ -40,123 +19,47 @@ const App = () => (
 		<SearchBox
 			componentId="search"
 			size={10}
-			aggregationSize={5}
-			categoryField="genres_data.keyword"
-			dataField={['original_title', 'overview']}
-			enablePopularSuggestions
-			popularSuggestionsConfig={{ index: 'movies-store-app', size: 5 }}
+			dataField={['original_title', 'original_title.search']}
 			render={({
 				error,
 				data,
-				value,
 				downshiftProps: { isOpen, getItemProps, highlightedIndex, selectedItem },
 			}) => {
 				if (error) {
 					return <div>Something went wrong! Error details {JSON.stringify(error)}</div>;
 				}
-				const popularResults = data.filter((res) => res._suggestion_type === 'popular');
 				const indexResults = data.filter(
-					(res) => res._suggestion_type === 'index' && !res._category,
+					res => res._suggestion_type === 'index' && !res._category,
 				);
-				const categoryResults = getCategoryResults(data.filter((res) => res._category));
 
-				return isOpen &&
-					(indexResults.length || categoryResults.length || popularResults.length) ? (
+				return isOpen && indexResults.length ? (
 					<div className="result suggestions">
 						<div className="flex column">
-							{indexResults.length ? (
-								<div className="resultSuggestion list">
-									<div className="listHead">Suggestions</div>
-									{indexResults.map((item, index) => (
-										<div
-											/* eslint-disable-next-line react/no-array-index-key */
-											key={item._id + index}
-											{...getItemProps({
-												item,
-												style: {
-													backgroundColor:
-														highlightedIndex === index
-															? 'lightgray'
-															: 'white',
-													fontWeight:
-														selectedItem === item ? 'bold' : 'normal',
-												},
-											})}
-											className="listItem"
-										>
-											<span className="listIcon">{magnifyingGlassIcon}</span>
-											<span className="clipText">{item.value}</span>
-										</div>
-									))}
-								</div>
-							) : null}
-							{categoryResults.length ? (
-								<div className="resultCategory list">
-									<div className="listHead">Genres</div>
-									{categoryResults.map((item, index) => (
-										<div
-											key={item._category}
-											{...getItemProps({
-												item,
-												style: {
-													backgroundColor:
-														highlightedIndex ===
-														index + indexResults.length
-															? 'lightgray'
-															: 'white',
-													fontWeight:
-														selectedItem === item ? 'bold' : 'normal',
-												},
-											})}
-											className="listItem"
-										>
-											<span className="listIcon">{magnifyingGlassIcon}</span>
-											<span className="clipText">{item.value}</span>
-										</div>
-									))}
-								</div>
-							) : null}
-						</div>
-						{(indexResults.length || categoryResults.length) &&
-						popularResults.length ? (
-							<div className="divider" />
-						) : null}
-						{popularResults.length ? (
-							<div className="resultPopular list">
-								<div className="listHead flex align-center">
-									{/* eslint-disable-next-line react/no-unescaped-entities */}
-									<span>Popular</span>
-									{value ? (
-										<span className="clipText pad-l-1">in "{value}"</span>
-									) : null}
-								</div>
-								<div>
-									{popularResults.map((item, index) => (
-										<div
-											key={item._id}
-											{...getItemProps({
-												item,
-												style: {
-													backgroundColor:
-														highlightedIndex ===
-														index +
-															indexResults.length +
-															categoryResults.length
-															? 'lightgray'
-															: 'white',
-													fontWeight:
-														selectedItem === item ? 'bold' : 'normal',
-												},
-											})}
-											className="listItem"
-										>
-											<span className="listIcon">{trendingIcon}</span>
-											<span className="clipText">{item.value}</span>
-										</div>
-									))}
-								</div>
+							<div className="resultSuggestion list">
+								<div className="listHead">Suggestions</div>
+								{indexResults.map((item, index) => (
+									<div
+										/* eslint-disable-next-line react/no-array-index-key */
+										key={item._id + index}
+										{...getItemProps({
+											item,
+											style: {
+												backgroundColor:
+													highlightedIndex === index
+														? 'lightgray'
+														: 'white',
+												fontWeight:
+													selectedItem === item ? 'bold' : 'normal',
+											},
+										})}
+										className="listItem"
+									>
+										<span className="listIcon">{magnifyingGlassIcon}</span>
+										<span className="clipText">{item.value}</span>
+									</div>
+								))}
 							</div>
-						) : null}
+						</div>
 					</div>
 				) : null;
 			}}
@@ -164,23 +67,24 @@ const App = () => (
 		<ReactiveList
 			componentId="result"
 			size={5}
-			dataField="original_title"
+			dataField="_score"
 			react={{ and: 'search' }}
 			pagination
 			render={({ data }) => (
 				<ReactiveList.ResultCardsWrapper>
-					{data.map((item) => (
+					{data.map(item => (
 						<ResultCard id={item._id} key={item._id}>
-							<ResultCard.Image
-								src={`https://image.tmdb.org/t/p/w500${item.poster_path}`}
-							/>
+							<ResultCard.Image src={item.image} />
 							<ResultCard.Title>
 								<div className="book-title">{item.original_title}</div>
 							</ResultCard.Title>
-
 							<ResultCard.Description>
-								<span className="language">{item.original_language}</span>
-								<span>-</span> <span>{item.release_year}</span>
+								<div>
+									by <span className="authors-list">{item.authors}</span>
+								</div>
+								<div>
+									Pub {item.original_publication_year} · {item.language_code}
+								</div>
 							</ResultCard.Description>
 						</ResultCard>
 					))}

--- a/packages/web/examples/QuerySuggestion/src/index.js
+++ b/packages/web/examples/QuerySuggestion/src/index.js
@@ -8,8 +8,8 @@ import App from './App';
 const Main = () => (
 	<ReactiveBase
 		app="movies-store-app"
-		credentials="b6bf924c4fb1:770dc0a7-7c11-415f-a5f1-88fa24633063"
-		url="https://appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
 	>
 		<App />
 	</ReactiveBase>

--- a/packages/web/examples/QuerySuggestion/src/index.js
+++ b/packages/web/examples/QuerySuggestion/src/index.js
@@ -7,7 +7,7 @@ import App from './App';
 
 const Main = () => (
 	<ReactiveBase
-		app="movies-store-app"
+		app="good-books-ds"
 		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		url="https://reactivesearch-api-9-4-0.onrender.com"
 	>

--- a/packages/web/examples/RangeInput/src/index.js
+++ b/packages/web/examples/RangeInput/src/index.js
@@ -7,7 +7,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row">
 			<div className="col">

--- a/packages/web/examples/RangeSlider/src/index.js
+++ b/packages/web/examples/RangeSlider/src/index.js
@@ -13,7 +13,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row">
 			<div className="col">

--- a/packages/web/examples/RatingsFilter/src/index.js
+++ b/packages/web/examples/RatingsFilter/src/index.js
@@ -12,7 +12,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row">
 			<div className="col">

--- a/packages/web/examples/ReactiveChart/Bar/src/index.js
+++ b/packages/web/examples/ReactiveChart/Bar/src/index.js
@@ -12,7 +12,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		reactivesearchAPIConfig={{
 			recordAnalytics: true,
 		}}

--- a/packages/web/examples/ReactiveChart/Histogram/src/index.js
+++ b/packages/web/examples/ReactiveChart/Histogram/src/index.js
@@ -13,7 +13,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		reactivesearchAPIConfig={{
 			recordAnalytics: true,
 		}}

--- a/packages/web/examples/ReactiveChart/Line/src/index.js
+++ b/packages/web/examples/ReactiveChart/Line/src/index.js
@@ -13,7 +13,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		reactivesearchAPIConfig={{
 			recordAnalytics: true,
 		}}

--- a/packages/web/examples/ReactiveChart/Pie/src/index.js
+++ b/packages/web/examples/ReactiveChart/Pie/src/index.js
@@ -14,7 +14,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		reactivesearchAPIConfig={{
 			recordAnalytics: true,
 		}}

--- a/packages/web/examples/ReactiveChart/Scatter/src/index.js
+++ b/packages/web/examples/ReactiveChart/Scatter/src/index.js
@@ -13,7 +13,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		reactivesearchAPIConfig={{
 			recordAnalytics: true,
 		}}

--- a/packages/web/examples/ReactiveChart/StackedBarChart/src/index.js
+++ b/packages/web/examples/ReactiveChart/StackedBarChart/src/index.js
@@ -13,7 +13,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="movies-store-app"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		reactivesearchAPIConfig={{
 			recordAnalytics: true,
 		}}

--- a/packages/web/examples/ReactiveComponent/src/index.js
+++ b/packages/web/examples/ReactiveComponent/src/index.js
@@ -16,7 +16,8 @@ class Main extends Component {
 		return (
 			<ReactiveBase
 				app="carstore-dataset"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 			>
 				<div className="row">
 					<div className="col">

--- a/packages/web/examples/ReactiveComponentGeneric/src/index.js
+++ b/packages/web/examples/ReactiveComponentGeneric/src/index.js
@@ -17,7 +17,8 @@ class Main extends Component {
 		return (
 			<ReactiveBase
 				app="carstore-dataset"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 			>
 				<div className="row">
 					<div className="col">

--- a/packages/web/examples/ReactiveComponentWithAggregation/src/index.js
+++ b/packages/web/examples/ReactiveComponentWithAggregation/src/index.js
@@ -16,7 +16,8 @@ class Main extends Component {
 		return (
 			<ReactiveBase
 				app="carstore-dataset-latest"
-				credentials="B86d2y2OE:4fecb2c5-5c5f-49e5-9e0b-0faba74597c6"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 			>
 				<div className="row">
 					<div className="col">

--- a/packages/web/examples/ReactiveList/src/index.js
+++ b/packages/web/examples/ReactiveList/src/index.js
@@ -14,7 +14,8 @@ class Main extends Component {
 		return (
 			<ReactiveBase
 				app="good-books-ds"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io?preference=lded"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 			>
 				<div className="row">
 					<div className="col">

--- a/packages/web/examples/ReactiveListWithAggregation/src/index.js
+++ b/packages/web/examples/ReactiveListWithAggregation/src/index.js
@@ -13,7 +13,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="carstore-dataset"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row">
 			<div className="col">

--- a/packages/web/examples/ResultCard/src/index.js
+++ b/packages/web/examples/ResultCard/src/index.js
@@ -12,7 +12,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row reverse-labels">
 			<div className="col">

--- a/packages/web/examples/ResultList/src/index.js
+++ b/packages/web/examples/ResultList/src/index.js
@@ -12,7 +12,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row reverse-labels">
 			<div className="col">

--- a/packages/web/examples/RichSnippets/src/index.js
+++ b/packages/web/examples/RichSnippets/src/index.js
@@ -8,7 +8,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="movies-store-rich-snippets"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="cover">
 			<p className="logo">

--- a/packages/web/examples/SavedSearch/src/index.js
+++ b/packages/web/examples/SavedSearch/src/index.js
@@ -21,7 +21,8 @@ class Main extends Component {
 		return (
 			<ReactiveBase
 				app="good-books-ds"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 			>
 				<StateProvider>
 					{({ setSearchState }) => (

--- a/packages/web/examples/SavedSearchAnalytics/src/index.js
+++ b/packages/web/examples/SavedSearchAnalytics/src/index.js
@@ -7,8 +7,8 @@ import './index.css';
 
 const AppbaseConfig = {
 	app: 'good-books-ds',
-	url: 'https://@appbase-demo-ansible-abxiydt-arc.searchbase.io',
-	credentials: 'a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 };
 const aaInstance = aa.init({
 	index: AppbaseConfig.app,

--- a/packages/web/examples/SearchBox/src/index.js
+++ b/packages/web/examples/SearchBox/src/index.js
@@ -13,7 +13,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		reactivesearchAPIConfig={{
 			recordAnalytics: true,
 			userId: 'jon',

--- a/packages/web/examples/SearchBoxWithAutosuggestions/src/index.js
+++ b/packages/web/examples/SearchBoxWithAutosuggestions/src/index.js
@@ -7,7 +7,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="movies-demo-app"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		reactivesearchAPIConfig={{
 			recordAnalytics: true,
 			userId: 'jon',

--- a/packages/web/examples/SearchBoxWithFAQSuggestions/src/index.js
+++ b/packages/web/examples/SearchBoxWithFAQSuggestions/src/index.js
@@ -7,7 +7,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="movies-demo-app"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		reactivesearchAPIConfig={{
 			recordAnalytics: true,
 			userId: 'jon',

--- a/packages/web/examples/SearchBoxWithFeaturedSuggestions/src/index.js
+++ b/packages/web/examples/SearchBoxWithFeaturedSuggestions/src/index.js
@@ -7,7 +7,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="movies-demo-app"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		reactivesearchAPIConfig={{
 			recordAnalytics: true,
 			userId: 'jon',

--- a/packages/web/examples/SearchBoxWithInstantSearch/src/index.js
+++ b/packages/web/examples/SearchBoxWithInstantSearch/src/index.js
@@ -7,7 +7,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="movies-demo-app"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row">
 			<div className="col">

--- a/packages/web/examples/SearchBoxWithKeyboardShortcuts/src/index.js
+++ b/packages/web/examples/SearchBoxWithKeyboardShortcuts/src/index.js
@@ -7,7 +7,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="movies-demo-app"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row">
 			<div className="col">

--- a/packages/web/examples/SearchBoxWithPillSuggestions/src/index.js
+++ b/packages/web/examples/SearchBoxWithPillSuggestions/src/index.js
@@ -9,7 +9,8 @@ const Main = () => {
 	return (
 		<ReactiveBase
 			app="movies-demo-app"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<div className="row">
 				<div className="col">

--- a/packages/web/examples/SearchBoxWithPopularRecentSuggestions/src/index.js
+++ b/packages/web/examples/SearchBoxWithPopularRecentSuggestions/src/index.js
@@ -7,7 +7,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="movies-demo-app"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		reactivesearchAPIConfig={{
 			recordAnalytics: true,
 			userId: 'jon',

--- a/packages/web/examples/SearchBoxWithTags/src/index.js
+++ b/packages/web/examples/SearchBoxWithTags/src/index.js
@@ -7,7 +7,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="movies-demo-app"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row">
 			<div className="col">

--- a/packages/web/examples/SearchBoxWithVoiceSearch/src/index.js
+++ b/packages/web/examples/SearchBoxWithVoiceSearch/src/index.js
@@ -9,7 +9,8 @@ const Main = () => {
 	return (
 		<ReactiveBase
 			app="movies-demo-app"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<div className="row">
 				<div className="col">

--- a/packages/web/examples/SelectedFilters/src/index.js
+++ b/packages/web/examples/SelectedFilters/src/index.js
@@ -13,7 +13,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row">
 			<div className="col">

--- a/packages/web/examples/SingleDataList/src/index.js
+++ b/packages/web/examples/SingleDataList/src/index.js
@@ -13,7 +13,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="meetup_app"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row">
 			<div className="col">

--- a/packages/web/examples/SingleDropdownList/src/index.js
+++ b/packages/web/examples/SingleDropdownList/src/index.js
@@ -15,7 +15,8 @@ class Main extends Component {
 		return (
 			<ReactiveBase
 				app="good-books-ds"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 			>
 				<div className="row">
 					<div className="col">

--- a/packages/web/examples/SingleDropdownRange/src/index.js
+++ b/packages/web/examples/SingleDropdownRange/src/index.js
@@ -13,7 +13,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row reverse-labels">
 			<div className="col">

--- a/packages/web/examples/SingleList/src/index.js
+++ b/packages/web/examples/SingleList/src/index.js
@@ -10,7 +10,8 @@ class Main extends Component {
 		return (
 			<ReactiveBase
 				app="good-books-ds"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 			>
 				<div className="row">
 					<div className="col">

--- a/packages/web/examples/SingleRange/src/index.js
+++ b/packages/web/examples/SingleRange/src/index.js
@@ -13,7 +13,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row reverse-labels">
 			<div className="col">

--- a/packages/web/examples/TabDataList/src/index.js
+++ b/packages/web/examples/TabDataList/src/index.js
@@ -13,7 +13,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="meetup_app"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="container">
 			<SelectedFilters />

--- a/packages/web/examples/TagCloud/src/index.js
+++ b/packages/web/examples/TagCloud/src/index.js
@@ -13,7 +13,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="meetup_app"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row">
 			<div className="col">

--- a/packages/web/examples/ToggleButton/src/index.js
+++ b/packages/web/examples/ToggleButton/src/index.js
@@ -3,28 +3,56 @@ import ReactDOM from 'react-dom/client';
 import {
 	ReactiveBase,
 	ToggleButton,
-	ResultList,
 	SelectedFilters,
 	ReactiveList,
 } from '@appbaseio/reactivesearch';
 
 import './index.css';
 
+const booksReactiveList = data => (
+	<div className="flex book-content" key={data._id}>
+		<img src={data.image} alt="Book Cover" className="book-image" />
+		<div className="flex column justify-center" style={{ marginLeft: 20 }}>
+			<div className="book-header">{data.original_title}</div>
+			<div className="flex column justify-space-between">
+				<div>
+					<div>
+						by <span className="authors-list">{data.authors}</span>
+					</div>
+					<div className="ratings-list flex align-center">
+						<span className="stars">
+							{
+								Array(data.average_rating_rounded)
+									.fill('x')
+									.map((item, index) => (
+										<i className="fas fa-star" key={index} />
+									)) // eslint-disable-line
+							}
+						</span>
+						<span className="avg-rating">({data.average_rating} avg)</span>
+					</div>
+				</div>
+				<span className="pub-year">Pub {data.original_publication_year}</span>
+			</div>
+		</div>
+	</div>
+);
+
 const Main = () => (
 	<ReactiveBase
-		app="meetup_app"
+		app="good-books-ds"
 		url="https://reactivesearch-api-9-4-0.onrender.com"
 		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row">
 			<div className="col">
 				<ToggleButton
-					componentId="CitySensor"
-					dataField="group.group_topics.topic_name_raw.keyword"
+					componentId="LanguageSensor"
+					dataField="language_code"
 					data={[
-						{ label: 'Social', value: 'Social' },
-						{ label: 'Adventure', value: 'Adventure' },
-						{ label: 'Music', value: 'Music' },
+						{ label: 'English', value: 'eng' },
+						{ label: 'French', value: 'fre' },
+						{ label: 'Spanish', value: 'spa' },
 					]}
 				/>
 			</div>
@@ -32,58 +60,17 @@ const Main = () => (
 				<SelectedFilters />
 				<ReactiveList
 					componentId="SearchResult"
-					dataField="group.group_topics.topic_name_raw.keyword"
+					dataField="original_title"
 					title="Results"
 					sortBy="asc"
 					className="result-list-container"
 					from={0}
 					size={5}
-					innerClass={{
-						image: 'meetup-list-image',
-					}}
 					pagination
 					react={{
-						and: ['CitySensor'],
+						and: ['LanguageSensor'],
 					}}
-					render={({ data }) => (
-						<ReactiveList.ResultListWrapper>
-							{data.map(item => (
-								<ResultList href={item.event.event_url} key={item._id}>
-									<ResultList.Image src={item.member.photo} small />
-									<ResultList.Content>
-										<ResultList.Title>
-											<div className="meetup-title">
-												{item.member ? item.member.member_name : ''} is
-												going to ${item.event ? item.event.event_name : ''}
-											</div>
-										</ResultList.Title>
-										<ResultList.Description>
-											<div className="flex column">
-												<div className="meetup-location">
-													<span className="location">
-														<i className="fas fa-map-marker-alt" />
-													</span>
-													{item.group ? item.group.group_city : ''}
-												</div>
-												<div className="flex wrap meetup-topics">
-													{item.group.group_topics
-														.slice(0, 4)
-														.map(tag => (
-															<div
-																className="meetup-topic"
-																key={tag.topic_name}
-															>
-																{tag.topic_name}
-															</div>
-														))}
-												</div>
-											</div>
-										</ResultList.Description>
-									</ResultList.Content>
-								</ResultList>
-							))}
-						</ReactiveList.ResultListWrapper>
-					)}
+					renderItem={booksReactiveList}
 				/>
 			</div>
 		</div>

--- a/packages/web/examples/ToggleButton/src/index.js
+++ b/packages/web/examples/ToggleButton/src/index.js
@@ -13,7 +13,8 @@ import './index.css';
 const Main = () => (
 	<ReactiveBase
 		app="meetup_app"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row">
 			<div className="col">

--- a/packages/web/examples/ToggleButton/src/index.js
+++ b/packages/web/examples/ToggleButton/src/index.js
@@ -60,7 +60,7 @@ const Main = () => (
 				<SelectedFilters />
 				<ReactiveList
 					componentId="SearchResult"
-					dataField="original_title"
+					dataField="original_title.keyword"
 					title="Results"
 					sortBy="asc"
 					className="result-list-container"

--- a/packages/web/examples/TreeList/src/index.js
+++ b/packages/web/examples/TreeList/src/index.js
@@ -10,7 +10,8 @@ class Main extends Component {
 		return (
 			<ReactiveBase
 				app="best-buy-dataset"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 			>
 				<div className="row">
 					<div className="col">

--- a/packages/web/examples/TreeListWithCustomSelectedFilters/src/index.js
+++ b/packages/web/examples/TreeListWithCustomSelectedFilters/src/index.js
@@ -18,7 +18,8 @@ class Main extends Component {
 		return (
 			<ReactiveBase
 				app="best-buy-dataset"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 			>
 				<div className="row">
 					<div className="col">

--- a/packages/web/examples/VectorSearch/src/index.js
+++ b/packages/web/examples/VectorSearch/src/index.js
@@ -13,8 +13,8 @@ const App = () => {
 	return (
 		<ReactiveBase
 			app="yc-companies-dataset"
-			url="https://appbase-demo-ansible-abxiydt-arc.searchbase.io"
-			credentials="a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 			enableAppbase
 		>
 			<div className="container">

--- a/packages/web/examples/ssr-with-react-dom/common/App.js
+++ b/packages/web/examples/ssr-with-react-dom/common/App.js
@@ -7,7 +7,8 @@ import BookCard from './BookCard';
 // settings for the ReactiveBase component
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr-with-react-dom/server/server.js
+++ b/packages/web/examples/ssr-with-react-dom/server/server.js
@@ -9,7 +9,8 @@ import App from '../common/App';
 // settings for the ReactiveBase component
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/datepicker.js
+++ b/packages/web/examples/ssr/pages/datepicker.js
@@ -31,7 +31,8 @@ const dateQuery = (value, props) => {
 
 const settings = {
 	app: 'airbnb-dev',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/daterange.js
+++ b/packages/web/examples/ssr/pages/daterange.js
@@ -32,7 +32,8 @@ const dateQuery = (value, props) => {
 
 const settings = {
 	app: 'airbnb-dev',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/dynamicrangeslider.js
+++ b/packages/web/examples/ssr/pages/dynamicrangeslider.js
@@ -13,7 +13,8 @@ import BookCard from '../components/BookCard';
 
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/index.js
+++ b/packages/web/examples/ssr/pages/index.js
@@ -24,7 +24,8 @@ function Main(props) {
 		<div className="main-container">
 			<ReactiveBase
 				app="movies-demo-app"
-				url="https://81719ecd9552:e06db001-a6d8-4cc2-bc43-9c15b1c0c987@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 				enableAppbase
 				theme={{
 					colors: {

--- a/packages/web/examples/ssr/pages/multidropdownlist.js
+++ b/packages/web/examples/ssr/pages/multidropdownlist.js
@@ -13,7 +13,8 @@ import BookCard from '../components/BookCard';
 
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/multidropdownrange.js
+++ b/packages/web/examples/ssr/pages/multidropdownrange.js
@@ -13,7 +13,8 @@ import BookCard from '../components/BookCard';
 
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/multilist.js
+++ b/packages/web/examples/ssr/pages/multilist.js
@@ -13,7 +13,8 @@ import BookCard from '../components/BookCard';
 
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/multirange.js
+++ b/packages/web/examples/ssr/pages/multirange.js
@@ -13,7 +13,8 @@ import BookCard from '../components/BookCard';
 
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/numberbox.js
+++ b/packages/web/examples/ssr/pages/numberbox.js
@@ -13,7 +13,8 @@ import BookCard from '../components/BookCard';
 
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/querystring.js
+++ b/packages/web/examples/ssr/pages/querystring.js
@@ -13,7 +13,8 @@ import BookCard from '../components/BookCard';
 
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/rangeinput.js
+++ b/packages/web/examples/ssr/pages/rangeinput.js
@@ -13,7 +13,8 @@ import BookCard from '../components/BookCard';
 
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/rangeslider.js
+++ b/packages/web/examples/ssr/pages/rangeslider.js
@@ -13,7 +13,8 @@ import BookCard from '../components/BookCard';
 
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/ratingsfilter.js
+++ b/packages/web/examples/ssr/pages/ratingsfilter.js
@@ -13,7 +13,8 @@ import BookCard from '../components/BookCard';
 
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/reactivelist.js
+++ b/packages/web/examples/ssr/pages/reactivelist.js
@@ -13,7 +13,8 @@ import BookCard from '../components/BookCard';
 
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/resultlist.js
+++ b/packages/web/examples/ssr/pages/resultlist.js
@@ -13,7 +13,8 @@ import ListItemView from '../components/ListItemView';
 
 const settings = {
 	app: 'meetup_app',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/searchBox.js
+++ b/packages/web/examples/ssr/pages/searchBox.js
@@ -13,7 +13,8 @@ import BookCard from '../components/BookCard';
 
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/searchBoxWithCategory.js
+++ b/packages/web/examples/ssr/pages/searchBoxWithCategory.js
@@ -13,7 +13,8 @@ import BookCard from '../components/BookCard';
 
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/singledatalist.js
+++ b/packages/web/examples/ssr/pages/singledatalist.js
@@ -13,7 +13,8 @@ import ListItemView from '../components/ListItemView';
 
 const settings = {
 	app: 'meetup_app',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/singledropdownlist.js
+++ b/packages/web/examples/ssr/pages/singledropdownlist.js
@@ -13,7 +13,8 @@ import BookCard from '../components/BookCard';
 
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/singledropdownrange.js
+++ b/packages/web/examples/ssr/pages/singledropdownrange.js
@@ -13,7 +13,8 @@ import BookCard from '../components/BookCard';
 
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/singlelist.js
+++ b/packages/web/examples/ssr/pages/singlelist.js
@@ -13,7 +13,8 @@ import BookCard from '../components/BookCard';
 
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/singlerange.js
+++ b/packages/web/examples/ssr/pages/singlerange.js
@@ -13,7 +13,8 @@ import BookCard from '../components/BookCard';
 
 const settings = {
 	app: 'good-books-ds',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/togglebutton.js
+++ b/packages/web/examples/ssr/pages/togglebutton.js
@@ -31,7 +31,7 @@ const toggleButtonProps = {
 
 const resultListProps = {
 	componentId: 'SearchResult',
-	dataField: 'original_title',
+	dataField: 'original_title.keyword',
 	title: 'Results',
 	sortBy: 'asc',
 	className: 'result-list-container',

--- a/packages/web/examples/ssr/pages/togglebutton.js
+++ b/packages/web/examples/ssr/pages/togglebutton.js
@@ -13,7 +13,8 @@ import ListItemView from '../components/ListItemView';
 
 const settings = {
 	app: 'meetup_app',
-	url: 'https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 

--- a/packages/web/examples/ssr/pages/togglebutton.js
+++ b/packages/web/examples/ssr/pages/togglebutton.js
@@ -9,29 +9,29 @@ import {
 import PropTypes from 'prop-types';
 
 import Layout from '../components/Layout';
-import ListItemView from '../components/ListItemView';
+import BookCard from '../components/BookCard';
 
 const settings = {
-	app: 'meetup_app',
+	app: 'good-books-ds',
 	url: 'https://reactivesearch-api-9-4-0.onrender.com',
 	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 	enableAppbase: true,
 };
 
 const toggleButtonProps = {
-	componentId: 'CitySensor',
-	dataField: 'group.group_topics.topic_name_raw.keyword',
+	componentId: 'LanguageSensor',
+	dataField: 'language_code',
 	data: [
-		{ label: 'Social', value: 'Social' },
-		{ label: 'Adventure', value: 'Adventure' },
-		{ label: 'Music', value: 'Music' },
+		{ label: 'English', value: 'eng' },
+		{ label: 'French', value: 'fre' },
+		{ label: 'Spanish', value: 'spa' },
 	],
-	defaultValue: 'Social',
+	defaultValue: 'eng',
 };
 
 const resultListProps = {
 	componentId: 'SearchResult',
-	dataField: 'group.group_topics.topic_name_raw.keyword',
+	dataField: 'original_title',
 	title: 'Results',
 	sortBy: 'asc',
 	className: 'result-list-container',
@@ -40,13 +40,13 @@ const resultListProps = {
 	render: ({ data }) => (
 		<ReactiveList.ResultListWrapper>
 			{data.map(item => (
-				<ListItemView key={item._id} {...item} />
+				<BookCard key={item._id} data={item} />
 			))}
 		</ReactiveList.ResultListWrapper>
 	),
 	pagination: true,
 	react: {
-		and: ['CitySensor'],
+		and: ['LanguageSensor'],
 	},
 };
 

--- a/packages/web/examples/ssr/pages/utils/index.js
+++ b/packages/web/examples/ssr/pages/utils/index.js
@@ -4,7 +4,7 @@ import { ReactiveList } from '@appbaseio/reactivesearch';
 const components = {
 	settings: {
 		app: 'movies-demo-app',
-		url: 'https://81719ecd9552:e06db001-a6d8-4cc2-bc43-9c15b1c0c987@appbase-demo-ansible-abxiydt-arc.searchbase.io',
+		url: 'https://reactivesearch-api-9-4-0.onrender.com',
 		theme: {
 			colors: {
 				backgroundColor: '#212121',

--- a/packages/web/examples/typescript/src/App.tsx
+++ b/packages/web/examples/typescript/src/App.tsx
@@ -12,7 +12,8 @@ import './index.css';
 export default () => (
 	<ReactiveBase
 		app="good-books-ds"
-		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 	>
 		<div className="row">
 			<div className="col">

--- a/packages/web/examples/usage-with-graphql/src/index.js
+++ b/packages/web/examples/usage-with-graphql/src/index.js
@@ -9,7 +9,8 @@ class Main extends Component {
 		return (
 			<ReactiveBase
 				app="good-books-ds"
-				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				url="https://reactivesearch-api-9-4-0.onrender.com"
+				credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 				graphQLUrl="https://graphql-es.herokuapp.com"
 			>
 				<div className="row">

--- a/packages/web/examples/withRedux/src/index.js
+++ b/packages/web/examples/withRedux/src/index.js
@@ -20,7 +20,8 @@ const Main = () => (
 	<Provider store={store}>
 		<ReactiveBase
 			app="good-books-ds"
-			url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<div className="row">
 				<div className="col">


### PR DESCRIPTION
## Summary

Migrates all `packages/web/examples/*` demos from legacy Appbase `searchbase.io` clusters to the self-hosted ReactiveSearch API on Render, unblocking Docs CodeSandbox embeds that load from `tree/next`.

| Setting | Before | After |
|---------|--------|-------|
| **URL** | `https://appbase-demo-ansible-abxiydt-arc.searchbase.io` (and embedded-credential variants) | `https://reactivesearch-api-9-4-0.onrender.com` |
| **Credentials** | Various per-demo keys (`a03a1cb71321:…`, `04717bb076f7:…`, etc.) | `d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0` (read-only) |
| **API path** | `/_reactivesearch` (legacy cluster default) | `/_reactivesearch` (unchanged; no `.v3` references found) |

**101 files updated** across standalone examples, SSR pages, and `ssr-with-react-dom`. Embedded credentials in URLs were split into explicit `url` + `credentials` props where needed.

### P0 examples (Docs embeds)

| Example | Index | CodeSandbox verification |
|---------|-------|--------------------------|
| `MyAwesomeSearchStep1` | `good-books-ds` | [Open CSB](https://codesandbox.io/p/github/appbaseio/reactivesearch/tree/feat%2Fdemo-migration-render/packages/web/examples/MyAwesomeSearchStep1) |
| `MyAwesomeSearchStep2` | `good-books-ds` | [Open CSB](https://codesandbox.io/p/github/appbaseio/reactivesearch/tree/feat%2Fdemo-migration-render/packages/web/examples/MyAwesomeSearchStep2) |
| `MyAwesomeSearchStep3` | `good-books-ds` | [Open CSB](https://codesandbox.io/p/github/appbaseio/reactivesearch/tree/feat%2Fdemo-migration-render/packages/web/examples/MyAwesomeSearchStep3) |
| `MyAwesomeSearchStep4` | `good-books-ds` | [Open CSB](https://codesandbox.io/p/github/appbaseio/reactivesearch/tree/feat%2Fdemo-migration-render/packages/web/examples/MyAwesomeSearchStep4) |
| `MyAwesomeSearchStep5` | `good-books-ds` | [Open CSB](https://codesandbox.io/p/github/appbaseio/reactivesearch/tree/feat%2Fdemo-migration-render/packages/web/examples/MyAwesomeSearchStep5) |
| `SearchBox` | `good-books-ds` | [Open CSB](https://codesandbox.io/p/github/appbaseio/reactivesearch/tree/feat%2Fdemo-migration-render/packages/web/examples/SearchBox) |
| `ReactiveList` | `good-books-ds` | [Open CSB](https://codesandbox.io/p/github/appbaseio/reactivesearch/tree/feat%2Fdemo-migration-render/packages/web/examples/ReactiveList) |
| `SingleList` | `good-books-ds` | [Open CSB](https://codesandbox.io/p/github/appbaseio/reactivesearch/tree/feat%2Fdemo-migration-render/packages/web/examples/SingleList) |

> **Note:** `SearchBox`, `ReactiveList`, and `SingleList` in this repo already target `good-books-ds` (not `recipes-demo`). No `dataField` changes were required.

### Examples not migrated / caveats

| Item | Reason |
|------|--------|
| `packages/web/examples/mongo-examples/*` | Uses MongoDB Realm webhooks, not Appbase — left unchanged |
| Examples using non-`good-books-ds` indices (`movies-demo-app`, `carstore-dataset`, `meetup_app`, `yc-companies-dataset`, etc.) | Backend URL/credentials updated; index availability on Render should be verified per-demo |
| Render cold start | First CSB load may be slow on free/starter tier |

### Backend smoke test

```bash
curl -s -u "d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0" \
  -X POST "https://reactivesearch-api-9-4-0.onrender.com/good-books-ds/_reactivesearch" \
  -H 'content-type: application/json' \
  --data-raw '{"settings":{"recordAnalytics":false},"query":[{"id":"search","type":"search","dataField":["original_title"],"execute":true,"value":"gatsby","size":3}]}'
```

Returns Gatsby result ✅

## Test plan

- [x] `rg searchbase.io packages/web/examples` — zero matches
- [x] curl smoke test against `good-books-ds/_reactivesearch`
- [x] Verify P0 CodeSandbox previews load and search works (links above)
- [x] Confirm no CORS errors from `*.codesandbox.io` origins
- [x] After merge to `next`, Docs `tree/next` embeds pick up changes automatically

## Coordination

Once CSB previews are verified, Docs team can either:
- Temporarily point P0 iframe URLs at `tree/feat%2Fdemo-migration-render` for pre-merge testing, or
- Merge this PR to `next` so existing `tree/next` embeds update automatically


Made with [Cursor](https://cursor.com)