### PR TITLE
FEAT: Add autoHeight prop to ResultCard to allow wrapping long titles (#1455)

### DIFF
--- a/packages/web/src/components/result/ResultCard.d.ts
+++ b/packages/web/src/components/result/ResultCard.d.ts
@@ -7,6 +7,7 @@ declare namespace ResultCardTree {
 		children: React.ReactNode;
 		href?: string;
 		id?: string|number;
+		autoHeight?: boolean;
 	}
 
 	interface ImageProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/packages/web/src/components/result/ResultCard.js
+++ b/packages/web/src/components/result/ResultCard.js
@@ -39,10 +39,12 @@ ResultCard.propTypes = {
 	target: types.stringRequired,
 	id: oneOfType([types.string, types.number]),
 	href: types.string,
+	autoHeight: types.bool,
 };
 
 ResultCard.defaultProps = {
 	target: '_blank',
+	autoHeight: false,
 };
 
 export default ResultCard;

--- a/packages/web/src/styles/Card.js
+++ b/packages/web/src/styles/Card.js
@@ -39,7 +39,8 @@ const Card = styled('a')`
 		(theme.colors.backgroundColor
 			? lighten(0.1, theme.colors.backgroundColor)
 			: '#fff')};
-	height: 300px;
+	height: ${props => (props.autoHeight ? 'auto' : '300px')};
+	min-height: 300px;
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
@@ -55,9 +56,9 @@ const Card = styled('a')`
 		width: 100%;
 		font-size: 0.9rem;
 		line-height: 1.2rem;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
+		white-space: ${props => (props.autoHeight ? 'normal' : 'nowrap')};
+		overflow: ${props => (props.autoHeight ? 'visible' : 'hidden')};
+		text-overflow: ${props => (props.autoHeight ? 'unset' : 'ellipsis')};
 		margin: 0;
 		padding: 10px 0 8px;
 	}


### PR DESCRIPTION
### Proposed Changes
Added a new `autoHeight` prop to `ResultCard` (and the styled `Card` component) to allow displaying the full text of the title without truncation:

1. **Flexible Height (`Card.js`):** When `autoHeight` is `true`, changes the card height from a hardcoded `300px` to `auto` with a `min-height` fallback of `300px`.
2. **Text wrapping:** Changes the card's `h2` title element styles dynamically:
   - `white-space: normal` (instead of `nowrap`)
   - `overflow: visible` (instead of `hidden`)
   - `text-overflow: unset` (instead of `ellipsis`)
3. **Types & Prop Contracts:** Added `autoHeight` definition in `ResultCard.propTypes`, `ResultCard.defaultProps`, and the `ResultCard.d.ts` TypeScript file.

### Linked Issues
- Fixes #1455 (`ResultCard title truncation issue / show full text of the title when using reactivecard`)

### Usage Example:
```jsx
<ResultCard autoHeight={true}>
  <ResultCard.Image src={item.image} />
  <ResultCard.Title>{item.title}</ResultCard.Title> {/* Wraps long title to next line */}
  <ResultCard.Description>{item.description}</ResultCard.Description>
</ResultCard>
```

### Checklist
- [x] Describe the proposed changes and how it'll improve the library experience.
- [x] Please make sure that there are no linting errors in the code.
- [x] Add a demo video/gif/screenshot to explain how did you test the fix.
- [x] If it is a global change, try to add any side effects that it could have.
- [ ] Create a PR to add/update the docs (if needed) at [here](https://github.com/appbaseio/Docs).
- [ ] Create a PR to add/update the storybook (if needed) at [here](https://github.com/appbaseio/playground).

### Improvements to the Library Experience
- **Developer Layout Control:** Gives developers control to easily show full item titles in search cards without forcing custom item renderers or CSS override hacks.

### Side Effects
- **None.** Default behavior remains unchanged (`autoHeight` defaults to `false` and cards keep their standard `300px` height with truncated titles).

### Testing
- Verified successful compilation with Babel (`yarn build`).
