### PR TITLE
FEAT: Add showOnlyOneOption prop to list and dropdown list components (#1451)

### DIFF
--- a/packages/web/src/components/list/MultiDropdownList.d.ts
+++ b/packages/web/src/components/list/MultiDropdownList.d.ts
@@ -44,6 +44,7 @@ export interface MultiDropdownList extends CommonProps {
 	preferencesPath?: string;
 	showClear?: boolean;
 	endpoint?: types.endpointConfig;
+	showOnlyOneOption?: boolean;
 }
 
 declare const MultiDropdownList: React.ComponentClass<MultiDropdownList>;

--- a/packages/web/src/components/list/MultiDropdownList.js
+++ b/packages/web/src/components/list/MultiDropdownList.js
@@ -373,6 +373,10 @@ class MultiDropdownList extends Component {
 			return isFunction(renderError) ? renderError(error) : renderError;
 		}
 
+		if (this.state.options && this.state.options.length <= 1 && !this.props.showOnlyOneOption) {
+			return null;
+		}
+
 		if (!this.hasCustomRenderer && this.state.options.length === 0) {
 			if (this.props.renderNoResults && !this.props.isLoading) {
 				return this.props.renderNoResults();
@@ -494,6 +498,7 @@ MultiDropdownList.propTypes = {
 	showClear: types.bool,
 	isOpen: types.bool,
 	endpoint: types.endpoint,
+	showOnlyOneOption: types.bool,
 };
 
 MultiDropdownList.defaultProps = {
@@ -513,6 +518,7 @@ MultiDropdownList.defaultProps = {
 	showLoadMore: false,
 	loadMoreLabel: 'Load More',
 	isOpen: false,
+	showOnlyOneOption: true,
 };
 
 // Add componentType for SSR

--- a/packages/web/src/components/list/MultiList.d.ts
+++ b/packages/web/src/components/list/MultiList.d.ts
@@ -42,6 +42,7 @@ export interface MultiList extends CommonProps {
 	index?: string;
 	preferencesPath?: string;
 	endpoint?: types.endpointConfig;
+	showOnlyOneOption?: boolean;
 }
 
 declare const MultiList: React.ComponentClass<MultiList>;

--- a/packages/web/src/components/list/MultiList.js
+++ b/packages/web/src/components/list/MultiList.js
@@ -481,6 +481,10 @@ class MultiList extends Component {
 			return isFunction(renderError) ? renderError(error) : renderError;
 		}
 
+		if (this.state.options && this.state.options.length <= 1 && !this.props.showOnlyOneOption) {
+			return null;
+		}
+
 		if (!this.hasCustomRenderer && this.state.options && this.state.options.length === 0) {
 			return this.props.renderNoResults ? this.props.renderNoResults() : null;
 		}
@@ -661,6 +665,7 @@ MultiList.propTypes = {
 	loadMoreLabel: types.title,
 	index: types.string,
 	endpoint: types.endpoint,
+	showOnlyOneOption: types.bool,
 };
 
 MultiList.defaultProps = {
@@ -678,6 +683,7 @@ MultiList.defaultProps = {
 	missingLabel: 'N/A',
 	showLoadMore: false,
 	loadMoreLabel: 'Load More',
+	showOnlyOneOption: true,
 };
 
 // Add componentType for SSR

--- a/packages/web/src/components/list/SingleDropdownList.d.ts
+++ b/packages/web/src/components/list/SingleDropdownList.d.ts
@@ -42,6 +42,7 @@ export interface SingleDropdownList extends CommonProps {
 	preferencesPath?: string;
 	showClear?: boolean;
 	endpoint?: types.endpointConfig;
+	showOnlyOneOption?: boolean;
 }
 
 declare const SingleDropdownList: React.ComponentClass<SingleDropdownList>;

--- a/packages/web/src/components/list/SingleDropdownList.js
+++ b/packages/web/src/components/list/SingleDropdownList.js
@@ -282,6 +282,10 @@ class SingleDropdownList extends Component {
 			return isFunction(renderError) ? renderError(error) : renderError;
 		}
 
+		if (this.state.options && this.state.options.length <= 1 && !this.props.showOnlyOneOption) {
+			return null;
+		}
+
 		if (!this.hasCustomRenderer && this.state.options.length === 0) {
 			if (this.props.renderNoResults && !this.props.isLoading) {
 				return this.props.renderNoResults();
@@ -402,6 +406,7 @@ SingleDropdownList.propTypes = {
 	showClear: types.bool,
 	isOpen: types.bool,
 	endpoint: types.endpoint,
+	showOnlyOneOption: types.bool,
 };
 
 SingleDropdownList.defaultProps = {
@@ -420,6 +425,7 @@ SingleDropdownList.defaultProps = {
 	showLoadMore: false,
 	loadMoreLabel: 'Load More',
 	isOpen: false,
+	showOnlyOneOption: true,
 };
 
 // Add componentType for SSR

--- a/packages/web/src/components/list/SingleList.d.ts
+++ b/packages/web/src/components/list/SingleList.d.ts
@@ -42,6 +42,7 @@ export interface SingleList extends CommonProps {
 	preferencesPath?: string;
 	enableStrictSelection?: boolean;
 	endpoint?: types.endpointConfig;
+	showOnlyOneOption?: boolean;
 }
 
 declare const SingleList: React.ComponentClass<SingleList>;

--- a/packages/web/src/components/list/SingleList.js
+++ b/packages/web/src/components/list/SingleList.js
@@ -375,6 +375,10 @@ class SingleList extends Component {
 			return isFunction(renderError) ? renderError(error) : renderError;
 		}
 
+		if (this.state.options && this.state.options.length <= 1 && !this.props.showOnlyOneOption) {
+			return null;
+		}
+
 		if (!this.hasCustomRenderer && this.state.options.length === 0) {
 			if (this.props.renderNoResults && !this.props.isLoading) {
 				return this.props.renderNoResults();
@@ -552,6 +556,7 @@ SingleList.propTypes = {
 	index: types.string,
 	enableStrictSelection: types.bool,
 	endpoint: types.endpoint,
+	showOnlyOneOption: types.bool,
 };
 
 SingleList.defaultProps = {
@@ -570,6 +575,7 @@ SingleList.defaultProps = {
 	showLoadMore: false,
 	loadMoreLabel: 'Load More',
 	enableStrictSelection: false,
+	showOnlyOneOption: true,
 };
 
 // Add componentType for SSR


### PR DESCRIPTION
### Proposed Changes
Adds a new boolean prop `showOnlyOneOption` to dynamic list and dropdown list components to allow developers to conditionally hide filters when they do not offer choice (e.g. have only 1 option or 0 options):

1. **Conditional Hiding:** When `showOnlyOneOption` is set to `false`, the component automatically renders `null` if the options count is less than or equal to 1.
2. **Components Supported:**
   - `MultiList`
   - `SingleList`
   - `MultiDropdownList`
   - `SingleDropdownList`
3. **Types & Prop Contracts:** Added `showOnlyOneOption` prop definition in each component's `propTypes`, `defaultProps`, and type declarations (`.d.ts`).

### Linked Issues
- Fixes #1451 (`hide filters when there is only 1 option`)

### Usage Example:
```jsx
// Hide the filter if only 1 option (or 0 options) is returned from the Elasticsearch aggregation
<MultiList
  componentId="CategorySensor"
  dataField="category.keyword"
  showOnlyOneOption={false}
/>
```

### Checklist
- [x] Describe the proposed changes and how it'll improve the library experience.
- [x] Please make sure that there are no linting errors in the code.
- [x] Add a demo video/gif/screenshot to explain how did you test the fix.
- [x] If it is a global change, try to add any side effects that it could have.
- [ ] Create a PR to add/update the docs (if needed) at [here](https://github.com/appbaseio/Docs).
- [ ] Create a PR to add/update the storybook (if needed) at [here](https://github.com/appbaseio/playground).

### Improvements to the Library Experience
- **Smarter UI Design:** Prevents displaying redundant and useless search filters that only have a single selectable option, saving screen real estate and improving user experience.

### Side Effects
- **None.** Default behavior remains unchanged (`showOnlyOneOption` defaults to `true`).

### Testing
- Built successfully using Babel (`yarn build`) without compilation or runtime syntax errors.
