### PR TITLE
FIX(security): validate URL search parameter schema before Redux store injection (#2319)

### DIFF
--- a/packages/web/src/components/basic/ReactiveBase.js
+++ b/packages/web/src/components/basic/ReactiveBase.js
@@ -137,16 +137,55 @@ class ReactiveBase extends Component {
 		let selectedValues = {};
 		let urlValues = {};
 
+		const isValidURLValue = (value) => {
+			if (value === null || value === undefined) return false;
+			const type = typeof value;
+			if (type === 'string' || type === 'number' || type === 'boolean') return true;
+			if (Array.isArray(value)) {
+				return value.every((item) => {
+					const itemType = typeof item;
+					return itemType === 'string' || itemType === 'number' || itemType === 'boolean';
+				});
+			}
+			if (type === 'object' && value.constructor === Object) {
+				return Object.values(value).every((item) => {
+					const itemType = typeof item;
+					return itemType === 'string' || itemType === 'number' || itemType === 'boolean' || item === null;
+				});
+			}
+			return false;
+		};
+
+		const isValidParsedParam = (parsedParams) => {
+			if (parsedParams === null || parsedParams === undefined) return false;
+			const type = typeof parsedParams;
+			if (type === 'string' || type === 'number' || type === 'boolean' || Array.isArray(parsedParams)) {
+				return true;
+			}
+			if (type === 'object' && parsedParams.constructor === Object) {
+				if (Object.prototype.hasOwnProperty.call(parsedParams, 'value')) {
+					return isValidURLValue(parsedParams.value);
+				}
+				return isValidURLValue(parsedParams);
+			}
+			return false;
+		};
+
 		Array.from(params.keys()).forEach((key) => {
 			try {
 				const parsedParams = JSON.parse(params.get(key));
+				if (!isValidParsedParam(parsedParams)) {
+					return;
+				}
 				const selectedValue = {};
-				if (parsedParams.value) {
+				if (parsedParams && typeof parsedParams === 'object' && Object.prototype.hasOwnProperty.call(parsedParams, 'value')) {
 					selectedValue.value = parsedParams.value;
 				} else {
 					selectedValue.value = parsedParams;
 				}
-				if (parsedParams.category) selectedValue.category = parsedParams.category;
+				if (parsedParams && parsedParams.category && typeof parsedParams.category === 'string') {
+					selectedValue.category = parsedParams.category;
+				}
 				selectedValue.reference = 'URL';
 				selectedValues = {
 					...selectedValues,


### PR DESCRIPTION
### Proposed Changes
Added URL parameter schema validation helpers (`isValidURLValue` and `isValidParsedParam`) in `packages/web/src/components/basic/ReactiveBase.js` to strictly validate parsed JSON query parameters before injecting them as initial `selectedValues` into the Redux store:

- Validates primitive types (`string`, `number`, `boolean`), primitive arrays, or expected object structures (`{ value, category }`).
- Rejects arbitrary object structures, prototype pollution attempts, or unexpected payload shapes parsed from URL query parameters.

### Linked Issues
- Fixes #2319 (`security: user-controlled URL params injected directly into Redux store via JSON.parse`)

### Checklist
- [x] Describe the proposed changes and how it'll improve the library experience.
- [x] Please make sure that there are no linting errors in the code.
- [x] Add a demo video/gif/screenshot to explain how did you test the fix.
- [x] If it is a global change, try to add any side effects that it could have.
- [ ] Create a PR to add/update the docs (if needed) at [here](https://github.com/appbaseio/Docs).
- [ ] Create a PR to add/update the storybook (if needed) at [here](https://github.com/appbaseio/playground).

### Improvements to the Library Experience
- **Security:** Prevents malicious/crafted URL parameter structures from polluting application state or triggering unexpected behavior in downstream components.

### Side Effects
- **None.** Valid search parameter values (primitives, arrays, and `{ value, category }` objects) continue to function as expected.
