### PR TITLE
CI: Add Dependabot configuration for weekly monorepo dependency updates (#2321)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'npm'
+    directory: '/packages/web'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'npm'
+    directory: '/packages/vue'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'npm'
+    directory: '/packages/native'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'npm'
+    directory: '/packages/reactivecore'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
### Proposed Changes
Added `.github/dependabot.yml` to automate dependency management across the monorepo:

- Configured weekly automated dependency update checks for all package directories:
  - Root (`/`)
  - Web (`/packages/web`)
  - Vue (`/packages/vue`)
  - Native (`/packages/native`)
  - Core (`/packages/reactivecore`)
  - GitHub Actions (`github-actions`)

### Linked Issues
- Fixes #2321 (`ci: no automated dependency management — critically outdated dependencies`)

### Checklist
- [x] Describe the proposed changes and how it'll improve the library experience.
- [x] Please make sure that there are no linting errors in the code.
- [x] Add a demo video/gif/screenshot to explain how did you test the fix.
- [x] If it is a global change, try to add any side effects that it could have.
- [ ] Create a PR to add/update the docs (if needed) at [here](https://github.com/appbaseio/Docs).
- [ ] Create a PR to add/update the storybook (if needed) at [here](https://github.com/appbaseio/playground).

### Improvements to the Library Experience
- **Automated Security & Maintenance:** Automatically creates weekly PRs to keep dependencies and GitHub Actions up to date, eliminating manual tracking burden.

### Side Effects
- **None.** Configuration file affects GitHub Dependabot scheduling only.
